### PR TITLE
LineUI - Add boundaryOffset option

### DIFF
--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   TextField,
   Label,
+  Input
 } from 'scorer-ui-kit';
 import { LineUIOptions } from '../../../dist/LineUI';
 
@@ -29,7 +30,8 @@ const Line: React.FC<{}> = () => {
     fixedImgDimensions: {
       x: 2310,
       y: 1535
-    }
+    },
+    boundaryOffset: 0
   });
 
   const fetchLine = useCallback(async () => {
@@ -87,6 +89,10 @@ const Line: React.FC<{}> = () => {
     fetchLine();
   }, [fetchLine])
 
+  const updateBoudaryOffset =  useCallback( ({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
+    setOptions({...options, boundaryOffset: parseInt(value) });
+  }, [options]);
+
   return (
     <Layout >
       <Sidebar>
@@ -109,6 +115,9 @@ const Line: React.FC<{}> = () => {
         </SidebarBox>
         <SidebarBox>
           <TextField label='Rename Line' fieldState='default' name='rename' value={state[0]?.name ||''} onChange={renameLine}/>
+          <Label labelText='Boundary Offset' htmlFor='boundaryOffset' >
+            <Input type='number' name='boundaryOffset' min={0} value={options.boundaryOffset} onChange={updateBoudaryOffset}/>
+          </Label>
         </SidebarBox>
         <SidebarBox>
           <Button design="secondary" onClick={toggleReadOnly()} >Toggle Read Only</Button>

--- a/src/LineUI/LineUI.tsx
+++ b/src/LineUI/LineUI.tsx
@@ -82,7 +82,8 @@ const LineUI: React.FC<LineUIProps> = ({
     setIndexOffset = 0,
     pointIndexOffset = 0,
     showPoint = false,
-    fixedImgDimensions
+    fixedImgDimensions,
+    boundaryOffset = 0
   } = {}
 }) => {
 
@@ -149,12 +150,12 @@ const LineUI: React.FC<LineUIProps> = ({
     const { viewBox } = frame.current;
     const bounds = {
       x: {
-        min: viewBox.baseVal.x,
-        max: viewBox.baseVal.x + viewBox.baseVal.width
+        min: viewBox.baseVal.x + boundaryOffset,
+        max: viewBox.baseVal.x + viewBox.baseVal.width - boundaryOffset
       },
       y: {
-        min: viewBox.baseVal.y,
-        max: viewBox.baseVal.y + viewBox.baseVal.height
+        min: viewBox.baseVal.y + boundaryOffset,
+        max: viewBox.baseVal.y + viewBox.baseVal.height - boundaryOffset
       },
     };
     console.debug('setBoundaries', bounds);

--- a/src/LineUI/LineUI.tsx
+++ b/src/LineUI/LineUI.tsx
@@ -160,7 +160,7 @@ const LineUI: React.FC<LineUIProps> = ({
     };
     console.debug('setBoundaries', bounds);
     setBoundaries(bounds);
-  }, [imgSize]);
+  }, [imgSize, boundaryOffset]);
 
   useEffect(() => {
 

--- a/src/LineUI/LineUIRTC.tsx
+++ b/src/LineUI/LineUIRTC.tsx
@@ -85,7 +85,7 @@ const LineUI : React.FC<LineUIProps> = ({
     setIndexOffset = 0,
     pointIndexOffset = 0,
     showPoint = false,
-    boundaryOffset = 0,
+    boundaryOffset = 0
   }={}
 }) => {
 

--- a/src/LineUI/LineUIRTC.tsx
+++ b/src/LineUI/LineUIRTC.tsx
@@ -84,7 +84,8 @@ const LineUI : React.FC<LineUIProps> = ({
     showGrabHandle,
     setIndexOffset = 0,
     pointIndexOffset = 0,
-    showPoint = false
+    showPoint = false,
+    boundaryOffset = 0,
   }={}
 }) => {
 
@@ -139,16 +140,16 @@ const LineUI : React.FC<LineUIProps> = ({
     const { viewBox } = frame.current;
     const bounds = {
       x: {
-        min: viewBox.baseVal.x,
-        max: viewBox.baseVal.x + viewBox.baseVal.width
+        min: viewBox.baseVal.x + boundaryOffset,
+        max: viewBox.baseVal.x + viewBox.baseVal.width - boundaryOffset
       },
       y: {
-        min: viewBox.baseVal.y,
-        max: viewBox.baseVal.y + viewBox.baseVal.height
+        min: viewBox.baseVal.y + boundaryOffset,
+        max: viewBox.baseVal.y + viewBox.baseVal.height - boundaryOffset
       },
     };
     setBoundaries(bounds);
-  }, [videoSize, loaded]);
+  }, [videoSize, loaded, boundaryOffset]);
 
   const onLoadedMetadata = useCallback(({target}) =>{
     if(target){

--- a/src/LineUI/LineUIVideo.tsx
+++ b/src/LineUI/LineUIVideo.tsx
@@ -92,6 +92,7 @@ const LineUIVideo : React.FC<LineUIProps> = ({
     setIndexOffset = 0,
     pointIndexOffset = 0,
     showPoint = false,
+    boundaryOffset = 0
   }={}
 }) => {
 
@@ -146,16 +147,16 @@ const LineUIVideo : React.FC<LineUIProps> = ({
     const { viewBox } = frame.current;
     const bounds = {
       x: {
-        min: viewBox.baseVal.x,
-        max: viewBox.baseVal.x + viewBox.baseVal.width
+        min: viewBox.baseVal.x + boundaryOffset,
+        max: viewBox.baseVal.x + viewBox.baseVal.width - boundaryOffset
       },
       y: {
-        min: viewBox.baseVal.y,
-        max: viewBox.baseVal.y + viewBox.baseVal.height
+        min: viewBox.baseVal.y + boundaryOffset,
+        max: viewBox.baseVal.y + viewBox.baseVal.height - boundaryOffset
       },
     };
     setBoundaries(bounds);
-  }, [videoSize, loaded]);
+  }, [videoSize, loaded, boundaryOffset]);
 
   const onLoadedMetadata = useCallback(({target}) =>{
     if(target){

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -62,6 +62,8 @@ export interface LineUIOptions {
     x: number;
     y: number;
   };
+
+  boundaryOffset? : number
 }
 
 export type  LineUIVideoOptions = VideoHTMLAttributes<HTMLVideoElement>


### PR DESCRIPTION
Add boundryOffset in LineUI to prevent user to put the vertices of quadrangles/line near the border. This feature is required if image used in LineUI is undistorted.