### PR TITLE
CustomDrawer in TopBar

### DIFF
--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -49,6 +49,14 @@ export interface IMenuTop {
     defaultMenuOpen?: boolean
   }
 
+  export interface ICustomDrawer {
+    customComponent: ReactElement
+    icon: string
+    status?: string
+    counter?: number
+    width?: string
+  }
+
   export interface ITopBar {
     hasNotifications?: boolean;
     userSubmenu?: any[];
@@ -61,6 +69,7 @@ export interface IMenuTop {
     searchPlaceholder?: string;
     userDrawerBespoke?: ReactElement;
     notificationsHistory? : INotificationsHistory;
+    customDrawer?: ICustomDrawer;
     onLogout?: ()=>void;
     onLanguageToggle?: ()=>void;
   }

--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -3,6 +3,7 @@ import {Content, Layout, MainContainer} from './atoms/Layout';
 import MainMenu from './organisms/MainMenu';
 import TopBar from './molecules/TopBar';
 import GlobalUI from './templates/GlobalUI';
+import { IStatusDot } from '..';
 
 export {
   SidebarBox,
@@ -15,12 +16,12 @@ export {
 } from './molecules/Sidebar';
 
 export {
-    Content,
-    Layout,
-    MainMenu,
-    TopBar,
-    MainContainer,
-    GlobalUI,
+  Content,
+  Layout,
+  MainMenu,
+  TopBar,
+  MainContainer,
+  GlobalUI
 };
 
 export interface IMenuTop {
@@ -52,7 +53,7 @@ export interface IMenuTop {
   export interface ICustomDrawer {
     customComponent: ReactElement
     icon: string
-    status?: string
+    status?: IStatusDot
     counter?: number
     width?: string
   }

--- a/src/Global/molecules/NotificationsHistory.tsx
+++ b/src/Global/molecules/NotificationsHistory.tsx
@@ -34,9 +34,9 @@ const renderNotifications = (items: INotificationItem[], type: string) => (
 const NotificationsHistory: React.FC<INotificationsHistory> = ({
   read,
   unread,
-  noNotificationsText = 'NO NEW NOTIFICATIONS',
-  readNotificationsText = 'NEW',
-  unreadNotificationsText = 'READ',
+  noNotificationsText = 'No new notifications',
+  readNotificationsText = 'New',
+  unreadNotificationsText = 'Read',
 
 }) => {
 

--- a/src/Global/molecules/TopBar.tsx
+++ b/src/Global/molecules/TopBar.tsx
@@ -132,7 +132,7 @@ const NotificationsContainer = styled.div`
     margin-right: -17px;
 `;
 
-type IDrawerKeys = 'user' | 'notifications' | 'custom' | undefined;
+type IDrawerKeys = 'user' | 'notifications' | 'custom' | null;
 
 
 const TopBar: React.FC<ITopBar> = ({
@@ -152,14 +152,14 @@ const TopBar: React.FC<ITopBar> = ({
   onLanguageToggle = () => { }
 }) => {
 
-  const [openDrawer, setOpenDrawer] = useState<IDrawerKeys>(undefined);
+  const [openDrawer, setOpenDrawer] = useState<IDrawerKeys>(null);
 
   const toggleDrawers = (drawerKey: IDrawerKeys) => {
     setOpenDrawer(
       prevDrawer => {
-        // if prevDrawer is open, just update to undefined to close
+        // if prevDrawer is open, just update to null to close
         if (prevDrawer === drawerKey) {
-          return undefined;
+          return null;
         }
 
         return drawerKey;

--- a/src/Global/molecules/TopBar.tsx
+++ b/src/Global/molecules/TopBar.tsx
@@ -2,10 +2,10 @@ import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import Icon from '../../Icons/Icon';
+import StatusIcon from '../../Icons/StatusIcon';
 import UserMenu from '../molecules/UserMenu';
 import { ITopBar } from '../index';
 import NotificationsHistory from './NotificationsHistory';
-import { IStatusDot } from '../..';
 
 const Container = styled.div`
   z-index: 9;
@@ -132,37 +132,6 @@ const NotificationsContainer = styled.div`
     margin-right: -17px;
 `;
 
-const IconStatusWrapper = styled.div`
-  position: relative;
-`;
-
-const StatusCounter = styled.div<{color?: IStatusDot}>`
-  background-color: ${({theme, color}) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 1.000)'};
-  position: absolute;
-  right: 7px;
-  top: -12px;
-  border-radius: 50%;
-  height: 14px;
-  width: 14px;
-  font-size: 10px;
-  color: white;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-const StatusDot = styled.div<{color?: IStatusDot}>`
-  background-color: ${({theme, color}) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 1.000)'};
-  width: 10px;
-  height: 10px;
-  border: solid 2px hsl(0, 0%, 100%);
-  border-radius: 50%;
-  position: absolute;
-  top: -6px;
-  right: 7px;
-`;
-
-
 type IDrawerKeys = 'user' | 'notifications' | 'custom' | '';
 
 
@@ -211,11 +180,7 @@ const TopBar: React.FC<ITopBar> = ({
       <ButtonArea>
         {customDrawer && (
           <DrawerToggle isActive={openDrawer === 'custom'} onClick={() => toggleDrawers('custom')}>
-            <IconStatusWrapper>
-              {customDrawer.status && (customDrawer.counter === undefined)  && <StatusDot color={customDrawer.status} />}
-              {(customDrawer.counter !== undefined) && <StatusCounter color={customDrawer.status}>{customDrawer.counter}</StatusCounter>}
-              <Icon icon={customDrawer.icon} size={customDrawer.status && (customDrawer.counter === undefined) ? 14 : 18} color='dimmed' />
-            </IconStatusWrapper>
+            <StatusIcon {...customDrawer} />
           </DrawerToggle>
         )}
         {hasNotifications && (

--- a/src/Global/molecules/TopBar.tsx
+++ b/src/Global/molecules/TopBar.tsx
@@ -7,7 +7,7 @@ import { ITopBar } from '../index';
 import NotificationsHistory from './NotificationsHistory';
 
 const Container = styled.div`
-  z-index: 9; 
+  z-index: 9;
   position: sticky;
   top: 0;
   align-self: flex-start;
@@ -100,7 +100,7 @@ const Drawer = styled.div<{ isOpen: boolean, baseWidth?: string }>`
   bottom: 0;
   background: ${({ theme }) => theme.styles.global.mainMenu.background};
   border-left: ${({ theme: { colors } }) => colors.divider} 1px solid;
-  width: ${({baseWidth}) => baseWidth ? baseWidth : `200px`};
+  width: ${({ baseWidth }) => baseWidth ? baseWidth : `200px`};
   opacity: 0;
   visibility: hidden;
   z-index: 100;
@@ -130,6 +130,8 @@ const NotificationsContainer = styled.div`
     margin-right: -17px;
 `;
 
+type IDrawerKeys = 'user' | 'notifications' | 'custom' | '';
+
 const TopBar: React.FC<ITopBar> = ({
   hasNotifications = false,
   hasLanguage = false,
@@ -142,12 +144,25 @@ const TopBar: React.FC<ITopBar> = ({
   userDrawerBespoke,
   loggedInUser,
   notificationsHistory,
+  customDrawer,
   onLogout = () => { },
   onLanguageToggle = () => { }
 }) => {
 
-  const [isUserMenuOpen, setUserMenuOpen] = useState<boolean>(false);
-  const [isNotificationsOpen, setNotificationsOpen] = useState<boolean>(false);
+  const [openDrawer, setOpenDrawer] = useState<IDrawerKeys>('');
+
+  const toggleDrawers = (drawerKey: IDrawerKeys) => {
+    setOpenDrawer(
+      prevDrawer => {
+        // if prevDrawer is open, just close
+        if (prevDrawer === drawerKey) {
+          return '';
+        }
+
+        return drawerKey;
+      }
+    );
+  };
 
   return (
     <Container>
@@ -160,12 +175,13 @@ const TopBar: React.FC<ITopBar> = ({
         </SearchBar> : <div />}
 
       <ButtonArea>
-        {hasNotifications ? <DrawerToggle isActive={isNotificationsOpen} onClick={() => { setNotificationsOpen(!isNotificationsOpen); setUserMenuOpen(false); }}><Icon icon='Notifications' size={18} color='dimmed' /></DrawerToggle> : null}
-        <DrawerToggle isActive={isUserMenuOpen} onClick={() => { setUserMenuOpen(!isUserMenuOpen); setNotificationsOpen(false); }}><Icon icon='UserProfile' size={18} color='dimmed' /></DrawerToggle>
+        {customDrawer ? <DrawerToggle isActive={openDrawer==='custom'} onClick={() => toggleDrawers('custom')}><Icon icon={customDrawer.icon} size={18} color='dimmed' /></DrawerToggle> : null}
+        {hasNotifications ? <DrawerToggle isActive={openDrawer==='notifications'} onClick={() => toggleDrawers('notifications')}><Icon icon='Notifications' size={18} color='dimmed' /></DrawerToggle> : null}
+        <DrawerToggle isActive={openDrawer==='user'} onClick={() => toggleDrawers('user')}><Icon icon='UserProfile' size={18} color='dimmed' /></DrawerToggle>
       </ButtonArea>
 
       {/* User Menu */}
-      <Drawer isOpen={isUserMenuOpen}>
+      <Drawer isOpen={openDrawer==='user'}>
         <UserMenu {...{
           hasLanguage,
           hasLogout,
@@ -182,11 +198,17 @@ const TopBar: React.FC<ITopBar> = ({
 
       {/* Notifications */}
       {hasNotifications ?
-        <Drawer isOpen={isNotificationsOpen} baseWidth='300px'>
+        <Drawer isOpen={openDrawer==='notifications'} baseWidth='300px'>
           <NotificationsContainer>
             {notificationsHistory ? <NotificationsHistory {...notificationsHistory} /> : null}
           </NotificationsContainer>
         </Drawer> : null}
+
+      {customDrawer && (
+        <Drawer isOpen={openDrawer==='custom'} baseWidth={customDrawer.width ? customDrawer.width : "200px"}>
+          {customDrawer.customComponent}
+        </Drawer>
+      )}
     </Container>
   );
 

--- a/src/Global/molecules/TopBar.tsx
+++ b/src/Global/molecules/TopBar.tsx
@@ -5,6 +5,7 @@ import Icon from '../../Icons/Icon';
 import UserMenu from '../molecules/UserMenu';
 import { ITopBar } from '../index';
 import NotificationsHistory from './NotificationsHistory';
+import { IStatusDot } from '../..';
 
 const Container = styled.div`
   z-index: 9;
@@ -63,6 +64,7 @@ const SearchInput = styled.input`
 const ButtonArea = styled.div`
   height: inherit;
   padding-right: 10px;
+  display: flex;
 `;
 
 const DrawerToggle = styled.button.attrs({ type: 'button' }) <{ isActive: boolean }>`
@@ -130,7 +132,39 @@ const NotificationsContainer = styled.div`
     margin-right: -17px;
 `;
 
+const IconStatusWrapper = styled.div`
+  position: relative;
+`;
+
+const StatusCounter = styled.div<{color?: IStatusDot}>`
+  background-color: ${({theme, color}) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 1.000)'};
+  position: absolute;
+  right: 7px;
+  top: -12px;
+  border-radius: 50%;
+  height: 14px;
+  width: 14px;
+  font-size: 10px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StatusDot = styled.div<{color?: IStatusDot}>`
+  background-color: ${({theme, color}) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 1.000)'};
+  width: 10px;
+  height: 10px;
+  border: solid 2px hsl(0, 0%, 100%);
+  border-radius: 50%;
+  position: absolute;
+  top: -6px;
+  right: 7px;
+`;
+
+
 type IDrawerKeys = 'user' | 'notifications' | 'custom' | '';
+
 
 const TopBar: React.FC<ITopBar> = ({
   hasNotifications = false,
@@ -175,13 +209,27 @@ const TopBar: React.FC<ITopBar> = ({
         </SearchBar> : <div />}
 
       <ButtonArea>
-        {customDrawer ? <DrawerToggle isActive={openDrawer==='custom'} onClick={() => toggleDrawers('custom')}><Icon icon={customDrawer.icon} size={18} color='dimmed' /></DrawerToggle> : null}
-        {hasNotifications ? <DrawerToggle isActive={openDrawer==='notifications'} onClick={() => toggleDrawers('notifications')}><Icon icon='Notifications' size={18} color='dimmed' /></DrawerToggle> : null}
-        <DrawerToggle isActive={openDrawer==='user'} onClick={() => toggleDrawers('user')}><Icon icon='UserProfile' size={18} color='dimmed' /></DrawerToggle>
+        {customDrawer && (
+          <DrawerToggle isActive={openDrawer === 'custom'} onClick={() => toggleDrawers('custom')}>
+            <IconStatusWrapper>
+              {customDrawer.status && (customDrawer.counter === undefined)  && <StatusDot color={customDrawer.status} />}
+              {(customDrawer.counter !== undefined) && <StatusCounter color={customDrawer.status}>{customDrawer.counter}</StatusCounter>}
+              <Icon icon={customDrawer.icon} size={customDrawer.status && (customDrawer.counter === undefined) ? 14 : 18} color='dimmed' />
+            </IconStatusWrapper>
+          </DrawerToggle>
+        )}
+        {hasNotifications && (
+          <DrawerToggle isActive={openDrawer === 'notifications'} onClick={() => toggleDrawers('notifications')}>
+            <Icon icon='Notifications' size={18} color='dimmed' />
+          </DrawerToggle>
+        )}
+        <DrawerToggle isActive={openDrawer === 'user'} onClick={() => toggleDrawers('user')}>
+          <Icon icon='UserProfile' size={18} color='dimmed' />
+        </DrawerToggle>
       </ButtonArea>
 
       {/* User Menu */}
-      <Drawer isOpen={openDrawer==='user'}>
+      <Drawer isOpen={openDrawer === 'user'}>
         <UserMenu {...{
           hasLanguage,
           hasLogout,
@@ -198,14 +246,14 @@ const TopBar: React.FC<ITopBar> = ({
 
       {/* Notifications */}
       {hasNotifications ?
-        <Drawer isOpen={openDrawer==='notifications'} baseWidth='300px'>
+        <Drawer isOpen={openDrawer === 'notifications'} baseWidth='300px'>
           <NotificationsContainer>
             {notificationsHistory ? <NotificationsHistory {...notificationsHistory} /> : null}
           </NotificationsContainer>
         </Drawer> : null}
 
       {customDrawer && (
-        <Drawer isOpen={openDrawer==='custom'} baseWidth={customDrawer.width ? customDrawer.width : "200px"}>
+        <Drawer isOpen={openDrawer === 'custom'} baseWidth={customDrawer.width ? customDrawer.width : "200px"}>
           {customDrawer.customComponent}
         </Drawer>
       )}

--- a/src/Global/molecules/TopBar.tsx
+++ b/src/Global/molecules/TopBar.tsx
@@ -132,7 +132,7 @@ const NotificationsContainer = styled.div`
     margin-right: -17px;
 `;
 
-type IDrawerKeys = 'user' | 'notifications' | 'custom' | '';
+type IDrawerKeys = 'user' | 'notifications' | 'custom' | undefined;
 
 
 const TopBar: React.FC<ITopBar> = ({
@@ -152,14 +152,14 @@ const TopBar: React.FC<ITopBar> = ({
   onLanguageToggle = () => { }
 }) => {
 
-  const [openDrawer, setOpenDrawer] = useState<IDrawerKeys>('');
+  const [openDrawer, setOpenDrawer] = useState<IDrawerKeys>(undefined);
 
   const toggleDrawers = (drawerKey: IDrawerKeys) => {
     setOpenDrawer(
       prevDrawer => {
-        // if prevDrawer is open, just close
+        // if prevDrawer is open, just update to undefined to close
         if (prevDrawer === drawerKey) {
-          return '';
+          return undefined;
         }
 
         return drawerKey;

--- a/src/Global/organisms/MobileNavbar.tsx
+++ b/src/Global/organisms/MobileNavbar.tsx
@@ -11,6 +11,12 @@ import MobileUserMenu from '../molecules/MobileUserMenu';
 import NotificationsHistory from '../molecules/NotificationsHistory';
 import { MOBILE_NAVBAR_HEIGHT } from '../atoms/Layout';
 
+const CLOSE_ID = 'closeMenu';
+const NOTI_TAB = 'notifications';
+const USER_TAB= 'user';
+const MENU_TAB = 'menu';
+const CUSTOM_TAB = 'custom';
+
 const Container = styled.nav`
   background-color: ${({theme}) => theme.styles.global.mainMenu.background.backgroundColor};
   position: sticky;
@@ -55,6 +61,7 @@ const MobileNavbar: React.FC<IMobileNavbar> = ({
   userDrawerBespoke,
   loggedInUser,
   notificationsHistory,
+  customDrawer,
   onLogout,
   onLanguageToggle,
 }) => {
@@ -63,18 +70,22 @@ const MobileNavbar: React.FC<IMobileNavbar> = ({
     <Container>
       <Tabs>
         <HeaderContainer>
-          <MobileLogoLink {...{ home, logoMark }} closeId='closeMenu' />
-          <TabList defaultTabId='closeMenu'>
-            {hasNotifications? <MobileTab tabFor='notifications' icon='Notifications' closeId='closeMenu' /> : null}
-            <MobileTab tabFor='user' icon='UserProfile' closeId='closeMenu' />
-            <MobileTab tabFor='menu' icon='Menu' closeId='closeMenu' />
+          <MobileLogoLink {...{ home, logoMark }} closeId={CLOSE_ID} />
+          <TabList defaultTabId={CLOSE_ID}>
+            {customDrawer && <MobileTab {...customDrawer} tabFor={CUSTOM_TAB} closeId={CLOSE_ID} />}
+            {hasNotifications? <MobileTab tabFor={NOTI_TAB} icon='Notifications' closeId={CLOSE_ID} /> : null}
+            <MobileTab tabFor={USER_TAB} icon='UserProfile' closeId={CLOSE_ID} />
+            <MobileTab tabFor={MENU_TAB} icon='Menu' closeId={CLOSE_ID} />
           </TabList>
         </HeaderContainer>
-        <MobileNavbarContainer closeId='closeMenu'>
-          <TabContent tabId='notifications'>
+        <MobileNavbarContainer closeId={CLOSE_ID}>
+          <TabContent tabId={CUSTOM_TAB}>
+            {customDrawer && customDrawer.customComponent}
+          </TabContent>
+          <TabContent tabId={NOTI_TAB}>
             {notificationsHistory && hasNotifications ? <NotificationsHistory {...notificationsHistory} /> : null}
           </TabContent>
-          <TabContent tabId='user'>
+          <TabContent tabId={USER_TAB}>
             <MobileUserMenu
               {...{
               hasLanguage,
@@ -87,14 +98,14 @@ const MobileNavbar: React.FC<IMobileNavbar> = ({
               onLogout,
               onLanguageToggle
             }}
-              closeId='closeMenu'
+              closeId={CLOSE_ID}
             />
 
           </TabContent>
-          <TabContent tabId='menu'>
-            <MobileMenu {...{ content, supportUrl, defaultMenuOpen }} closeId='closeMenu' />
+          <TabContent tabId={MENU_TAB}>
+            <MobileMenu {...{ content, supportUrl, defaultMenuOpen }} closeId={CLOSE_ID} />
           </TabContent>
-          <CloseButton {...{ closeText }} closeId='closeMenu' />
+          <CloseButton {...{ closeText }} closeId={CLOSE_ID} />
         </MobileNavbarContainer>
       </Tabs>
     </Container>

--- a/src/Global/templates/GlobalUI.tsx
+++ b/src/Global/templates/GlobalUI.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IMenu, ITopBar, INotificationsHistory } from '..';
+import { IMenu, ITopBar} from '..';
 import { Layout, MainContainer, ContentArea, MobileLayout } from '../atoms/Layout';
 import MainMenu from '../organisms/MainMenu';
 import TopBar from '../molecules/TopBar';
@@ -9,8 +9,7 @@ import useBreakpoints from '../../hooks/useBreakpoints';
 
 interface OwnProps {
   maxWidth?: string,
-  paddingOverride?: string,
-  notificationsHistory?: INotificationsHistory
+  paddingOverride?: string
 }
 
 type INavigation = OwnProps & IMenu & ITopBar;
@@ -26,7 +25,6 @@ const GlobalUI: React.FC<INavigation> = ({
   paddingOverride,
   maxWidth,
   children,
-  notificationsHistory,
   ...props
 }) => {
 
@@ -48,7 +46,7 @@ const GlobalUI: React.FC<INavigation> = ({
         />
         <MainContainer>
           <TopBar
-            {...{...props, notificationsHistory}}
+            {...{...props}}
           />
           <ContentArea {...{maxWidth, paddingOverride}}>
             {children}
@@ -65,7 +63,6 @@ const GlobalUI: React.FC<INavigation> = ({
             logoMark,
             supportUrl,
             defaultMenuOpen,
-            notificationsHistory,
             ...props
             }
           }

--- a/src/Icons/StatusIcon.tsx
+++ b/src/Icons/StatusIcon.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import styled from 'styled-components';
+import Icon from './Icon';
+import { IStatusDot } from '..';
+
+const Container = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+const StatusCounter = styled.div<{ color?: IStatusDot }>`
+  background-color: ${({ theme, color }) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 1.000)'};
+  position: absolute;
+  left: 14px;;
+  top: -12px;
+  border-radius: 50%;
+  height: 14px;
+  min-width: 14px;
+  padding: 2px;
+  font-size: 10px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StatusDot = styled.div<{ color?: IStatusDot }>`
+  background-color: ${({ theme, color }) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 1.000)'};
+  width: 10px;
+  height: 10px;
+  border: solid 2px hsl(0, 0%, 100%);
+  border-radius: 50%;
+  position: absolute;
+  top: -6px;
+  right: -9px;
+`;
+
+interface IStatusIcon {
+  icon: string
+  status?: IStatusDot
+  counter?: number
+}
+
+const StatusIcon: React.FC<IStatusIcon> = ({icon, status, counter}) => {
+  return (
+    <Container>
+      {status && (counter === undefined) && <StatusDot color={status} />}
+      {(counter !== undefined) && <StatusCounter color={status}>{counter}</StatusCounter>}
+      <Icon icon={icon} size={status && (counter === undefined) ? 14 : 18} color='dimmed' />
+    </Container>
+  );
+};
+
+export default StatusIcon;

--- a/src/Icons/StatusIcon.tsx
+++ b/src/Icons/StatusIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 import Icon from './Icon';
 import { IStatusDot } from '..';
 
@@ -9,7 +9,6 @@ const Container = styled.div`
 `;
 
 const StatusCounter = styled.div<{ color?: IStatusDot }>`
-  background-color: ${({ theme, color }) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 1.000)'};
   position: absolute;
   left: 14px;;
   top: -12px;
@@ -22,10 +21,13 @@ const StatusCounter = styled.div<{ color?: IStatusDot }>`
   display: flex;
   align-items: center;
   justify-content: center;
+  ${({theme:{animation}}) => css`
+    transition: background-color ${animation.speed.slow} ${animation.easing.primary.easeInOut};
+  `}
+  background-color: ${({ theme, color }) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 0)'};
 `;
 
 const StatusDot = styled.div<{ color?: IStatusDot }>`
-  background-color: ${({ theme, color }) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 1.000)'};
   width: 10px;
   height: 10px;
   border: solid 2px hsl(0, 0%, 100%);
@@ -33,6 +35,10 @@ const StatusDot = styled.div<{ color?: IStatusDot }>`
   position: absolute;
   top: -6px;
   right: -9px;
+  ${({theme:{animation}}) => css`
+    transition: background-color ${animation.speed.slow} ${animation.easing.primary.easeInOut};
+  `}
+  background-color: ${({ theme, color }) => color ? theme.colors.status[color] : 'hsla(0, 0%, 91.8%, 0)'};
 `;
 
 interface IStatusIcon {
@@ -44,8 +50,9 @@ interface IStatusIcon {
 const StatusIcon: React.FC<IStatusIcon> = ({icon, status, counter}) => {
   return (
     <Container>
-      {status && (counter === undefined) && <StatusDot color={status} />}
-      {(counter !== undefined) && <StatusCounter color={status}>{counter}</StatusCounter>}
+      {status && (counter === undefined)
+        ? <StatusDot color={status} />
+        :  (counter === undefined) ? null : <StatusCounter color={status}>{counter}</StatusCounter>}
       <Icon icon={icon} size={status && (counter === undefined) ? 14 : 18} color='dimmed' />
     </Container>
   );

--- a/src/Tabs/MobileTab.tsx
+++ b/src/Tabs/MobileTab.tsx
@@ -1,8 +1,10 @@
 import React, { useContext, useCallback } from 'react';
 import styled, { css } from 'styled-components';
 import { TabContext, ContextProps } from './Tabs';
-import Icon, { IconWrapper } from '../Icons/Icon';
+import { IconWrapper } from '../Icons/Icon';
+import StatusIcon from '../Icons/StatusIcon';
 import { resetButtonStyles } from '../common/index';
+import { IStatusDot } from '..';
 
 const Container = styled.button`
   ${resetButtonStyles}
@@ -52,9 +54,11 @@ interface IMobileTab {
   tabFor: string
   icon: string
   closeId: string
+  counter?: number
+  status?: IStatusDot
 }
 
-const MobileTab: React.FC<IMobileTab> = ({ tabFor, icon, closeId, ...props }) => {
+const MobileTab: React.FC<IMobileTab> = ({ tabFor, icon, closeId, counter, status, ...props }) => {
   const { selected, setSelected }: ContextProps = useContext(TabContext);
 
   const onChangeTab = useCallback((tabId: string) => {
@@ -65,7 +69,7 @@ const MobileTab: React.FC<IMobileTab> = ({ tabFor, icon, closeId, ...props }) =>
   return (
     <Container {...props} onClick={() => onChangeTab(tabFor)}>
       <LinkTab isActive={selected === tabFor}>
-        <Icon {...{ icon }} size={18} />
+        <StatusIcon {...{icon, status, counter}} />
       </LinkTab>
     </Container>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -275,7 +275,9 @@ export type ITimeUnit = 'seconds' | 'minutes' | 'hours';
 
 export type IMediaType = 'img' | 'video'
 
-export type IStatusDot = 'caution' | 'danger' | 'good' | 'neutral';
+export type IStatusDot = 'caution' | 'danger' | 'good' | 'neutral' | 'highlight';
+
+
 
 export type {
   IModal,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,6 +48,8 @@ import {
 } from './Filters';
 
 import Icon, {IconSVGs} from  './Icons/Icon';
+import StatusIcon from './Icons/StatusIcon';
+
 // Components - Line UI
 import {
   LineUI,
@@ -198,6 +200,7 @@ export {
   //Icon
   Icon,
   IconSVGs,
+  StatusIcon,
 
   //Pages
   IntroductionText,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -134,7 +134,8 @@ import {
   Sidebar,
   GlobalUI,
   INotificationItem,
-  INotificationsHistory
+  INotificationsHistory,
+  ICustomDrawer,
 } from './Global';
 
 // Tabs
@@ -280,4 +281,5 @@ export type {
   ISliderMark,
   INotificationItem,
   INotificationsHistory,
+  ICustomDrawer,
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -135,7 +135,7 @@ import {
   GlobalUI,
   INotificationItem,
   INotificationsHistory,
-  ICustomDrawer,
+  ICustomDrawer
 } from './Global';
 
 // Tabs
@@ -272,6 +272,8 @@ export type ITimeUnit = 'seconds' | 'minutes' | 'hours';
 
 export type IMediaType = 'img' | 'video'
 
+export type IStatusDot = 'caution' | 'danger' | 'good' | 'neutral';
+
 export type {
   IModal,
   INotificationProps,
@@ -281,5 +283,5 @@ export type {
   ISliderMark,
   INotificationItem,
   INotificationsHistory,
-  ICustomDrawer,
+  ICustomDrawer
 };

--- a/src/themes/light/colors.js
+++ b/src/themes/light/colors.js
@@ -29,6 +29,7 @@ export const colors = {
         "danger": "hsla(0, 63.5%, 64.5%, 1.000)",
         "folder": "hsla(207, 95.3%, 66.5%, 1.000)",
         "good": "hsla(126, 48.1%, 68.2%, 1.000)",
-        "neutral": "hsla(0, 0%, 91.8%, 1.000)"
+        "neutral": "hsla(0, 0%, 91.8%, 1.000)",
+        "highlight": "hsla(207, 95.3%, 66.5%, 1.000)"
     }
 };

--- a/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -1,5 +1,13 @@
-import React from 'react';
-import { GlobalUI, PageHeader, TextAreaField, INotificationItem, INotificationsHistory } from 'scorer-ui-kit';
+import React, {ReactElement} from 'react';
+import {
+  GlobalUI,
+  PageHeader,
+  TextAreaField,
+  INotificationItem,
+  INotificationsHistory,
+  ICustomDrawer
+} from 'scorer-ui-kit';
+
 import styled from 'styled-components';
 import { Route, Switch, RouteComponentProps } from 'react-router-dom';
 
@@ -83,10 +91,10 @@ const Welcome = () => (
     <PageHeader
       title='Example'
       introductionText={`
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt 
-        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco 
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in 
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat 
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
         non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       `}
     />
@@ -250,6 +258,16 @@ const allNotifications: INotificationsHistory = {
   unreadNotificationsText: 'READ',
 }
 
+const MyCustomDrawer: ReactElement = <h1>Hello Drawer</h1>;
+
+const customDrawer : ICustomDrawer = {
+  customComponent: MyCustomDrawer,
+  icon: 'Add',
+  status: 'danger',
+  // counter: 5,
+  width: '280px;'
+}
+
 export const _GlobalUI = () => {
 
   const maxWidth = text("Max width", "1200px");
@@ -351,7 +369,7 @@ export const _GlobalUI = () => {
         content={menuConfig}
         home={menuHomeLink}
         defaultMenuOpen={true}
-        {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory }}
+        {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory, customDrawer }}
         {...{ loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, searchPlaceholder, hasLanguage, hasCurrentUser }}
       >
         <ComponentLinks />

--- a/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -253,9 +253,9 @@ const readNotifications: INotificationItem[] = [
 const allNotifications: INotificationsHistory = {
   unread: unreadNotifications,
   read: readNotifications,
-  noNotificationsText: 'NO NEW NOTIFICATIONS',
-  readNotificationsText: 'NEW',
-  unreadNotificationsText: 'READ',
+  noNotificationsText: 'No new notifications',
+  readNotificationsText: 'New',
+  unreadNotificationsText: 'Read',
 }
 
 const MyCustomDrawer: ReactElement = <h1>Hello Drawer</h1>;

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 const MyCustomDrawer: ReactElement = <h1>Hello Drawer</h1>;
 
-const drawerProps : ICustomDrawer = {
+const drawerProps: ICustomDrawer = {
   customComponent: MyCustomDrawer,
   icon: 'Add',
   status: 'danger',
@@ -131,11 +131,9 @@ export const _TopBar = () => {
         searchPlaceholder,
         hasLanguage,
         hasCurrentUser,
-        notificationsHistory
-        }
-        }
+        notificationsHistory}}
         customDrawer={drawerProps}
-        />
+      />
     </Container>
   );
 };

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import styled from 'styled-components';
 import { object, text, boolean } from "@storybook/addon-knobs";
-import { TopBar, ICustomDrawer } from 'scorer-ui-kit';
+import { TopBar, ICustomDrawer, INotificationItem, INotificationsHistory } from 'scorer-ui-kit';
 
 const Container = styled.div`
   position: fixed;

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import styled from 'styled-components';
-import {  object, text, boolean } from "@storybook/addon-knobs";
-import {TopBar} from 'scorer-ui-kit';
+import { object, text, boolean } from "@storybook/addon-knobs";
+import { TopBar, ICustomDrawer } from 'scorer-ui-kit';
 
 const Container = styled.div`
   position: fixed;
@@ -16,8 +16,17 @@ export default {
   decorators: []
 };
 
-export const _TopBar = () => {
+const MyCustomDrawer: ReactElement = <h1>Hello Drawer</h1>;
 
+const drawerProps : ICustomDrawer = {
+  customComponent: MyCustomDrawer,
+  icon: 'Add',
+  status: 'danger',
+  counter: 5,
+  width: '300px;'
+}
+
+export const _TopBar = () => {
 
   const loggedInUser = text("Logged In User", "full.name@example.com");
 
@@ -45,5 +54,22 @@ export const _TopBar = () => {
 
   // userDrawerBespoke: See examples for implementation of this prop.
 
-  return <Container><TopBar {...{loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, searchPlaceholder, hasLanguage, hasCurrentUser}}/></Container>;
+  return (
+    <Container>
+      <TopBar {...{
+        loggedInUser,
+        userSubmenu,
+        hasSearch,
+        hasLogout,
+        hasNotifications,
+        logoutLink,
+        searchPlaceholder,
+        hasLanguage,
+        hasCurrentUser
+        }
+        }
+        customDrawer={drawerProps}
+        />
+    </Container>
+  );
 };

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -22,8 +22,72 @@ const drawerProps : ICustomDrawer = {
   customComponent: MyCustomDrawer,
   icon: 'Add',
   status: 'danger',
-  counter: 5,
+  // counter: 5,
   width: '300px;'
+}
+
+const unreadNotifications: INotificationItem[] = [
+  {
+    imgUrl: '',
+    title: 'Event Type',
+    message: 'A short message limited to two lines. Extra text will just truncat...',
+    time: 'Just Now',
+  },
+  {
+    imgUrl: '',
+    title: 'Device is off',
+    message: 'The device has correctly turn off',
+    time: '1 min ago',
+  },
+  {
+    imgUrl: '',
+    title: 'Device is on',
+    message: 'The device has correctly turn on',
+    time: '6 mins ago',
+  },
+  {
+    imgUrl: '',
+    title: 'Connection was interrupted',
+    message: 'The connections is not working properly. Please verify your connection or contact your personal support.',
+    time: '1 hour ago',
+  },
+  {
+    imgUrl: '',
+    title: 'Device is off',
+    message: 'The device has correctly turn off',
+    time: '3 hour ago',
+  },
+]
+
+const readNotifications: INotificationItem[] = [
+  {
+    imgUrl: '',
+    title: 'Device is off',
+    message: 'The device has correctly turn off',
+    time: '3 days ago',
+  },
+  {
+    imgUrl: '',
+    title: 'Device is on',
+    message: 'The device has correctly turn on',
+    time: '3 days ago',
+  },
+  {
+    imgUrl: '',
+    title: 'A new device was added',
+    message: 'The device has bean correctly added',
+    time: '3 days ago',
+  }
+];
+
+
+// unread read can be empty array when there are no notifications
+const allNotifications: INotificationsHistory = {
+  unread: unreadNotifications,
+  read: readNotifications,
+  noNotificationsText: 'NO NEW NOTIFICATIONS',
+  readNotificationsText: 'NEW',
+  unreadNotificationsText: 'READ',
 }
 
 export const _TopBar = () => {
@@ -51,6 +115,7 @@ export const _TopBar = () => {
       href: '#'
     }
   ])
+  const notificationsHistory = object("Notifications History", allNotifications);
 
   // userDrawerBespoke: See examples for implementation of this prop.
 
@@ -65,7 +130,8 @@ export const _TopBar = () => {
         logoutLink,
         searchPlaceholder,
         hasLanguage,
-        hasCurrentUser
+        hasCurrentUser,
+        notificationsHistory
         }
         }
         customDrawer={drawerProps}

--- a/storybook/src/stories/Misc/StatusIcon.stories.tsx
+++ b/storybook/src/stories/Misc/StatusIcon.stories.tsx
@@ -32,7 +32,7 @@ export const _Status_Icon = () => {
 
   const icon = select("Name", iconList, Object.keys(iconList)[0]);
   const counter = number('Counter', 5);
-  const status = select("Status", { Caution: 'caution', Danger: 'danger', Good: 'good', Neutral:'neutral'}, 'danger');
+  const status = select("Status", { Caution: 'caution', Danger: 'danger', Good: 'good', Neutral:'neutral', Highlight:'highlight'}, 'danger');
   const undefineCounter = boolean('Show empty counter', false);
 
   return (

--- a/storybook/src/stories/Misc/StatusIcon.stories.tsx
+++ b/storybook/src/stories/Misc/StatusIcon.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {  select, number, boolean } from "@storybook/addon-knobs";
+import styled from 'styled-components';
+import {StatusIcon} from 'scorer-ui-kit';
+import {IconSVGs} from '@future-standard/icons';
+
+
+export default {
+  title: 'Misc',
+  component: StatusIcon,
+  decorators: []
+};
+
+const Container = styled.div`
+  margin: 20px;
+`;
+
+
+const generateIconList = () => {
+  let iconList : {[key: string]: string}= {};
+
+
+  for(const key in IconSVGs){
+    iconList[key] = key;
+  }
+
+  return iconList;
+};
+
+export const _Status_Icon = () => {
+  const iconList = generateIconList();
+
+  const icon = select("Name", iconList, Object.keys(iconList)[0]);
+  const counter = number('Counter', 5);
+  const status = select("Status", { Caution: 'caution', Danger: 'danger', Good: 'good', Neutral:'neutral'}, 'danger');
+  const undefineCounter = boolean('Show empty counter', false);
+
+  return (
+    <Container>
+      <StatusIcon {...{icon, status}} counter={undefineCounter ? undefined : counter}/>
+    </Container>
+  );
+}


### PR DESCRIPTION
### Requirements
The requests of Issue #105 

Custom drawer with:

- An icon to the header.
- That icon can have a status color dot / counter.
- The drawer contents will be blank and allow for a custom component to be injected.

### Implementation

I created a StatusIcon to cover Dot and counter cases.

I notice in the design that the icon with status is smaller than the others, however the icon with the numbers looked kind of weird smaller than the counter so I left it same size, but let me know if it should be different.

### Screenshoot

**Status Icon**
<img width="314" alt="Screen Shot 2021-07-13 at 10 45 20" src="https://user-images.githubusercontent.com/10409078/125377159-6d7f7a00-e3c7-11eb-8b55-52d940e4e326.png">

**Desktop Version**
<img width="1210" alt="Screen Shot 2021-07-13 at 10 44 16" src="https://user-images.githubusercontent.com/10409078/125377058-46c14380-e3c7-11eb-8c8d-e199d12dd4ec.png">

**Mobile Version**
<img width="490" alt="Screen Shot 2021-07-13 at 10 44 41" src="https://user-images.githubusercontent.com/10409078/125377101-55a7f600-e3c7-11eb-9d2a-a56b9c5d1391.png">
