### PR TITLE
Add extra-small button with loading and icon update

### DIFF
--- a/src/Form/atoms/Button.tsx
+++ b/src/Form/atoms/Button.tsx
@@ -11,10 +11,11 @@ interface IStyledComponentProps {
 
 
 const StyledButton = styled.button<IStyledComponentProps>`
-  ${({theme, design, size}) => css`
+  ${({theme, design, size}) => css` 
 
     ${theme.styles.form.button[design].default};
-    height: ${theme.dimensions.form.button[ size ]};
+    height: ${theme.dimensions.form.button.height[ size ]};
+    padding: ${theme.dimensions.form.button.padding[ size ]};
 
     ${theme.typography.form.button[ design ][ size ]};
     font-family: ${theme.fontFamily.ui};
@@ -44,7 +45,6 @@ const StyledButton = styled.button<IStyledComponentProps>`
   border: none;
   cursor: pointer;
   border-radius: 3px;
-  padding: 0 20px;
   outline: none;
 
   button + button {

--- a/src/Form/atoms/ButtonWithIcon.tsx
+++ b/src/Form/atoms/ButtonWithIcon.tsx
@@ -3,10 +3,10 @@ import styled, { css } from 'styled-components';
 
 import Button from './Button';
 import Icon from '../../Icons/Icon';
-import { IButtonProps } from '..';
+import { IButtonProps, TypeButtonSizes } from '..';
 
 
-const TextContainer = styled.div`
+const TextContainer = styled.div<{size:TypeButtonSizes}>`
   height: inherit;
   flex: 1;
   order: 1;
@@ -14,8 +14,9 @@ const TextContainer = styled.div`
   justify-content: center;
   align-items: center;
   white-space: nowrap;
-  padding: 0 20px;
-  ${({theme}) => theme && css`
+
+  ${({theme, size}) => theme && css`
+    padding: ${theme.dimensions.form.button.padding[ size ]};
     transition: padding ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeInOut};
   `}
 
@@ -38,17 +39,12 @@ const IconContainer = styled.div<{ position?: string }>`
   }
 `;
 
-const InnerContainer = styled.div<{position?: string}>`
+const InnerContainer = styled.div<{size?:TypeButtonSizes }>`
   display: flex;
   height: inherit;
-
-
-  ${({ position }) => position && position === 'left' ? css`
-    margin-right: -20px;
-  ` : css`
-    margin-left: -20px;
-  `}
-
+  ${({size}) => (size==='extraSmall')? css`margin-top: -3px` : ``};
+  ${({size}) => (size==='extraSmall')? css`padding-right: 10px` : ``};
+  margin-left: ${({size}) => (size==='extraSmall') ? `-10px` : `-20px` };
 `;
 
 interface IProps extends IButtonProps {
@@ -56,19 +52,21 @@ interface IProps extends IButtonProps {
   position?: 'left' | 'right'
 }
 
-const ButtonWithIcon : React.FC<IProps> = ({design, size, onClick, disabled, position, icon, children, ...props}) => {
+const ButtonWithIcon : React.FC<IProps> = ({design, size = 'normal', onClick, disabled, position, icon, children, ...props}) => {
 
   const iconSize = size === 'large' ? 20 : 16;
   const iconColor = design === 'secondary' ? 'dimmed' : 'inverse';
 
-  return <Button disabled={disabled} {...{ design, size, onClick, disabled }} {...props}>
-    <InnerContainer>
-      <TextContainer>{children}</TextContainer>
-      <IconContainer {...{ design, position }}>
-        <Icon icon={icon} size={iconSize} color={iconColor} weight={'heavy'} />
-      </IconContainer>
-    </InnerContainer>
-  </Button>;
+  return (
+    <Button disabled={disabled} {...{ design, size, onClick, disabled }} {...props}>
+      <InnerContainer {...{size}}>
+        <TextContainer {...{size}}>{children}</TextContainer>
+        <IconContainer {...{ design, position }}>
+          <Icon icon={icon} size={iconSize} color={iconColor} weight='heavy' />
+        </IconContainer>
+      </InnerContainer>
+    </Button>
+  );
 };
 
 export default ButtonWithIcon;

--- a/src/Form/atoms/ButtonWithLoading.tsx
+++ b/src/Form/atoms/ButtonWithLoading.tsx
@@ -3,20 +3,21 @@ import styled, { css } from 'styled-components';
 
 import Button from './Button';
 import Spinner from '../../Indicators/Spinner';
-import { TypeButtonDesigns, IButtonProps } from '..';
+import { TypeButtonDesigns, TypeButtonSizes, IButtonProps } from '..';
 
 
-const LoadingButton = styled(Button)<{ loading: boolean }>`
-  ${({loading, theme, design}) => loading && css`
+const LoadingButton = styled(Button)<{ loading: boolean, size: TypeButtonSizes }>`
+  ${({loading, theme, size}) => loading && css`
     cursor: wait;
     background: ${ theme.styles.form.button['primary'].active };
-
+    ${(size === 'extraSmall') && css`
+        padding: 3px 20px 3px 10px;
+      `};
     &:disabled {
       opacity: 1;
     }
   `};
-
-`
+`;
 
 const TextContainer = styled.div`
   height: inherit;
@@ -41,7 +42,7 @@ const LoadingContainer = styled.div<{ design: TypeButtonDesigns, show?: boolean,
   overflow: hidden;
   opacity: 0;
 
-  ${({ theme, position, design }) => css`
+  ${({ theme, position}) => css`
     transition:
       flex ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeInOut} ${theme.animation.speed.slow},
       opacity ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeInOut};
@@ -54,18 +55,24 @@ const LoadingContainer = styled.div<{ design: TypeButtonDesigns, show?: boolean,
   }
 `;
 
-const InnerContainer = styled.div<{position?: string, loading: string, design: TypeButtonDesigns}>`
+const InnerContainer = styled.div<{position?: string, loading: string, design: TypeButtonDesigns, size: TypeButtonSizes}>`
   display: flex;
   height: inherit;
+  ${({size}) => (size === 'extraSmall') ? css`margin-top: -3px`: ``};
 
-
-  ${({ position, loading }) => position && position === 'left' ? css`
-    margin-right: ${ loading === 'true' ? '-20px' : '0' };
+  ${({ position, loading, size }) => position && position === 'left' ? css`
+      margin-right: ${ loading === 'true'
+      ?  (size === 'extraSmall') ? '-10px' : '-20px'
+      : '0' 
+    };
   ` : css`
-    margin-left: ${ loading === 'true' ? '-20px' : '0' };
+      margin-left: ${ loading === 'true'
+      ? (size === 'extraSmall') ? '-10px' : '-20px'
+      : '0'
+    };
   `}
 
-  ${({ loading, theme, design }) => loading === 'true' ? css`
+  ${({ loading, theme, design, size }) => loading === 'true' ? css`
 
     // TODO: Fix transition animation so the below line doesn't look awful when transitioning - L
     // ${ theme.styles.form.button[design].active };
@@ -73,7 +80,7 @@ const InnerContainer = styled.div<{position?: string, loading: string, design: T
     transition: margin ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeInOut};
 
     ${TextContainer}{
-      padding: 0 20px;
+      padding: ${theme.dimensions.form.button.padding[ size ]};
     }
     ${LoadingContainer}{
       opacity: 1;
@@ -95,7 +102,7 @@ interface IProps extends IButtonProps {
 const ButtonWithLoading : React.FC<IProps> = ({design='primary', size='normal', onClick, disabled, position, loading, children,...rest}) => {
   return (
     <LoadingButton disabled={disabled || loading} {...{ design, size, loading, onClick}} {...rest}>
-      <InnerContainer loading={loading.toString()} {...{ design}}>
+      <InnerContainer loading={loading.toString()} {...{ design, size }}>
         <TextContainer>{children}</TextContainer>
         <LoadingContainer {...{ design, position }}>
           <Spinner size='small' styling={design} />

--- a/src/Form/index.ts
+++ b/src/Form/index.ts
@@ -41,7 +41,7 @@ export {
 
 export type TypeFieldState = 'default' | 'disabled' | 'required' | 'valid' | 'invalid' | 'processing';
 export type TypeButtonDesigns = 'primary' | 'secondary' | 'danger';
-export type TypeButtonSizes = 'small' | 'normal' | 'large';
+export type TypeButtonSizes = 'extraSmall'| 'small' | 'normal' | 'large';
 
 interface ButtonProps {
   size?: TypeButtonSizes

--- a/src/themes/common.tsx
+++ b/src/themes/common.tsx
@@ -13,9 +13,18 @@ export const dimensions = {
   },
   form: {
     button: {
-      small: '30px',
-      normal: '40px',
-      large: '60px'
+      height: {
+        extraSmall: '20px',
+        small: '30px',
+        normal: '40px',
+        large: '60px'
+      },
+      padding: {
+        extraSmall: '3px 10px',
+        small: '0 20px',
+        normal: '0 20px',
+        large: '0 20px'        
+      }
     },
     input: {
       height: '40px'

--- a/src/themes/light/styles.js
+++ b/src/themes/light/styles.js
@@ -388,4 +388,4 @@ export const styles = {
             "backgroundColor": "hsla(30, 91%, 61%, 1.000)"
         }
     }
-}
+};

--- a/src/themes/light/typography.js
+++ b/src/themes/light/typography.js
@@ -184,7 +184,14 @@ export const typography = {
                     "fontWeight": 600,
                     "textDecoration": "none",
                     "color": "hsla(0, 0%, 100%, 1.000)"
-                }
+                },
+                "extraSmall": {
+                  "textAlign": "left",
+                  "fontSize": "12px",
+                  "fontWeight": 600,
+                  "textDecoration": "none",
+                  "color": "hsla(0, 0%, 100%, 1.000)"
+              }
             },
             "secondary": {
                 "large": {
@@ -207,7 +214,14 @@ export const typography = {
                     "fontWeight": 600,
                     "textDecoration": "none",
                     "color": "hsla(0, 0%, 55.3%, 1.000)"
-                }
+                },
+                "extraSmall": {
+                  "textAlign": "left",
+                  "fontSize": "12px",
+                  "fontWeight": 600,
+                  "textDecoration": "none",
+                  "color": "hsla(0, 0%, 55.3%, 1.000)"
+              }
             },
             "danger": {
                 "large": {
@@ -227,6 +241,13 @@ export const typography = {
                 "small": {
                     "textAlign": "left",
                     "fontSize": "14px",
+                    "fontWeight": 600,
+                    "textDecoration": "none",
+                    "color": "hsla(0, 0%, 100%, 1.000)"
+                },
+                "extraSmall": {
+                    "textAlign": "left",
+                    "fontSize": "12px",
                     "fontWeight": 600,
                     "textDecoration": "none",
                     "color": "hsla(0, 0%, 100%, 1.000)"
@@ -675,4 +696,4 @@ export const typography = {
             "color": "hsla(202, 6.2%, 74.5%, 1.000)"
         }
     }
-}
+};

--- a/storybook/src/stories/Form/Button.stories.tsx
+++ b/storybook/src/stories/Form/Button.stories.tsx
@@ -13,7 +13,7 @@ export default {
 export const StandardButton = () => {
   const buttonText = text("Button Text", "Example Title");
   const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger" }, "primary");
-  const buttonSize = select("Size", { Small: "small", Normal: "normal", Large: "large" }, "normal");
+  const buttonSize = select("Size", { ExtraSmall: 'extraSmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonOnClick = action('button-click');
 

--- a/storybook/src/stories/Form/ButtonWithIcons.stories.tsx
+++ b/storybook/src/stories/Form/ButtonWithIcons.stories.tsx
@@ -14,7 +14,7 @@ export const _WithIcon = () => {
 
   const buttonText = text("Button Text", "Example Title");
   const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger" }, "primary");
-  const buttonSize = select("Size", { Small: "small", Normal: "normal", Large: "large" }, "normal");
+  const buttonSize = select("Size", { ExtraSmall: 'extraSmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonIcon = select("Icon", iconList, Object.keys(iconList)[0]);
   const buttonIconPosition = select("Icon Position", { Left: "left", Right: "right"}, "right");

--- a/storybook/src/stories/Form/ButtonWithLoading.stories.tsx
+++ b/storybook/src/stories/Form/ButtonWithLoading.stories.tsx
@@ -13,7 +13,7 @@ export default {
 export const _WithLoading = () => {
   const buttonText = text("Button Text", "Example Title");
   const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger" }, "primary");
-  const buttonSize = select("Size", { Small: "small", Normal: "normal", Large: "large" }, "normal");
+  const buttonSize = select("Size", { ExtraSmall: 'extraSmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonLoading = boolean("Loading", true);
   const buttonLoadingPosition = select("Loading Position", { Left: "left", Right: "right"}, "right");


### PR DESCRIPTION
### Requirements
[Bugherd#40](https://www.bugherd.com/projects/216308/tasks/40)

[Buttons] Add extra small variant.

### Implementation
Made added the extraSmall style by hand, not sure if this will complate later the auto generated one of zepplin.
Did small refactor to have button padding in dimensions file.

### Screenshots 

**Extra small base**
<img width="549" alt="Screen Shot 2021-04-12 at 20 05 51" src="https://user-images.githubusercontent.com/10409078/114385074-7c893d00-9bca-11eb-93ec-227513a75aac.png">

**Extra small with icon**
<img width="591" alt="Screen Shot 2021-04-12 at 20 05 22" src="https://user-images.githubusercontent.com/10409078/114385013-6b403080-9bca-11eb-816a-1234adba0c25.png">

**Extra small with loading**
<img width="685" alt="Screen Shot 2021-04-12 at 20 04 37" src="https://user-images.githubusercontent.com/10409078/114384937-51065280-9bca-11eb-8465-309d3cdacf2d.png">
