### PR TITLE
Add example with mixed values for duration slider

### DIFF
--- a/src/Form/molecules/DurationSlider.tsx
+++ b/src/Form/molecules/DurationSlider.tsx
@@ -30,6 +30,7 @@ const ValueTitle = styled(Label)`
 interface IDurationSliderProps {
   title: string
   timeUnit: ITimeUnit
+  controlledValue?: number
 }
 
 type IDurationSlider = IDurationSliderProps & ISlider;
@@ -41,6 +42,7 @@ const DurationSlider: React.FC<IDurationSlider> = (
     defaultValue=0,
     title='',
     timeUnit,
+    controlledValue,
     inputCallback,
     ...props
   }
@@ -55,11 +57,13 @@ const DurationSlider: React.FC<IDurationSlider> = (
     setSelectedValue(value);
   },[inputCallback]);
 
+  const labelValue = controlledValue ? controlledValue : selectedValue;
+
   return(
     <Container>
       <Headers>
         <Label htmlFor='duration-slider' labelText={title} />
-        <ValueTitle htmlFor='duration-slider' labelText={getTextTimeUnit(selectedValue, timeUnit)} />
+        <ValueTitle htmlFor='duration-slider' labelText={getTextTimeUnit(labelValue, timeUnit)} />
       </Headers>
       <SliderInput
         {

--- a/storybook/src/stories/Form/DurationSlider.stories.tsx
+++ b/storybook/src/stories/Form/DurationSlider.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 // import { action } from '@storybook/addon-actions';
 import { boolean, number, object, text, select } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
-import {DurationSlider, ISliderMark} from 'scorer-ui-kit';
+import { DurationSlider, ISliderMark, PageHeader, ITimeUnit } from 'scorer-ui-kit';
 
 
 export default {
@@ -13,11 +13,15 @@ export default {
 };
 
 const Container = styled.div`
-    margin: 20px;
-    width: 268px;
+  display: flex;
 `;
 
-const exampleMarks : ISliderMark[] = [
+const Wrapper = styled.div`
+  margin: 20px;
+  width: 280px;
+`;
+
+const exampleMarks: ISliderMark[] = [
   {
     value: 1,
     label: '1H',
@@ -36,25 +40,101 @@ const exampleMarks : ISliderMark[] = [
   },
   {
     value: 5,
-    label:'5H',
+    label: '5H',
   },
   {
     value: 6,
-    label:'6H',
+    label: '6H',
   },
   {
     value: 7,
-    label:'7H',
+    label: '7H',
   },
   {
     value: 8,
-    label:'8H',
+    label: '8H',
   },
 ];
-  
+
+const exampleMarks2: ISliderMark[] = [
+  {
+    value: 3,
+    label: '3s',
+  },
+  {
+    value: 360,
+    label: '',
+  },
+  {
+    value: 720,
+    label: '',
+  },
+  {
+    value: 1080,
+    label: '',
+  },
+  {
+    value: 1440,
+    label: '',
+  },
+  {
+    value: 1800,
+    label: '',
+  },
+  {
+    value: 2160,
+    label: '',
+  },
+  {
+    value: 2520,
+    label: '',
+  },
+  {
+    value: 2880,
+    label: '',
+  },
+  {
+    value: 3240,
+    label: '',
+  },
+  {
+    value: 3600,
+    label: '1h',
+  },
+];
+const defaultMixValue = 1800;
+
+interface ITimeValue {
+  time: number
+  unit: ITimeUnit
+}
+
+const secToMinAndHours = (seconds: number): ITimeValue => {
+
+  if (seconds >= 3600) {
+    return {
+      time: Math.round(seconds / 3600),
+      unit: 'hours'
+    }
+  }
+
+  if (seconds >= 60) {
+    return {
+      time: Math.round(seconds / 60),
+      unit: 'minutes'
+    }
+  }
+
+  return {
+    time: seconds,
+    unit: 'seconds'
+  }
+}
+
 export const _DurationSlider = () => {
+
   const title = text('Title', 'Duration');
-  const durationUnit= select("Time Unit", { Seconds: 'seconds', Minutes: 'minutes', Hours: 'hours' }, 'hours');
+  const durationUnit = select("Time Unit", { Seconds: 'seconds', Minutes: 'minutes', Hours: 'hours' }, 'hours');
   const disabled = boolean('Disabled', false);
   const maxValue = number('Max', 8);
   const minValue = number('Min', 1);
@@ -68,9 +148,34 @@ export const _DurationSlider = () => {
     showValue(`Returned value: ${value}`, value)
   };
 
+  const [value2, setValue2] = useState<ITimeValue>({time: 30, unit: 'minutes'});
+
+  const title2 = text('Title 2', 'Time');
+  const disabled2 = boolean('Disabled 2', false);
+  const maxValue2 = number('Max 2', 3600);
+  const minValue2 = number('Min 2', 3);
+  const defaultValue2 = number('Default value 2', defaultMixValue)
+
+  const showValue2 = action('Input Callback');
+  const marks2 = object('Marks 2', exampleMarks2);
+  // const step = number('Step', 1); // still fixing step option
+  const handleUpdate2 = (value: number) => {
+    console.log('updated value', value);
+    showValue2(`Returned value: ${value}`, value)
+    const newValue = secToMinAndHours(value)
+    console.log('new time converted');
+    setValue2(newValue);
+    
+  };
+
   return (
     <Container>
-      <DurationSlider
+      <Wrapper>
+        <PageHeader
+          title='Simple example'
+          introductionText='Values are controlled by component'
+        />
+        <DurationSlider
           max={maxValue}
           min={minValue}
           disabled={disabled}
@@ -81,6 +186,25 @@ export const _DurationSlider = () => {
           title={title}
           timeUnit={durationUnit}
         />
+      </Wrapper>
+      <Wrapper>
+        <PageHeader
+          title='Mixed values example'
+          introductionText='Values are controlled from outside'
+        />
+        <DurationSlider
+          max={maxValue2}
+          min={minValue2}
+          disabled={disabled2}
+          // step={step}
+          inputCallback={handleUpdate2}
+          marks={marks2}
+          defaultValue={defaultValue2}
+          controlledValue={value2.time}
+          title={title2}
+          timeUnit={value2.unit}
+        />
+      </Wrapper>
     </Container>
   )
 }


### PR DESCRIPTION
### Requirements

Update the duration slider UI kit component to allow a mix of units

### Implementation

Previous implementation allowed to have custom marks and the slider does not take account of the unit but to update the top right label. I have updated to allow the user to control this tag and value. The rest of the component stays the same.

### Screenshots

<img width="687" alt="Screen Shot 2021-06-14 at 21 41 07" src="https://user-images.githubusercontent.com/10409078/121893689-3df23900-cd59-11eb-8b5b-a560a8c5e755.png">