### PR TITLE
Prop to hide logout link in drawer

### DIFF
--- a/src/Global/TopBar.tsx
+++ b/src/Global/TopBar.tsx
@@ -213,6 +213,7 @@ interface IProps {
   logoutLink?: string;
   loggedInUser: string;
   useSearch?: boolean;
+  useLogout?: boolean;
   searchPlaceholder?: string;
   showLanguage?: boolean;
   userDrawerBespoke?: ReactElement;
@@ -224,6 +225,7 @@ const TopBar : React.FC<IProps> = ({
   useNotifications = false,
   logoutLink = '/logout',
   useSearch = false,
+  useLogout = true,
   searchPlaceholder = 'Search for devices, analysis tasks, etc.',
   userSubmenu = [],
   userDrawerBespoke,
@@ -278,11 +280,13 @@ const TopBar : React.FC<IProps> = ({
 
           {userDrawerBespoke ? userDrawerBespoke : null}
 
-          <Logout>
-            <LinkMenu>
-              <LinkMenuItem><LinkMenuItemA onClick={logoutHandler} href={logoutLink}>Logout</LinkMenuItemA></LinkMenuItem>
-            </LinkMenu>
-          </Logout>
+          {useLogout ?
+            <Logout>
+              <LinkMenu>
+                <LinkMenuItem><LinkMenuItemA onClick={logoutHandler} href={logoutLink}>Logout</LinkMenuItemA></LinkMenuItem>
+              </LinkMenu>
+            </Logout>
+          : null }
         </DrawerTop>
         <DrawerBottom>
           {

--- a/src/Global/TopBar.tsx
+++ b/src/Global/TopBar.tsx
@@ -208,30 +208,30 @@ const LanguageMenu = styled.button`
 `;
 
 interface IProps {
-  useNotifications?: boolean;
+  showNotifications?: boolean;
   userSubmenu?: any[];
-  logoutLink?: string;
   loggedInUser: string;
-  useSearch?: boolean;
-  useLogout?: boolean;
-  searchPlaceholder?: string;
   showLanguage?: boolean;
+  showLogout?: boolean;
+  logoutLink?: string;
+  showSearch?: boolean;
+  searchPlaceholder?: string;
   userDrawerBespoke?: ReactElement;
   onLogout?: ()=>void;
   onLanguageToggle?: ()=>void;
 }
 
 const TopBar : React.FC<IProps> = ({
-  useNotifications = false,
+  showNotifications = false,
+  showLanguage = false,
+  showLogout = true,
   logoutLink = '/logout',
-  useSearch = false,
-  useLogout = true,
+  showSearch = false,
   searchPlaceholder = 'Search for devices, analysis tasks, etc.',
   userSubmenu = [],
   userDrawerBespoke,
   loggedInUser,
   onLogout = ()=>{},
-  showLanguage = false,
   onLanguageToggle = ()=>{}
 }) => {
 
@@ -246,7 +246,7 @@ const TopBar : React.FC<IProps> = ({
 
   return (
     <Container>
-      {useSearch ?
+      {showSearch ?
         <SearchBar>
           <IconWrapper>
             <Icon icon='Search' size={18} color='dimmed' />
@@ -255,7 +255,7 @@ const TopBar : React.FC<IProps> = ({
         </SearchBar> : <div />}
 
       <ButtonArea>
-        {useNotifications ? <DrawerToggle isActive={isNotificationsOpen} onClick={() => { setNotificationsOpen(!isNotificationsOpen); setUserMenuOpen(false); }}><Icon icon='Notifications' size={18} color='dimmed' /></DrawerToggle> : null}
+        {showNotifications ? <DrawerToggle isActive={isNotificationsOpen} onClick={() => { setNotificationsOpen(!isNotificationsOpen); setUserMenuOpen(false); }}><Icon icon='Notifications' size={18} color='dimmed' /></DrawerToggle> : null}
         <DrawerToggle isActive={isUserMenuOpen} onClick={() => { setUserMenuOpen(!isUserMenuOpen); setNotificationsOpen(false); }}><Icon icon='UserProfile' size={18} color='dimmed' /></DrawerToggle>
       </ButtonArea>
 
@@ -280,7 +280,7 @@ const TopBar : React.FC<IProps> = ({
 
           {userDrawerBespoke ? userDrawerBespoke : null}
 
-          {useLogout ?
+          {showLogout ?
             <Logout>
               <LinkMenu>
                 <LinkMenuItem><LinkMenuItemA onClick={logoutHandler} href={logoutLink}>Logout</LinkMenuItemA></LinkMenuItem>
@@ -303,7 +303,7 @@ const TopBar : React.FC<IProps> = ({
       </Drawer>
 
       {/* Notifications */}
-      {useNotifications ?
+      {showNotifications ?
         <Drawer isOpen={isNotificationsOpen}>
           <CurrentUser>
             <em>Feature Pending Development.</em>

--- a/src/Global/TopBar.tsx
+++ b/src/Global/TopBar.tsx
@@ -208,13 +208,13 @@ const LanguageMenu = styled.button`
 `;
 
 interface IProps {
-  showNotifications?: boolean;
+  hasNotifications?: boolean;
   userSubmenu?: any[];
   loggedInUser: string;
-  showLanguage?: boolean;
-  showLogout?: boolean;
+  hasLanguage?: boolean;
+  hasLogout?: boolean;
   logoutLink?: string;
-  showSearch?: boolean;
+  hasSearch?: boolean;
   searchPlaceholder?: string;
   userDrawerBespoke?: ReactElement;
   onLogout?: ()=>void;
@@ -222,11 +222,11 @@ interface IProps {
 }
 
 const TopBar : React.FC<IProps> = ({
-  showNotifications = false,
-  showLanguage = false,
-  showLogout = true,
+  hasNotifications = false,
+  hasLanguage = false,
+  hasLogout = true,
   logoutLink = '/logout',
-  showSearch = false,
+  hasSearch = false,
   searchPlaceholder = 'Search for devices, analysis tasks, etc.',
   userSubmenu = [],
   userDrawerBespoke,
@@ -246,7 +246,7 @@ const TopBar : React.FC<IProps> = ({
 
   return (
     <Container>
-      {showSearch ?
+      {hasSearch ?
         <SearchBar>
           <IconWrapper>
             <Icon icon='Search' size={18} color='dimmed' />
@@ -255,7 +255,7 @@ const TopBar : React.FC<IProps> = ({
         </SearchBar> : <div />}
 
       <ButtonArea>
-        {showNotifications ? <DrawerToggle isActive={isNotificationsOpen} onClick={() => { setNotificationsOpen(!isNotificationsOpen); setUserMenuOpen(false); }}><Icon icon='Notifications' size={18} color='dimmed' /></DrawerToggle> : null}
+        {hasNotifications ? <DrawerToggle isActive={isNotificationsOpen} onClick={() => { setNotificationsOpen(!isNotificationsOpen); setUserMenuOpen(false); }}><Icon icon='Notifications' size={18} color='dimmed' /></DrawerToggle> : null}
         <DrawerToggle isActive={isUserMenuOpen} onClick={() => { setUserMenuOpen(!isUserMenuOpen); setNotificationsOpen(false); }}><Icon icon='UserProfile' size={18} color='dimmed' /></DrawerToggle>
       </ButtonArea>
 
@@ -280,7 +280,7 @@ const TopBar : React.FC<IProps> = ({
 
           {userDrawerBespoke ? userDrawerBespoke : null}
 
-          {showLogout ?
+          {hasLogout ?
             <Logout>
               <LinkMenu>
                 <LinkMenuItem><LinkMenuItemA onClick={logoutHandler} href={logoutLink}>Logout</LinkMenuItemA></LinkMenuItem>
@@ -290,7 +290,7 @@ const TopBar : React.FC<IProps> = ({
         </DrawerTop>
         <DrawerBottom>
           {
-            showLanguage &&
+            hasLanguage &&
               <LanguageMenu onClick={onLanguageToggle}>
                 <IconWrapper>
                   <Icon icon='Language' size={18} color='dimmed' />
@@ -303,7 +303,7 @@ const TopBar : React.FC<IProps> = ({
       </Drawer>
 
       {/* Notifications */}
-      {showNotifications ?
+      {hasNotifications ?
         <Drawer isOpen={isNotificationsOpen}>
           <CurrentUser>
             <em>Feature Pending Development.</em>

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -36,6 +36,7 @@ export const _TopBar = () => {
   ])
 
   const useSearch = boolean("Use Search", true);
+  const useLogout = boolean("Use Logout", true);
   const useNotifications = boolean("Use Notifications", true);
   const showLanguage = boolean("Show Language", true);
   const logoutLink = text("Logout Url", "#")
@@ -43,5 +44,5 @@ export const _TopBar = () => {
 
   // userDrawerBespoke: See examples for implementation of this prop.
 
-  return <Container><TopBar {...{loggedInUser, userSubmenu, useSearch, useNotifications, logoutLink, searchPlaceholder, showLanguage}}/></Container>;
+  return <Container><TopBar {...{loggedInUser, userSubmenu, useSearch, useLogout, useNotifications, logoutLink, searchPlaceholder, showLanguage}}/></Container>;
 };

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -35,14 +35,14 @@ export const _TopBar = () => {
     }
   ])
 
-  const useSearch = boolean("Use Search", true);
-  const useLogout = boolean("Use Logout", true);
-  const useNotifications = boolean("Use Notifications", true);
+  const showSearch = boolean("Show Search", true);
+  const showLogout = boolean("Show Logout", true);
+  const showNotifications = boolean("Show Notifications", true);
   const showLanguage = boolean("Show Language", true);
   const logoutLink = text("Logout Url", "#")
   const searchPlaceholder = text("Search Placeholder", "Search area names, etc.")
 
   // userDrawerBespoke: See examples for implementation of this prop.
 
-  return <Container><TopBar {...{loggedInUser, userSubmenu, useSearch, useLogout, useNotifications, logoutLink, searchPlaceholder, showLanguage}}/></Container>;
+  return <Container><TopBar {...{loggedInUser, userSubmenu, showSearch, showLogout, showNotifications, logoutLink, searchPlaceholder, showLanguage}}/></Container>;
 };

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -35,14 +35,14 @@ export const _TopBar = () => {
     }
   ])
 
-  const showSearch = boolean("Show Search", true);
-  const showLogout = boolean("Show Logout", true);
-  const showNotifications = boolean("Show Notifications", true);
-  const showLanguage = boolean("Show Language", true);
+  const hasSearch = boolean("Has Search", true);
+  const hasLogout = boolean("Has Logout", true);
+  const hasNotifications = boolean("Has Notifications", true);
+  const hasLanguage = boolean("Has Language", true);
   const logoutLink = text("Logout Url", "#")
   const searchPlaceholder = text("Search Placeholder", "Search area names, etc.")
 
   // userDrawerBespoke: See examples for implementation of this prop.
 
-  return <Container><TopBar {...{loggedInUser, userSubmenu, showSearch, showLogout, showNotifications, logoutLink, searchPlaceholder, showLanguage}}/></Container>;
+  return <Container><TopBar {...{loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, searchPlaceholder, hasLanguage}}/></Container>;
 };


### PR DESCRIPTION
This is required on some Edge side projects where this isn't relevant. 

I originally wanted to do conditional hiding based on if `logoutLink` or `onLogout` were passed as props but as we set a default for onLogout I wasn't sure how to detect that as an empty function. If you can think of a better was to refactor this, happy to do that. Otherwise I've just gone with a simple boolean to show and hide.