### PR TITLE
Fix cell hover for copy icon

### DIFF
--- a/example/src/pages/TablePage.tsx
+++ b/example/src/pages/TablePage.tsx
@@ -26,7 +26,8 @@ const columnConfig : ITableColumnConfig[] = [
     header: 'Created',
     sortable: false,
     cellStyle: 'lowImportance',
-    alignment: 'center'
+    alignment: 'center',
+    hasCopyButton: true
   },
   {
     header: 'Usage',

--- a/src/Tables/atoms/TypeTableCell.tsx
+++ b/src/Tables/atoms/TypeTableCell.tsx
@@ -11,7 +11,7 @@ const CopyToClipboard = styled.button`
   opacity: 0;
 
   position: absolute;
-  right: -20px;
+  right: 0;
   top: 14px;
   width: 20px;
   height: 20px;
@@ -33,13 +33,12 @@ const CopyToClipboard = styled.button`
 
 `;
 
-const CellContainer = styled.div<{ cellStyle: TypeCellStyle, alignment: TypeCellAlignment, hideDivider?: boolean }>`
+const CellContainer = styled.div<{ cellStyle: TypeCellStyle, alignment: TypeCellAlignment, hideDivider?: boolean, hasCopyButton?:boolean }>`
   display: table-cell;
   height: 50px;
   vertical-align: middle;
   position: relative;
   line-height: 30px;
-
   font-family: ${p => p.theme.fontFamily.data};
 
   &:hover ${CopyToClipboard}{
@@ -56,9 +55,11 @@ const CellContainer = styled.div<{ cellStyle: TypeCellStyle, alignment: TypeCell
 
   a:hover {
     text-decoration: underline;
-
-
   }
+
+  ${({hasCopyButton}) => hasCopyButton && css`
+    padding-right: 20px;
+  `};
 
   ${({hideDivider}) => !hideDivider && css`
     &::after {
@@ -72,7 +73,6 @@ const CellContainer = styled.div<{ cellStyle: TypeCellStyle, alignment: TypeCell
       width: 100%;
       bottom: 0px;
       position: absolute;
-
     }
   `}
 `;
@@ -115,7 +115,7 @@ const TypeTableCell : React.FC<IProps> = ({ showUnit = false, showStatus = false
     useCopyToClipboard(copyText);
   }, [useCopyToClipboard]);
 
-  return <CellContainer {...{cellStyle, alignment, hideDivider}}>
+  return <CellContainer {...{cellStyle, alignment, hideDivider, hasCopyButton}}>
     {showStatus ? <StatusBlip {...{status}}></StatusBlip> : null}
     {href ? <a href={href}>{children}</a> : children}
     {showUnit ? <UnitText>{unit}</UnitText> : null}

--- a/src/Tables/molecules/TypeTable.tsx
+++ b/src/Tables/molecules/TypeTable.tsx
@@ -18,13 +18,17 @@ const HeaderRow = styled.div`
   display: table-row;
   height: 50px;
 `;
-const HeaderItem = styled.div<{fixedWidth?: number, alignment?: TypeCellAlignment }>`
+const HeaderItem = styled.div<{fixedWidth?: number, alignment?: TypeCellAlignment, hasCopyButton?: boolean }>`
   display: table-cell;
   height: inherit;
   vertical-align:top;
   line-height: 20px;
 
   font-family: ${p => p.theme.fontFamily.ui };
+
+  ${({hasCopyButton}) => hasCopyButton && css`
+    padding-right: 20px;
+  `};
 
   ${({theme, alignment}) => alignment ? css`
     ${theme.typography.table.header[alignment]};
@@ -70,8 +74,8 @@ const TypeTable : React.FC<IProps> = ({ columnConfig, selectable, selectCallback
         {hasTypeIcon ? <HeaderItem fixedWidth={35} /> : null}
 
         {columnConfig.map((column, key) => {
-          const {alignment, header} = column;
-          return <HeaderItem key={key} alignment={alignment}>{header}</HeaderItem>;
+          const {alignment, header, hasCopyButton} = column;
+          return <HeaderItem key={key} alignment={alignment} hasCopyButton={hasCopyButton}>{header}</HeaderItem>;
         })}
       </HeaderRow>
 

--- a/storybook/src/stories/Tables/TypeTable.stories.tsx
+++ b/storybook/src/stories/Tables/TypeTable.stories.tsx
@@ -32,7 +32,8 @@ const columnConfigSample : ITableColumnConfig[] = [
     header: 'Created',
     sortable: false,
     cellStyle: 'lowImportance',
-    alignment: 'center'
+    alignment: 'center',
+    hasCopyButton: true
   },
   {
     header: 'Usage',


### PR DESCRIPTION

### Requirements
 https://www.bugherd.com/projects/216308/tasks/9
 Tables: Copy button often can't be reached because hover area is left. (see attachment)
 
 ### Implementation
 Before this fix the problem seems to be that the copy button is absolute positioned -20px right and the icon overlaps in the area of the next table cell. 
 
I added conditional padding to header and cell depending of the config. This will keep the icon inside the cell.
I pushed the example config to have the copy icon in the created column.
 
 ### Screenshoots
 
 <img width="667" alt="Screen Shot 2021-01-14 at 10 27 52" src="https://user-images.githubusercontent.com/10409078/104532283-36682000-5653-11eb-8912-4e3f903a2aa7.png">