### PR TITLE
Add fallback to fonts

### DIFF
--- a/src/themes/common.tsx
+++ b/src/themes/common.tsx
@@ -1,6 +1,6 @@
 export const fontFamily = {
-  ui: 'Monorale',
-  data: 'Lato'
+  ui: 'Monorale, Hiragino Sans, "ヒラギノ角ゴシック", Hiragino Kaku Gothic ProN, "ヒラギノ角ゴ ProN W3", Roboto, YuGothic, "游ゴシック", Meiryo, "メイリオ", sans-serif;',
+  data: 'Lato, Hiragino Sans, "ヒラギノ角ゴシック", Hiragino Kaku Gothic ProN, "ヒラギノ角ゴ ProN W3", Roboto, YuGothic, "游ゴシック", Meiryo, "メイリオ", sans-serif;'
 };
 
 export const dimensions = {


### PR DESCRIPTION
### Requirement
[Bugherd54](https://www.bugherd.com/projects/216308/tasks/54)

Better font-stack in theme [(See comments)
I don't think this has been a major issue at all but would be good to add the follow to the end of each font-family in theme/common fontFamily settings:

... Hiragino Sans, "ヒラギノ角ゴシック", Hiragino Kaku Gothic ProN, "ヒラギノ角ゴ ProN W3", Roboto, YuGothic, "游ゴシック", Meiryo, "メイリオ", sans-serif;


###Screenshoots
Miss added the mane of monorale to verify the fallback.
<img width="1027" alt="Screen Shot 2021-04-14 at 18 00 46" src="https://user-images.githubusercontent.com/10409078/114684643-1298a100-9d4c-11eb-91b4-f53cb44b5736.png">