### PR TITLE
Fix checkAll in table and disable hovers in check component

### DIFF
--- a/src/Form/atoms/Checkbox.tsx
+++ b/src/Form/atoms/Checkbox.tsx
@@ -69,6 +69,7 @@ const Container = styled.label<{visualState?: CheckboxState, disabled?: boolean}
     ${disabled && css`
       ${CheckboxOuter}{
         ${styles.form.checkbox.unchecked.disabled};
+        cursor: not-allowed;
       }
     `}
   `}
@@ -88,6 +89,7 @@ const Container = styled.label<{visualState?: CheckboxState, disabled?: boolean}
     ${disabled && css`
       ${CheckboxOuter}{
         ${styles.form.checkbox.checked.disabled};
+        cursor: not-allowed;
       }
     `}
   `}

--- a/src/Form/atoms/Checkbox.tsx
+++ b/src/Form/atoms/Checkbox.tsx
@@ -60,9 +60,11 @@ const Container = styled.label<{visualState?: CheckboxState, disabled?: boolean}
       ${styles.form.checkbox.unchecked.default};
     }
 
-    &:hover ${CheckboxOuter} {
-      ${styles.form.checkbox.unchecked.hover};
-    }
+    ${!disabled && css`
+      &:hover ${CheckboxOuter} {
+        ${styles.form.checkbox.unchecked.hover};
+      }`
+    };
 
     ${disabled && css`
       ${CheckboxOuter}{
@@ -76,11 +78,12 @@ const Container = styled.label<{visualState?: CheckboxState, disabled?: boolean}
       ${styles.form.checkbox.checked.default};
       border: none;
     }
-
-    &:hover ${CheckboxOuter}{
-      ${styles.form.checkbox.checked.hover};
-      border: none;
-    }
+    ${!disabled && css`
+      &:hover ${CheckboxOuter}{
+        ${styles.form.checkbox.checked.hover};
+        border: none;
+      }`
+    };
 
     ${disabled && css`
       ${CheckboxOuter}{
@@ -89,16 +92,15 @@ const Container = styled.label<{visualState?: CheckboxState, disabled?: boolean}
     `}
   `}
 
-  ${({visualState, theme: { styles }}) => visualState === CheckboxState.Indeterminate && css`
+  ${({visualState, disabled, theme: { styles }}) => visualState === CheckboxState.Indeterminate && css`
     ${CheckboxOuter}{
       ${styles.form.checkbox.indeterminate.default};
     }
-
-    &:hover ${CheckboxOuter}{
-      ${styles.form.checkbox.indeterminate.hover};
-    }
-
-
+    ${!disabled && css`
+      &:hover ${CheckboxOuter}{
+        ${styles.form.checkbox.indeterminate.hover};
+      }
+    `};
 
   `}
 

--- a/src/Tables/molecules/TypeTable.tsx
+++ b/src/Tables/molecules/TypeTable.tsx
@@ -131,9 +131,15 @@ const TypeTable: React.FC<IProps> = ({
   const [sortSpec, setSortSpec] = useState(columnConfig);
   const [ascendingState, setAscendingState] = useState(defaultAscending);
 
+  const isEmptyTable = (rows.length === 1) && (rows[0].columns.length === 0) && (!isLoading);
+
   useEffect(() => {
-    setAllChecked(rows.every(isChecked) && rows.length > 0);
-  }, [rows]);
+    let areAllChecked = false;
+    if(rows.every(isChecked) && (rows.length > 0) && !isEmptyTable) { 
+      areAllChecked = true;
+    }
+    setAllChecked(areAllChecked);
+  }, [isEmptyTable, rows]);
 
 
   const toggleSort = useCallback((indexKey: number, columnId?: string) => {
@@ -176,13 +182,12 @@ const TypeTable: React.FC<IProps> = ({
     If we allow columns to be optional, previous implementations
     wont be able to have "No data" Message
   */
-  const isEmptyTable = (rows.length === 1) && (rows[0].columns.length === 0) && (!isLoading);
 
   return (
     <Container>
       <TableContainer>
         <HeaderRow>
-          {selectable ? <HeaderItem fixedWidth={30}><Checkbox checked={allChecked} onChangeCallback={toggleAllCallbackWrapper} /></HeaderItem> : null}
+          {selectable ? <HeaderItem fixedWidth={30}><Checkbox checked={allChecked} disabled={isEmptyTable || isLoading} onChangeCallback={toggleAllCallbackWrapper} /></HeaderItem> : null}
           {hasStatus ? <HeaderItem fixedWidth={10} /> : null}
           {hasThumbnail ? <HeaderItem fixedWidth={70} /> : null}
           {hasTypeIcon ? <HeaderItem fixedWidth={35} /> : null}

--- a/src/themes/light/colors.js
+++ b/src/themes/light/colors.js
@@ -31,4 +31,4 @@ export const colors = {
         "good": "hsla(126, 48.1%, 68.2%, 1.000)",
         "neutral": "hsla(0, 0%, 91.8%, 1.000)"
     }
-}
+};

--- a/src/themes/light/styles.js
+++ b/src/themes/light/styles.js
@@ -256,7 +256,8 @@ export const styles = {
             "unchecked": {
                 "disabled": {
                     "backgroundColor": "hsla(0, 0%, 98.8%, 1.000)",
-                    "borderColor": "hsla(210, 20%, 90.2%, 1.000)"
+                    "borderColor": "hsla(210, 20%, 90.2%, 1.000)",
+                    "cursor": "not-allowed",
                 },
                 "default": {
                     "borderColor": "hsla(208, 24.6%, 77.6%, 1.000)"
@@ -268,7 +269,8 @@ export const styles = {
             "checked": {
                 "disabled": {
                     "boxShadow": "inset 0px 1px 5px 0px hsla(205, 50.3%, 30%, 0.051)",
-                    "backgroundColor": "hsla(210, 20%, 90.2%, 1.000)"
+                    "backgroundColor": "hsla(210, 20%, 90.2%, 1.000)",
+                    "cursor": "not-allowed",
                 },
                 "default": {
                     "boxShadow": "inset 0px 1px 5px 0px hsla(205, 50.3%, 30%, 0.051)",
@@ -388,4 +390,4 @@ export const styles = {
             "backgroundColor": "hsla(30, 91%, 61%, 1.000)"
         }
     }
-}
+};

--- a/src/themes/light/styles.js
+++ b/src/themes/light/styles.js
@@ -257,7 +257,6 @@ export const styles = {
                 "disabled": {
                     "backgroundColor": "hsla(0, 0%, 98.8%, 1.000)",
                     "borderColor": "hsla(210, 20%, 90.2%, 1.000)",
-                    "cursor": "not-allowed",
                 },
                 "default": {
                     "borderColor": "hsla(208, 24.6%, 77.6%, 1.000)"
@@ -270,7 +269,6 @@ export const styles = {
                 "disabled": {
                     "boxShadow": "inset 0px 1px 5px 0px hsla(205, 50.3%, 30%, 0.051)",
                     "backgroundColor": "hsla(210, 20%, 90.2%, 1.000)",
-                    "cursor": "not-allowed",
                 },
                 "default": {
                     "boxShadow": "inset 0px 1px 5px 0px hsla(205, 50.3%, 30%, 0.051)",

--- a/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
+++ b/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
@@ -108,6 +108,8 @@ export const _LoadingTable = () => {
   const emptyTableText = text("emptyTableText", 'There is currently no data');
   const loadingText = text("loadingText", 'Loading Data..')
   const columnConfig = object("Column Configuration", columnConfigSample);
+  const selectable = boolean("Selectable Rows", true);
+  
   const [rows, setRows] = useState<ITypeTableData>(initialRows);
 
   const toggleAllCallback = useCallback((checked:boolean) => {
@@ -115,10 +117,20 @@ export const _LoadingTable = () => {
 
     newRows.forEach((row) => {
       row._checked = checked;
-    });
+  });
 
     setRows(newRows);
   }, [rows, setRows]);
+
+    // Sent to checkbox in TableRow via Table component.
+    const selectCallback = useCallback((checked:boolean, id?: string | number) => {
+      const newRows = [...rows];
+      const targetRowIndex = newRows.findIndex(row => row.id === id)
+      newRows[targetRowIndex]._checked = checked;
+  
+      setRows(newRows);
+  
+    }, [rows, setRows]);
 
   useEffect(() => {
     if(emptyTable) {
@@ -138,6 +150,8 @@ export const _LoadingTable = () => {
           columnConfig,
           rows,
           toggleAllCallback,
+          selectable,
+          selectCallback,
           isLoading,
           loadingText,
           hasThumbnail: true,


### PR DESCRIPTION
### Requirements
[Burherd#24](https://www.bugherd.com/projects/216308/tasks/24)

Bug: If a table has Select All but no entries then it is marked as checked. It should be uncheck and disabled or maybe just hidden.

### Implementation
I made the review of this on the Loading table of storybook.
Realized that checkbox had hover styling when disabled and modified a little the theme.
I felt a dejavu about it and I'm not sure if @atomworks  told me not to change that before hehehe..

Please review that the disabled check is working as designed.

### Screenshot

#### Before Fix Screenshots


AllChecked and enabled with empty loading
<img width="757" alt="Screen Shot 2021-05-11 at 16 22 10" src="https://user-images.githubusercontent.com/10409078/117790148-08eb5600-b284-11eb-801f-c8f234e8c165.png">

AllChecked and enabled when  background data loading
<img width="771" alt="Screen Shot 2021-05-11 at 16 22 18" src="https://user-images.githubusercontent.com/10409078/117790303-2ddfc900-b284-11eb-9748-d4b4bd5ab4b8.png">
#### After Fix Screenshots

Empty AllCheckbox unchecked and disabled with loading
<img width="820" alt="Screen Shot 2021-05-11 at 17 58 58" src="https://user-images.githubusercontent.com/10409078/117791239-0d643e80-b285-11eb-97c0-8da3fb149000.png">

Data loading AllCheckbox checked disabled
<img width="798" alt="Screen Shot 2021-05-11 at 17 58 45" src="https://user-images.githubusercontent.com/10409078/117791366-34bb0b80-b285-11eb-9600-c24ae7ed030a.png">

Data loading Some checked, AllCheckbox not check disabled
<img width="765" alt="Screen Shot 2021-05-11 at 18 18 28" src="https://user-images.githubusercontent.com/10409078/117791435-4a303580-b285-11eb-86a7-c09471bf7207.png">


