### PR TITLE
Add CurrentUser as optional prop in top bar

### DIFF
--- a/src/Global/TopBar.tsx
+++ b/src/Global/TopBar.tsx
@@ -215,6 +215,7 @@ interface IProps {
   hasLogout?: boolean;
   logoutLink?: string;
   hasSearch?: boolean;
+  hasCurrentUser?: boolean;
   searchPlaceholder?: string;
   userDrawerBespoke?: ReactElement;
   onLogout?: ()=>void;
@@ -227,6 +228,7 @@ const TopBar : React.FC<IProps> = ({
   hasLogout = true,
   logoutLink = '/logout',
   hasSearch = false,
+  hasCurrentUser = true,
   searchPlaceholder = 'Search for devices, analysis tasks, etc.',
   userSubmenu = [],
   userDrawerBespoke,
@@ -262,10 +264,12 @@ const TopBar : React.FC<IProps> = ({
       {/* User Menu */}
       <Drawer isOpen={isUserMenuOpen}>
         <DrawerTop>
-          <CurrentUser>
-            <DrawerHeader>Current User</DrawerHeader>
-            {loggedInUser}
-          </CurrentUser>
+          {hasCurrentUser ?
+            <CurrentUser>
+              <DrawerHeader>Current User</DrawerHeader>
+              {loggedInUser}
+            </CurrentUser>
+          : null}
 
           {userSubmenu.length > 0 ?
             <UserMenu>
@@ -286,7 +290,7 @@ const TopBar : React.FC<IProps> = ({
                 <LinkMenuItem><LinkMenuItemA onClick={logoutHandler} href={logoutLink}>Logout</LinkMenuItemA></LinkMenuItem>
               </LinkMenu>
             </Logout>
-          : null }
+          : null}
         </DrawerTop>
         <DrawerBottom>
           {

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -20,6 +20,14 @@ export const _TopBar = () => {
 
 
   const loggedInUser = text("Logged In User", "full.name@example.com");
+
+  const hasSearch = boolean("Has Search", true);
+  const hasLogout = boolean("Has Logout", true);
+  const hasNotifications = boolean("Has Notifications", true);
+  const hasLanguage = boolean("Has Language", true);
+  const hasCurrentUser = boolean("Has Current User", true);
+  const logoutLink = text("Logout Url", "#")
+  const searchPlaceholder = text("Search Placeholder", "Search area names, etc.")
   const userSubmenu = object("Submenu", [
     {
       text: 'Accounts',
@@ -35,14 +43,7 @@ export const _TopBar = () => {
     }
   ])
 
-  const hasSearch = boolean("Has Search", true);
-  const hasLogout = boolean("Has Logout", true);
-  const hasNotifications = boolean("Has Notifications", true);
-  const hasLanguage = boolean("Has Language", true);
-  const logoutLink = text("Logout Url", "#")
-  const searchPlaceholder = text("Search Placeholder", "Search area names, etc.")
-
   // userDrawerBespoke: See examples for implementation of this prop.
 
-  return <Container><TopBar {...{loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, searchPlaceholder, hasLanguage}}/></Container>;
+  return <Container><TopBar {...{loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, searchPlaceholder, hasLanguage, hasCurrentUser}}/></Container>;
 };


### PR DESCRIPTION
### Requirements

[Bugherd55](https://www.bugherd.com/projects/216308/tasks/55)

[User Menu] Allow for current user to be hidden (use similar approach to how logout hide works)

### Implementation
I leave it at hasCurrentUser as true by default since it wasn't specified.


### Screenshot

<img width="1200" alt="Screen Shot 2021-04-13 at 19 25 25" src="https://user-images.githubusercontent.com/10409078/114538144-00f0c400-9c8e-11eb-9912-9c331c1d9434.png">
