### PR TITLE
Fix  disabled background and SubArea Header

### DIFF
--- a/src/Form/atoms/Button.tsx
+++ b/src/Form/atoms/Button.tsx
@@ -26,7 +26,7 @@ const StyledButton = styled.button<IStyledComponentProps>`
       background: ${theme.styles.form.button[design].hover.backgroundColor};
     }
 
-    &:active {
+    &:active:enabled {
       background: ${theme.styles.form.button[design].active.backgroundColor};
     }
 

--- a/src/Form/atoms/Button.tsx
+++ b/src/Form/atoms/Button.tsx
@@ -22,7 +22,9 @@ const StyledButton = styled.button<IStyledComponentProps>`
     // No transition at this time as we're using a gradient in the default view. Requires work to make smooth.
     // transition: background ${theme.animation.speed.normal} ${theme.animation.easing.primary.easeOut};
 
-    &:hover {
+    transition: opacity ${theme.animation.speed.normal} ${theme.animation.easing.primary.easeOut};
+
+    &:hover:enabled {
       background: ${theme.styles.form.button[design].hover.backgroundColor};
     }
 
@@ -31,6 +33,8 @@ const StyledButton = styled.button<IStyledComponentProps>`
     }
 
     &:disabled {
+      cursor: not-allowed;
+      opacity: 50%;
       background: ${theme.styles.form.button[design].disabled.backgroundColor};
     }
 

--- a/src/Form/atoms/ButtonWithLoading.tsx
+++ b/src/Form/atoms/ButtonWithLoading.tsx
@@ -6,6 +6,18 @@ import Spinner from '../../Indicators/Spinner';
 import { TypeButtonDesigns, IButtonProps } from '..';
 
 
+const LoadingButton = styled(Button)<{ loading: boolean }>`
+  ${({loading, theme, design}) => loading && css`
+    cursor: wait;
+    background: ${ theme.styles.form.button['primary'].active };
+
+    &:disabled {
+      opacity: 1;
+    }
+  `};
+
+`
+
 const TextContainer = styled.div`
   height: inherit;
   flex: 1;
@@ -35,7 +47,6 @@ const LoadingContainer = styled.div<{ design: TypeButtonDesigns, show?: boolean,
       opacity ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeInOut};
 
     order: ${ position && position === 'left' ? 0 : 2 };
-    background: ${ theme.styles.form.button[design].actionArea };
   `}
 
   svg {
@@ -43,18 +54,21 @@ const LoadingContainer = styled.div<{ design: TypeButtonDesigns, show?: boolean,
   }
 `;
 
-const InnerContainer = styled.div<{position?: string, loading: string}>`
+const InnerContainer = styled.div<{position?: string, loading: string, design: TypeButtonDesigns}>`
   display: flex;
   height: inherit;
 
 
   ${({ position, loading }) => position && position === 'left' ? css`
-  margin-right: ${ loading === 'true' ? '-20px' : '0' };
+    margin-right: ${ loading === 'true' ? '-20px' : '0' };
   ` : css`
-  margin-left: ${ loading === 'true' ? '-20px' : '0' };
+    margin-left: ${ loading === 'true' ? '-20px' : '0' };
   `}
 
-  ${({ loading, theme }) => loading === 'true' ? css`
+  ${({ loading, theme, design }) => loading === 'true' ? css`
+
+    // TODO: Fix transition animation so the below line doesn't look awful when transitioning - L
+    // ${ theme.styles.form.button[design].active };
 
     transition: margin ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeInOut};
 
@@ -64,6 +78,7 @@ const InnerContainer = styled.div<{position?: string, loading: string}>`
     ${LoadingContainer}{
       opacity: 1;
       transition: flex ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeInOut}, opacity ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeInOut} ${theme.animation.speed.slow};
+      ${ theme.styles.form.button[design].actionArea };
     }
   ` : css`
     ${LoadingContainer}{
@@ -79,14 +94,14 @@ interface IProps extends IButtonProps {
 
 const ButtonWithLoading : React.FC<IProps> = ({design='primary', size='normal', onClick, disabled, position, loading, children,...rest}) => {
   return (
-    <Button disabled={disabled || loading} {...{ design, size, onClick}} {...rest}>
-      <InnerContainer loading={loading.toString()}>
+    <LoadingButton disabled={disabled || loading} {...{ design, size, loading, onClick}} {...rest}>
+      <InnerContainer loading={loading.toString()} {...{ design}}>
         <TextContainer>{children}</TextContainer>
         <LoadingContainer {...{ design, position }}>
           <Spinner size='small' styling={design} />
         </LoadingContainer>
       </InnerContainer>
-    </Button>
+    </LoadingButton>
   );
 };
 

--- a/src/Pages/atoms/PageTitle.tsx
+++ b/src/Pages/atoms/PageTitle.tsx
@@ -32,19 +32,26 @@ const Title = styled.h1`
   margin: 0 0 20px;
 `;
 
-const AreaTitle = styled(Link)`
+
+const AreaTitleCss = css`
   ${({theme}) => css`
-    font-family: ${theme.fontFamily.ui};
-    ${theme.typography.pageHeader.areaTitle};
+  font-family: ${theme.fontFamily.ui};
+  ${theme.typography.pageHeader.areaTitle};
   `}
   margin: 0;
   position: absolute;
   top: -18px;
+`;
 
+const AreaTitle = styled.div`
+  ${AreaTitleCss}
+`;
+
+const AreaLinkTitle = styled(Link)`
+  ${AreaTitleCss}
   &:hover {
     text-decoration: underline;
   }
-
 `;
 
 interface IProps {
@@ -61,10 +68,12 @@ const PageTitle : React.FC<IProps> = ({title, icon, areaTitle, areaHref, updateD
     useTitle(title, areaTitle || "");
   }
 
+
   return <Container>
-    {areaTitle && areaHref ?
-      <AreaTitle to={areaHref}>{areaTitle}</AreaTitle>
-    : null}
+    {areaTitle && areaHref
+      ? <AreaLinkTitle to={areaHref}>{areaTitle}</AreaLinkTitle>
+      : areaTitle && <AreaTitle>{areaTitle}</AreaTitle> 
+    }
     <Title>{title}</Title>
     {icon ?
       <IconContainer><Icon size={24} color='dimmed' {...{icon}} /></IconContainer>


### PR DESCRIPTION
### Requirements
[Bugherd25](https://www.bugherd.com/projects/216308/tasks/25)
For "Standard Button", "Disabled" works.
But for “With Icon” and “With Loading”, we still can push the button even “Disabled” is checked.

[Bugherd39](https://www.bugherd.com/projects/216308/tasks/39)
[Page Header] Allow setting a subarea title without needing a url. 

### Implementation
**Bugherd35 Disabled buttons**
:active was not working properly when the button was wrapping items.
:active:enable verifies that is not disabled

**Bugherd39**
I created a link and a non link where it doesn't have a url.

### Screenshots
**Bugherd35 Disabled buttons video**
[InteractiveVideo](https://drive.google.com/file/d/14uYQJ5d-UFMS15jBTPUFUypfWs85lpCr/view?usp=sharing)

**Bugherd39 Page header** 
<img width="689" alt="Screen Shot 2021-03-12 at 18 35 15" src="https://user-images.githubusercontent.com/10409078/110921987-85d08100-8362-11eb-8bea-846b4d7034d2.png">
