### PR TITLE
Missing Danger color on icons storybook

### DIFF
--- a/storybook/src/stories/Misc/Icons.stories.tsx
+++ b/storybook/src/stories/Misc/Icons.stories.tsx
@@ -49,14 +49,14 @@ export const _Icons = () => {
 
   const showAll = boolean("Show All", false);
   const iconName = select("Name", iconList, Object.keys(iconList)[0]);
-  const iconColor = select("Color", { Mono: "mono", Dimmed: "dimmed", Subtle: "subtle", Inverse: "inverse", Primary: "primary" }, "mono");
+  const iconColor = select("Color", { Mono: "mono", Dimmed: "dimmed", Subtle: "subtle", Inverse: "inverse", Primary: "primary" , Danger: "danger"}, "mono");
   const iconWeight = select("Weight", { Light: "light", Regular: "regular", Heavy: "heavy" }, "regular");
   const iconSize = number("Size", 24);
 
   /**
    * Generate a grid of all the icons for easy browsing and hovering to find names.
    */
-  const generateIconGrid = (props: { color: "mono" | "dimmed" | "subtle" | "inverse" | "primary"; weight: "regular" | "light" | "heavy"; size: number; }) => {
+  const generateIconGrid = (props: { color: "mono" | "dimmed" | "subtle" | "inverse" | "primary" | "danger" ; weight: "regular" | "light" | "heavy"; size: number; }) => {
     return Object.keys(IconSVGs).map((iconName) => (
       <div title={iconName} key={iconName}>
         <Icon icon={iconName} {...props} ></Icon>


### PR DESCRIPTION
### Requirements

 The Danger option was not available in the icons of storybook.
 The specifics can be reviewed on issue #104 
 
### Screenshoots
<img width="1006" alt="Screen Shot 2021-07-05 at 20 00 40" src="https://user-images.githubusercontent.com/10409078/124461497-ad44d100-ddcb-11eb-953d-fb35270ac58d.png">
