### PR TITLE
Feature/table type reload fix

### DIFF
--- a/src/Form/atoms/Checkbox.tsx
+++ b/src/Form/atoms/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import Icon from '../../Icons/Icon';
@@ -111,7 +111,7 @@ const Checkbox : React.FC<IProps> = ({ indeterminate = false, disabled, checked 
   const [ visualState, setVisualState ] = useState<CheckboxState>(checked ? CheckboxState.On : CheckboxState.Off);
 
   const customOnChange = (e: any) => {
-    const checked = e.target.checked
+    const checked = e.target.checked;
 
     setIsChecked(checked);
     if(onChangeCallback){ onChangeCallback(checked); }
@@ -124,20 +124,22 @@ const Checkbox : React.FC<IProps> = ({ indeterminate = false, disabled, checked 
 
     setVisualState( state );
 
-  }, [isChecked, setVisualState])
+  }, [checked, isChecked, setVisualState]);
 
   useEffect(() => {
     setIsChecked(checked);
   }, [checked, setIsChecked]);
 
-  return <Container onChange={customOnChange} {...{indeterminate, disabled, visualState}}>
-    <CheckboxOuter>
-      <CheckboxInner>
-        {visualState === CheckboxState.On ? <IconWrapper><Icon icon='CloseCompact' color='inverse' size={18} weight='regular' /></IconWrapper> : null}
-      </CheckboxInner>
-    </CheckboxOuter>
-    <RealInput type='checkbox' checked={isChecked} readOnly={true} {...{disabled}} /> {/* disabled={state !== 'default' && state !== 'failure'} */}
-  </Container>;
+  return (
+    <Container onChange={customOnChange} {...{indeterminate, disabled, visualState}}>
+      <CheckboxOuter>
+        <CheckboxInner>
+          {visualState === CheckboxState.On ? <IconWrapper><Icon icon='CloseCompact' color='inverse' size={18} weight='regular' /></IconWrapper> : null}
+        </CheckboxInner>
+      </CheckboxOuter>
+      <RealInput type='checkbox' checked={isChecked} readOnly {...{disabled}} /> {/* disabled={state !== 'default' && state !== 'failure'} */}
+    </Container>
+  );
 
 };
 

--- a/src/Tables/atoms/TypeTableCell.tsx
+++ b/src/Tables/atoms/TypeTableCell.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 
 import Icon from '../../Icons/Icon';

--- a/src/Tables/atoms/TypeTableCell.tsx
+++ b/src/Tables/atoms/TypeTableCell.tsx
@@ -111,16 +111,17 @@ const TypeTableCell : React.FC<IProps> = ({ showUnit = false, showStatus = false
   // No divider on the last row.
   hideDivider = isLastRow ? true : hideDivider;
 
-  const copyValue = useCallback((copyText : string) => {
-    useCopyToClipboard(copyText);
-  }, [useCopyToClipboard]);
+  const {copyToClipboard} = useCopyToClipboard();
 
-  return <CellContainer {...{cellStyle, alignment, hideDivider, hasCopyButton}}>
-    {showStatus ? <StatusBlip {...{status}}></StatusBlip> : null}
-    {href ? <a href={href}>{children}</a> : children}
-    {showUnit ? <UnitText>{unit}</UnitText> : null}
-    {hasCopyButton ? <CopyToClipboard onClick={ () => typeof children === 'string' && copyValue(children) }><Icon icon='Copy' size={16} /></CopyToClipboard> : null}
-  </CellContainer>;
+
+  return (
+    <CellContainer {...{cellStyle, alignment, hideDivider, hasCopyButton}}>
+      {showStatus ? <StatusBlip {...{status}} /> : null}
+      {href ? <a href={href}>{children}</a> : children}
+      {showUnit ? <UnitText>{unit}</UnitText> : null}
+      {hasCopyButton ? <CopyToClipboard onClick={() => typeof children === 'string' && copyToClipboard(children)}><Icon icon='Copy' size={16} /></CopyToClipboard> : null}
+    </CellContainer>
+  );
 };
 
 export default TypeTableCell;

--- a/src/Tables/atoms/TypeTableDeviceStatus.tsx
+++ b/src/Tables/atoms/TypeTableDeviceStatus.tsx
@@ -21,7 +21,7 @@ interface IProps {
 }
 
 const TypeTableDeviceStatus : React.FC<IProps> = ({status = 'neutral'}) => {
-  return <Container status={status}></Container>;
+  return <Container status={status} />;
 };
 
 export default TypeTableDeviceStatus;

--- a/src/Tables/atoms/TypeTableRow.tsx
+++ b/src/Tables/atoms/TypeTableRow.tsx
@@ -5,7 +5,7 @@ import Checkbox from '../../Form/atoms/Checkbox';
 import TableRowThumbnail from './TableRowThumbnail';
 import TypeTableDeviceStatus from './TypeTableDeviceStatus';
 import TypeTableCell from './TypeTableCell';
-import Icon from '../../Icons/Icon'
+import Icon from '../../Icons/Icon';
 import { ITableColumnConfig, IRowData } from '..';
 
 
@@ -27,22 +27,24 @@ interface IProps {
 const TypeTableRow : React.FC<IProps> = ({selectable = false, selectCallback, hasStatus, hasThumbnail, hasTypeIcon, rowData, isLastRow, columnConfig }) => {
 
   const wrappedSelectCallback = useCallback((checked) => {
-    if(selectCallback){ selectCallback(checked, rowData.id) }
-  }, [])
+    if(selectCallback){ selectCallback(checked, rowData.id); }
+  }, [rowData.id, selectCallback]);
 
-  return <RowContainer>
-    {selectable ? <TypeTableCell hideDivider={true}><Checkbox checked={rowData._checked} onChangeCallback={ wrappedSelectCallback } /></TypeTableCell> : null}
-    {hasStatus ?  <TypeTableCell hideDivider={true}><TypeTableDeviceStatus status={ rowData.header?.status } /></TypeTableCell> : null}
-    {hasThumbnail ? <TypeTableCell hideDivider={true}><TableRowThumbnail image={ rowData.header?.image } /></TypeTableCell> : null}
-    {hasTypeIcon ? <TypeTableCell hideDivider={true}><Icon icon={ rowData.header?.icon || '' } size={16} /></TypeTableCell> : null}
+  return (
+    <RowContainer>
+      {selectable ? <TypeTableCell hideDivider><Checkbox checked={rowData._checked} onChangeCallback={wrappedSelectCallback} /></TypeTableCell> : null}
+      {hasStatus ?  <TypeTableCell hideDivider><TypeTableDeviceStatus status={rowData.header?.status} /></TypeTableCell> : null}
+      {hasThumbnail ? <TypeTableCell hideDivider><TableRowThumbnail image={rowData.header?.image} /></TypeTableCell> : null}
+      {hasTypeIcon ? <TypeTableCell hideDivider><Icon icon={rowData.header?.icon || ''} size={16} /></TypeTableCell> : null}
 
-    {rowData.columns.map((cell, key) => {
-      const {cellStyle, alignment, showUnit, showStatus, hasCopyButton} = columnConfig[key];
-      const {unit, status, text} = cell;
-      return <TypeTableCell key={key} href={cell.href} {...{cellStyle, alignment, showUnit, showStatus, hasCopyButton, unit, status, isLastRow}}>{text}</TypeTableCell>;
-    })}
+      {rowData.columns.map((cell, key) => {
+        const {cellStyle, alignment, showUnit, showStatus, hasCopyButton} = columnConfig[key];
+        const {unit, status, text} = cell;
+        return <TypeTableCell key={key} href={cell.href} {...{cellStyle, alignment, showUnit, showStatus, hasCopyButton, unit, status, isLastRow}}>{text}</TypeTableCell>;
+      })}
 
-  </RowContainer>;
+    </RowContainer>
+  );
 };
 
 

--- a/src/Tables/molecules/TypeTable.tsx
+++ b/src/Tables/molecules/TypeTable.tsx
@@ -3,7 +3,7 @@ import styled, {css} from 'styled-components';
 
 import TypeTableRow from '../atoms/TypeTableRow';
 import Checkbox from '../../Form/atoms/Checkbox';
-import { TypeCellAlignment, ITableColumnConfig, ITypeTableData } from '..';
+import { TypeCellAlignment, ITableColumnConfig, ITypeTableData, IRowData } from '..';
 
 const Container = styled.div`
 
@@ -49,17 +49,24 @@ interface IProps {
   hasStatus?: boolean
   hasThumbnail?: boolean
   hasTypeIcon?: boolean
-  selectCallback? : any
-  toggleAllCallback? : any
+  selectCallback? : (checked:boolean, id?: string | number)=>void
+  toggleAllCallback? : (checked: boolean)=>void
 }
 
-const TypeTable : React.FC<IProps> = ({ columnConfig, selectable, selectCallback, toggleAllCallback, rows, hasStatus = false, hasThumbnail = false, hasTypeIcon = false }) => {
+const TypeTable : React.FC<IProps> = ({
+  columnConfig,
+  selectable,
+  selectCallback = ()=>{},
+  toggleAllCallback = ()=>{},
+  rows = [],
+  hasStatus = false,
+  hasThumbnail = false,
+  hasTypeIcon = false
+}) => {
   const [allChecked, setAllChecked] = useState(false);
   const toggleAllCallbackWrapper = useCallback((checked:boolean) => {
-    if(toggleAllCallback){ toggleAllCallback(checked); }
+    toggleAllCallback(checked);
   }, [toggleAllCallback]);
-
-  const isChecked = (currentValue : any) => currentValue._checked === true;
 
   useEffect(() => {
     setAllChecked(rows.every(isChecked) && rows.length > 0);
@@ -92,3 +99,7 @@ const TypeTable : React.FC<IProps> = ({ columnConfig, selectable, selectCallback
 };
 
 export default TypeTable;
+
+function isChecked({_checked=false} : IRowData){
+  return _checked === true;
+}

--- a/src/Tables/molecules/TypeTable.tsx
+++ b/src/Tables/molecules/TypeTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled, {css} from 'styled-components';
 
 import TypeTableRow from '../atoms/TypeTableRow';
@@ -54,22 +54,22 @@ interface IProps {
 }
 
 const TypeTable : React.FC<IProps> = ({ columnConfig, selectable, selectCallback, toggleAllCallback, rows, hasStatus = false, hasThumbnail = false, hasTypeIcon = false }) => {
-
+  const [allChecked, setAllChecked] = useState(false);
   const toggleAllCallbackWrapper = useCallback((checked:boolean) => {
     if(toggleAllCallback){ toggleAllCallback(checked); }
   }, [toggleAllCallback]);
 
   const isChecked = (currentValue : any) => currentValue._checked === true;
 
-  const allChecked = useCallback(() => {
-    return rows.every(isChecked);
+  useEffect(() => {
+    setAllChecked(rows.every(isChecked) && rows.length > 0);
   }, [rows]);
 
   return (
     <Container>
       <TableContainer>
         <HeaderRow>
-          {selectable ? <HeaderItem fixedWidth={30}><Checkbox checked={ allChecked() } onChangeCallback={toggleAllCallbackWrapper} /></HeaderItem> : null}
+          {selectable ? <HeaderItem fixedWidth={30}><Checkbox checked={allChecked} onChangeCallback={toggleAllCallbackWrapper} /></HeaderItem> : null}
           {hasStatus ? <HeaderItem fixedWidth={10} /> : null}
           {hasThumbnail ? <HeaderItem fixedWidth={70} /> : null}
           {hasTypeIcon ? <HeaderItem fixedWidth={35} /> : null}

--- a/src/Tables/molecules/TypeTable.tsx
+++ b/src/Tables/molecules/TypeTable.tsx
@@ -56,37 +56,39 @@ interface IProps {
 const TypeTable : React.FC<IProps> = ({ columnConfig, selectable, selectCallback, toggleAllCallback, rows, hasStatus = false, hasThumbnail = false, hasTypeIcon = false }) => {
 
   const toggleAllCallbackWrapper = useCallback((checked:boolean) => {
-    if(toggleAllCallback){ toggleAllCallback(checked) }
-  }, [])
+    if(toggleAllCallback){ toggleAllCallback(checked); }
+  }, [toggleAllCallback]);
 
   const isChecked = (currentValue : any) => currentValue._checked === true;
 
   const allChecked = useCallback(() => {
     return rows.every(isChecked);
-  }, [rows])
+  }, [rows]);
 
-  return <Container>
-    <TableContainer>
-      <HeaderRow>
-        {selectable ? <HeaderItem fixedWidth={30}><Checkbox checked={ allChecked() } onChangeCallback={toggleAllCallbackWrapper} /></HeaderItem> : null}
-        {hasStatus ? <HeaderItem fixedWidth={10} /> : null}
-        {hasThumbnail ? <HeaderItem fixedWidth={70} /> : null}
-        {hasTypeIcon ? <HeaderItem fixedWidth={35} /> : null}
+  return (
+    <Container>
+      <TableContainer>
+        <HeaderRow>
+          {selectable ? <HeaderItem fixedWidth={30}><Checkbox checked={ allChecked() } onChangeCallback={toggleAllCallbackWrapper} /></HeaderItem> : null}
+          {hasStatus ? <HeaderItem fixedWidth={10} /> : null}
+          {hasThumbnail ? <HeaderItem fixedWidth={70} /> : null}
+          {hasTypeIcon ? <HeaderItem fixedWidth={35} /> : null}
 
-        {columnConfig.map((column, key) => {
-          const {alignment, header, hasCopyButton} = column;
-          return <HeaderItem key={key} alignment={alignment} hasCopyButton={hasCopyButton}>{header}</HeaderItem>;
+          {columnConfig.map((column, key) => {
+            const {alignment, header, hasCopyButton} = column;
+            return <HeaderItem key={key} alignment={alignment} hasCopyButton={hasCopyButton}>{header}</HeaderItem>;
+          })}
+        </HeaderRow>
+
+        {rows.map((rowData, key) => {
+          const isLastRow = (rows.length - 1 === key) ? true : false;
+          return <TypeTableRow key={key} {...{rowData, isLastRow, selectable, selectCallback, columnConfig, hasStatus, hasThumbnail, hasTypeIcon}} />;
         })}
-      </HeaderRow>
 
-      {rows.map((rowData, key) => {
-        const isLastRow = (rows.length - 1 === key) ? true : false;
-        return <TypeTableRow key={key} {...{rowData, isLastRow, selectable, selectCallback, columnConfig, hasStatus, hasThumbnail, hasTypeIcon}} />;
-      })}
+      </TableContainer>
 
-    </TableContainer>
-
-  </Container>;
+    </Container>
+  );
 };
 
 export default TypeTable;

--- a/src/hooks/useCopyToClipboard.tsx
+++ b/src/hooks/useCopyToClipboard.tsx
@@ -1,32 +1,34 @@
-export const useCopyToClipboard = (text : string) => {
-  return copyToClipboard(text)
-};
+import { useCallback } from 'react';
 
-const copyToClipboard = (str : string) : boolean => {
+export const useCopyToClipboard = () => {
+  const copyToClipboard = useCallback((str : string) : boolean => {
 
-  // Make an area to allow for copying.
-  const el = document.createElement('textarea');
-  el.value = str;
-  el.setAttribute('readonly', '');
-  el.style.position = 'absolute';
-  el.style.left = '-9999px';
-  document.body.appendChild(el);
+      // Make an area to allow for copying.
+      const el = document.createElement('textarea');
+      el.value = str;
+      el.setAttribute('readonly', '');
+      el.style.position = 'absolute';
+      el.style.left = '-9999px';
+      document.body.appendChild(el);
 
-  const selection = document.getSelection()
+      const selection = document.getSelection();
 
-  if(selection){
-    const selected = selection.rangeCount > 0 ? selection.getRangeAt(0) : false;
-    el.select();
+      if(selection){
+        const selected = selection.rangeCount > 0 ? selection.getRangeAt(0) : false;
+        el.select();
 
-    const success = document.execCommand('copy');
-    document.body.removeChild(el);
-    if(selected) {
-      selection.removeAllRanges();
-      selection.addRange(selected);
-    }
-    return success;
-  }
+        const success = document.execCommand('copy');
+        document.body.removeChild(el);
+        if(selected) {
+          selection.removeAllRanges();
+          selection.addRange(selected);
+        }
+        return success;
+      }
 
-  return false;
+      return false;
 
+  },[]);
+
+  return {copyToClipboard};
 };


### PR DESCRIPTION
Fixed a few bugs in TypeTable that were impacting TrafficCounter:

1. Lots of linting
2. changed allChecked logic to use a useEffect instead of a useCallback (prevents calling every render) 
3. Fixed checkbox to actually listen for checked to change in its useEffect
4. Changed Row rendering to be on new row list instead of using useCallback 