### PR TITLE
Remove min-height and add blur to backdrop in modal

### DIFF
--- a/src/Alerts/atom/Modal.tsx
+++ b/src/Alerts/atom/Modal.tsx
@@ -61,7 +61,6 @@ const CloseButton = styled.button<{ selected?: boolean }>`
 
 const LightBox = styled.div<{ padding?: boolean, width?: string}>`
   position: relative;
-  min-height: 300px;
   margin: 27px 0 0;
   box-shadow: 0 10px 15px 0 hsla(205, 42%, 60%, 0.15);
   background-color: hsl(0, 0%, 100%);

--- a/src/Alerts/atom/Modal.tsx
+++ b/src/Alerts/atom/Modal.tsx
@@ -16,7 +16,10 @@ const Container = styled.div`
   align-items: center;
   justify-content: center;
   background-color: hsl(0, 0%, 0%, 0.2);
+  -webkit-backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
   font-family: ${({ theme }) => theme.fontFamily.ui};
+
 `;
 
 const CloseIcon = styled(Icon)``;

--- a/src/Alerts/atom/Modal.tsx
+++ b/src/Alerts/atom/Modal.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: hsl(0, 0%, 0%, 0.2);
+  background-color: hsla(202, 33%, 95%, 0.51);
   -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
   font-family: ${({ theme }) => theme.fontFamily.ui};


### PR DESCRIPTION
### Requirement

1.- Some designs have less than 300px height and current implementation doesn't allow to implement those.
2.- @atomworks mention that it would be great that the backdrop has blur.

### Implementation

Reviewed a couple of options fr the min-height with @atomworks and we decided just removing it will be better for now.

### Screenshots 


New Empty Modal
<img width="812" alt="Screen Shot 2021-04-05 at 12 59 12" src="https://user-images.githubusercontent.com/10409078/113535567-ba0c2a00-960e-11eb-90c0-cede57455295.png">


Previous templates, since content was bigger than 300px won't show any  difference
<img width="986" alt="Screen Shot 2021-04-05 at 15 19 17" src="https://user-images.githubusercontent.com/10409078/113544059-8b984a00-9622-11eb-8f25-96d86dcb5968.png">


