### PR TITLE
Update Duration and Percentage Slider Titles to use Label component

### DIFF
--- a/src/Form/atoms/Label.tsx
+++ b/src/Form/atoms/Label.tsx
@@ -16,7 +16,7 @@ const LabelText = styled.span`
 `;
 
 interface OwnProps {
-  htmlFor?: string
+  htmlFor: string
   labelText: string
 }
 type Props = OwnProps & LabelHTMLAttributes<HTMLLabelElement>

--- a/src/Form/atoms/Label.tsx
+++ b/src/Form/atoms/Label.tsx
@@ -16,16 +16,18 @@ const LabelText = styled.span`
 `;
 
 interface OwnProps {
-  htmlFor: string
+  htmlFor?: string
   labelText: string
 }
 type Props = OwnProps & LabelHTMLAttributes<HTMLLabelElement>
 
 const Label : React.FC<Props> = ({ htmlFor, labelText, children, ...props }) => {
-  return <StyledLabel htmlFor={htmlFor} {...props}>
-    <LabelText>{labelText}</LabelText>
-    {children}
-  </StyledLabel>;
+  return (
+    <StyledLabel htmlFor={htmlFor} {...props}>
+      <LabelText>{labelText}</LabelText>
+      {children}
+    </StyledLabel>
+  );
 };
 
 export default Label;

--- a/src/Form/molecules/DurationSlider.tsx
+++ b/src/Form/molecules/DurationSlider.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import {ITimeUnit} from '../../index';
 import SliderInput, {ISlider} from '../atoms/SliderInput';
 import {getTextTimeUnit} from '../../helpers';
+import Label from '../atoms/Label';
 
 
 /**
@@ -22,11 +23,7 @@ const Headers = styled.div`
   padding: 0 6px;
 `;
 
-const MainTitle = styled.div`
-  font-family: ${({ theme }) => theme.fontFamily.ui};
-`;
-
-const ValueTitle = styled.div`
+const ValueTitle = styled(Label)`
   font-family: ${({ theme }) => theme.fontFamily.data};
 `;
 
@@ -61,8 +58,8 @@ const DurationSlider: React.FC<IDurationSlider> = (
   return(
     <Container>
       <Headers>
-        <MainTitle>{title}</MainTitle>
-        <ValueTitle>{getTextTimeUnit(selectedValue, timeUnit)}</ValueTitle>
+        <Label labelText={title} />
+        <ValueTitle labelText={getTextTimeUnit(selectedValue, timeUnit)} />
       </Headers>
       <SliderInput
         {

--- a/src/Form/molecules/DurationSlider.tsx
+++ b/src/Form/molecules/DurationSlider.tsx
@@ -58,12 +58,13 @@ const DurationSlider: React.FC<IDurationSlider> = (
   return(
     <Container>
       <Headers>
-        <Label labelText={title} />
-        <ValueTitle labelText={getTextTimeUnit(selectedValue, timeUnit)} />
+        <Label htmlFor='duration-slider' labelText={title} />
+        <ValueTitle htmlFor='duration-slider' labelText={getTextTimeUnit(selectedValue, timeUnit)} />
       </Headers>
       <SliderInput
         {
           ...props}
+        id='duration-slider'
         max={max}
         min={min}
         defaultValue={defaultValue}

--- a/src/Form/molecules/PercentageSlider.tsx
+++ b/src/Form/molecules/PercentageSlider.tsx
@@ -2,6 +2,7 @@ import React, {InputHTMLAttributes, useState, useCallback} from 'react';
 import styled from 'styled-components';
 import SliderInput, {ISliderMark} from '../atoms/SliderInput';
 import {IFeedbackColor} from '../../index';
+import Label from '../atoms/Label';
 
 
 const Container = styled.div``;
@@ -13,10 +14,8 @@ const Headers = styled.div`
   margin-bottom: 20px;
   padding: 0 6px;
 `;
-const MainTitle = styled.div`
-  font-family: ${({ theme }) => theme.fontFamily.ui};
-`;
-const ValueTitle = styled.div`
+
+const ValueTitle = styled(Label)`
   font-family: ${({ theme }) => theme.fontFamily.data};
 `;
 
@@ -79,14 +78,10 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
   return(
     <Container>
       <Headers>
-        <MainTitle>
-          {
-            updateTitle
-            ? updateTitle(selectedValue)
-            : getTitleLevel(selectedValue)
-          }
-        </MainTitle>
-        <ValueTitle>{`${selectedValue}%`}</ValueTitle>
+        <Label
+          labelText={updateTitle ? updateTitle(selectedValue) : getTitleLevel(selectedValue)}
+        />
+        <ValueTitle labelText={`${selectedValue}%`} />
       </Headers>
       <SliderInput
         {...props}

--- a/src/Form/molecules/PercentageSlider.tsx
+++ b/src/Form/molecules/PercentageSlider.tsx
@@ -79,12 +79,14 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
     <Container>
       <Headers>
         <Label
+          htmlFor='percentage-slider'
           labelText={updateTitle ? updateTitle(selectedValue) : getTitleLevel(selectedValue)}
         />
-        <ValueTitle labelText={`${selectedValue}%`} />
+        <ValueTitle htmlFor='percentage-slider' labelText={`${selectedValue}%`} />
       </Headers>
       <SliderInput
         {...props}
+        id='percentage-slider'
         max={100}
         min={0}
         defaultValue={defaultValue}


### PR DESCRIPTION
### Requirements
This is fix request from the FTI team

```
For other input component label  font-weight in ui-kit is 500, but in slider component doesn't have font-weight for the label. Is there any way so we can modify the styles of slider label? (Please check the attached snapshot)
```

### Implementation
I had not added the titles as Label component's the first time.

### Screenshots
<img width="922" alt="Screen Shot 2021-04-08 at 18 15 37" src="https://user-images.githubusercontent.com/10409078/114000936-6ca1ee00-9896-11eb-93c8-372c384623a5.png">
