### PR TITLE
Avatar Upload feature iteration

### DIFF
--- a/src/Form/atoms/ButtonWithIcon.tsx
+++ b/src/Form/atoms/ButtonWithIcon.tsx
@@ -31,6 +31,7 @@ const IconContainer = styled.div<{ position?: string }>`
   justify-content: center;
   align-items: center;
   overflow: hidden;
+  flex-shrink: 0;
 
   ${({ position }) => css`
     order: ${ position && position === 'left' ? 0 : 2 };

--- a/src/Form/molecules/CropTool.tsx
+++ b/src/Form/molecules/CropTool.tsx
@@ -178,7 +178,7 @@ const CropTool: React.FC<ICrop> = ({
       );
     // triggers a render to repaint canvas
     setLoadDimensions((prevState) =>
-      ({ 
+      ({
         ...prevState,
         cropLeft: newCrop.left,
         cropTop: newCrop.top,
@@ -262,7 +262,7 @@ const CropTool: React.FC<ICrop> = ({
     if (!viewDimensions.isResizing) { return; }
     viewDimensions.isResizing = false;
   }, []);
-  
+
   const updateSelect = useCallback((left, top, width, height) =>{
     if (!cropRef.current) { return; }
     cropRef.current.style.left = `${left}px`;

--- a/src/Form/organisms/AvatarUploader.tsx
+++ b/src/Form/organisms/AvatarUploader.tsx
@@ -76,6 +76,16 @@ const StyledInputFileButton = styled(InputFileButton)`
   width: 100%;
 `;
 
+const ButtonsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  button {
+    margin-bottom: 10px;
+  }
+
+`;
+
 interface IAvatar {
   title?: string
   photoText?: string
@@ -89,6 +99,7 @@ interface IAvatar {
   hasCrop?: boolean
   onAvatarUpdate?: (imgFile: File) => void
   onError?: (msg: string) => void
+  onRemove?: () => void
 }
 
 const AvatarUploader: React.FC<IAvatar> = ({
@@ -104,6 +115,7 @@ const AvatarUploader: React.FC<IAvatar> = ({
   hasCrop = true,
   onAvatarUpdate = () => { },
   onError = () => { },
+  onRemove = () => { }
 }) => {
 
   const [avatarImg, setAvatarImg] = useState(currentImg);
@@ -160,20 +172,38 @@ const AvatarUploader: React.FC<IAvatar> = ({
     }
   }, [currentImg])
 
-  const renderButton = useCallback(() => {
-    if ((currentImg && (!hasCrop)) || !currentImg) {
-      return (
-        <StyledInputFileButton
+  const handleRemove = () => {
+    setAvatarImg('');
+    onRemove();
+  }
+
+  const renderButtons = useCallback(() => {
+    return (
+      avatarImg
+        ? (
+          <ButtonsWrapper>
+            {hasCrop
+              ? <ButtonWithIcon icon='Crop' design='secondary' position='left' size='small' onClick={() => handleEdit(avatarImg)}>{uploaderCropText}</ButtonWithIcon>
+              : <StyledInputFileButton
+                  id='avatar-upload'
+                  text={buttonTextReplace}
+                  buttonSize='small'
+                  buttonDesign='secondary'
+                  accept='image/*'
+                  inputCallback={handleFileUpload}
+                />
+            }
+            <ButtonWithIcon icon='Delete' design='secondary' position='left' size='small' onClick={handleRemove}>Remove</ButtonWithIcon>
+          </ButtonsWrapper>
+        )
+        : <StyledInputFileButton
           id='avatar-upload'
-          text={avatarImg ? buttonTextReplace : buttonText}
+          text={buttonText}
           buttonSize='small'
           accept='image/*'
           inputCallback={handleFileUpload}
         />
-      )
-    }
-    return <Button size='small' onClick={() => handleEdit(currentImg)}>{uploaderCropText}</Button>
-
+    );
   }, [currentImg, avatarImg, hasCrop]);
 
   return (
@@ -190,7 +220,7 @@ const AvatarUploader: React.FC<IAvatar> = ({
           )}
         {((currentImg && (!hasCrop)) || !currentImg) && <DropArea height={PHOTO_HEIGHT} dropCallback={handleFileUpload} />}
       </PreviewImageGroup>
-      {renderButton()}
+      {renderButtons()}
       {isCropOpen && hasCrop
         ? <CropTool
           imgUrl={cropImg}
@@ -204,7 +234,7 @@ const AvatarUploader: React.FC<IAvatar> = ({
           aspectRatio={ratio}
           title={cropToolTitle}
           cancelBtnTxt={cropToolCancelTxt}
-          cropBtnTxt ={cropToolConfirmTxt}
+          cropBtnTxt={cropToolConfirmTxt}
           isResizable
         />
         : null}

--- a/src/Form/organisms/AvatarUploader.tsx
+++ b/src/Form/organisms/AvatarUploader.tsx
@@ -55,6 +55,7 @@ const PhotoContainerStyle = css`
 `;
 const PreviewImage = styled.img`
   ${PhotoContainerStyle}
+  object-fit: cover;
 `;
 
 const PlaceholderText = styled.div`

--- a/src/Form/organisms/AvatarUploader.tsx
+++ b/src/Form/organisms/AvatarUploader.tsx
@@ -75,7 +75,7 @@ const StyledInputFileButton = styled(InputFileButton)`
 `;
 
 interface IAvatar {
-  uploaderTitle?: string
+  title?: string
   photoText?: string
   buttonText?: string
   buttonTextReplace?: string
@@ -90,7 +90,7 @@ interface IAvatar {
 }
 
 const AvatarUploader: React.FC<IAvatar> = ({
-  uploaderTitle = 'Photograph',
+  title = 'Photograph',
   photoText = 'Drop Photo',
   buttonText = 'Select File',
   buttonTextReplace = 'Replace Photo',
@@ -176,7 +176,7 @@ const AvatarUploader: React.FC<IAvatar> = ({
 
   return (
     <Container>
-      <Label labelText={uploaderTitle} htmlFor='avatar-upload' />
+      <Label labelText={title} htmlFor='avatar-upload' />
       <PreviewImageGroup>
         {avatarImg
           ? <PreviewImage src={avatarImg} alt='avatar image' />

--- a/src/Form/organisms/AvatarUploader.tsx
+++ b/src/Form/organisms/AvatarUploader.tsx
@@ -75,11 +75,14 @@ const StyledInputFileButton = styled(InputFileButton)`
 `;
 
 interface IAvatar {
-  title?: string
+  uploaderTitle?: string
   photoText?: string
   buttonText?: string
   buttonTextReplace?: string
-  cropText?: string
+  cropToolTitle?: string
+  cropToolCancelTxt?: string
+  cropToolConfirmTxt?: string
+  uploaderCropText?: string
   defaultImg?: string
   hasCrop?: boolean
   onAvatarUpdate?: (imgFile: File) => void
@@ -87,11 +90,14 @@ interface IAvatar {
 }
 
 const AvatarUploader: React.FC<IAvatar> = ({
-  title = 'Photograph',
+  uploaderTitle = 'Photograph',
   photoText = 'Drop Photo',
   buttonText = 'Select File',
   buttonTextReplace = 'Replace Photo',
-  cropText = 'Crop Image',
+  uploaderCropText = 'Crop Image',
+  cropToolTitle,
+  cropToolCancelTxt,
+  cropToolConfirmTxt,
   defaultImg,
   hasCrop = true,
   onAvatarUpdate = () => { },
@@ -164,13 +170,13 @@ const AvatarUploader: React.FC<IAvatar> = ({
         />
       )
     }
-    return <Button size='small' onClick={() => handleEdit(defaultImg)}>{cropText}</Button>
+    return <Button size='small' onClick={() => handleEdit(defaultImg)}>{uploaderCropText}</Button>
 
   }, [defaultImg, avatarImg, hasCrop]);
 
   return (
     <Container>
-      <Label labelText={title} htmlFor='avatar-upload' />
+      <Label labelText={uploaderTitle} htmlFor='avatar-upload' />
       <PreviewImageGroup>
         {avatarImg
           ? <PreviewImage src={avatarImg} alt='avatar image' />
@@ -194,6 +200,9 @@ const AvatarUploader: React.FC<IAvatar> = ({
           cropHeight={CROP_WIDTH_AREA}
           cropWidth={CROP_HEIGHT_AREA}
           aspectRatio={ratio}
+          title={cropToolTitle}
+          cancelBtnTxt={cropToolCancelTxt}
+          cropBtnTxt ={cropToolConfirmTxt}
           isResizable
         />
         : null}

--- a/src/Form/organisms/AvatarUploader.tsx
+++ b/src/Form/organisms/AvatarUploader.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import InputFileButton from '../atoms/InputFileButton';
 import Button from '../atoms/Button';
+import ButtonWithIcon from '../atoms/ButtonWithIcon';
 import DropArea from '../atoms/DropArea';
 import CropTool from '../molecules/CropTool';
 import { AvatarPlaceholder } from '../../svg';
@@ -84,7 +85,7 @@ interface IAvatar {
   cropToolCancelTxt?: string
   cropToolConfirmTxt?: string
   uploaderCropText?: string
-  defaultImg?: string
+  currentImg?: string
   hasCrop?: boolean
   onAvatarUpdate?: (imgFile: File) => void
   onError?: (msg: string) => void
@@ -99,13 +100,13 @@ const AvatarUploader: React.FC<IAvatar> = ({
   cropToolTitle,
   cropToolCancelTxt,
   cropToolConfirmTxt,
-  defaultImg,
+  currentImg,
   hasCrop = true,
   onAvatarUpdate = () => { },
   onError = () => { },
 }) => {
 
-  const [avatarImg, setAvatarImg] = useState(defaultImg);
+  const [avatarImg, setAvatarImg] = useState(currentImg);
   const [cropImg, setCropImg] = useState('');
   const [isCropOpen, setIsCropOpen] = useState(false);
 
@@ -153,14 +154,14 @@ const AvatarUploader: React.FC<IAvatar> = ({
   }, []);
 
   useEffect(() => {
-    setAvatarImg(defaultImg);
+    setAvatarImg(currentImg);
     return () => {
       setAvatarImg('');
     }
-  }, [defaultImg])
+  }, [currentImg])
 
   const renderButton = useCallback(() => {
-    if ((defaultImg && (!hasCrop)) || !defaultImg) {
+    if ((currentImg && (!hasCrop)) || !currentImg) {
       return (
         <StyledInputFileButton
           id='avatar-upload'
@@ -171,9 +172,9 @@ const AvatarUploader: React.FC<IAvatar> = ({
         />
       )
     }
-    return <Button size='small' onClick={() => handleEdit(defaultImg)}>{uploaderCropText}</Button>
+    return <Button size='small' onClick={() => handleEdit(currentImg)}>{uploaderCropText}</Button>
 
-  }, [defaultImg, avatarImg, hasCrop]);
+  }, [currentImg, avatarImg, hasCrop]);
 
   return (
     <Container>
@@ -187,7 +188,7 @@ const AvatarUploader: React.FC<IAvatar> = ({
               <PlaceholderText>{photoText}</PlaceholderText>
             </NoPhoto>
           )}
-        {((defaultImg && (!hasCrop)) || !defaultImg) && <DropArea height={PHOTO_HEIGHT} dropCallback={handleFileUpload} />}
+        {((currentImg && (!hasCrop)) || !currentImg) && <DropArea height={PHOTO_HEIGHT} dropCallback={handleFileUpload} />}
       </PreviewImageGroup>
       {renderButton()}
       {isCropOpen && hasCrop

--- a/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
+++ b/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
@@ -23,7 +23,7 @@ export const _AvatarUploader = () => {
   const cropToolTitle = text('CropTool Title', 'Crop utility');
   const cropToolCancelTxt = text('CropTool Cancel Text', 'Cancel');
   const cropToolConfirmTxt = text('CropTool Confirm Text', 'Crop and Save');
-  const baseImg = boolean('Default Photo', false);
+  const baseImg = boolean('Current Image', false);
   const hasCrop = boolean('Has Crop', true);
   const showValue = action('Input Callback');
   const errorValue = action('Error');
@@ -42,7 +42,7 @@ export const _AvatarUploader = () => {
     <Container>
       <AvatarUploader
         onAvatarUpdate={uploadReady}
-        defaultImg={baseImg ? photo : ''}
+        currentImg={baseImg ? photo : ''}
         {...{
           title,
           photoText,

--- a/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
+++ b/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
@@ -15,7 +15,7 @@ export default {
 
 export const _AvatarUploader = () => {
 
-  const uploaderTitle = text('Uploader Title', 'Photograph');
+  const title = text('Uploader Title', 'Photograph');
   const photoText = text('Photo Text', 'Drop Photo');
   const buttonText = text('Button Text', 'Select File');
   const buttonReplaceText = text('Button Replace Text', 'Replace Photo');
@@ -44,7 +44,7 @@ export const _AvatarUploader = () => {
         onAvatarUpdate={uploadReady}
         defaultImg={baseImg ? photo : ''}
         {...{
-          uploaderTitle,
+          title,
           photoText,
           buttonText,
           buttonReplaceText,

--- a/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
+++ b/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
@@ -1,29 +1,33 @@
 import React from 'react';
 import styled from 'styled-components';
-import {AvatarUploader} from 'scorer-ui-kit';
+import { AvatarUploader } from 'scorer-ui-kit';
 import { action } from '@storybook/addon-actions';
-import { text} from "@storybook/addon-knobs";
+import { text, boolean } from "@storybook/addon-knobs";
+import photo from '../../assets/placeholder.jpg';
 
 const Container = styled.div``;
 
 export default {
   title: 'Form/File Management',
   component: AvatarUploader,
-  decorators:[]
+  decorators: []
 };
 
 export const _AvatarUploader = () => {
 
-  const title = text('Title','Photograph' );
+  const title = text('Title', 'Photograph');
   const photoText = text('Photo Text', 'Drop Photo');
   const buttonText = text('Button Text', 'Select File');
   const buttonReplaceText = text('Button Replace Text', 'Replace Photo');
+  const cropText = text('Crop Text','Crop Image');
+  const baseImg = boolean('Default Photo', false);
+  const hasCrop = boolean('Has Crop', true);
   const showValue = action('Input Callback');
-  const errorValue = action ('Error');
-  
+  const errorValue = action('Error');
+
   const uploadReady = (imgFile: File) => {
     console.log('file', imgFile);
-      showValue(imgFile.name);
+    showValue(imgFile.name);
   };
 
   const onError = (msg: string) => {
@@ -31,17 +35,19 @@ export const _AvatarUploader = () => {
     errorValue(msg);
   };
 
-
-  return(
+  return (
     <Container>
       <AvatarUploader
         onAvatarUpdate={uploadReady}
+        defaultImg={baseImg ? photo : ''}
         {...{
           title,
           photoText,
           buttonText,
           buttonReplaceText,
-          onError
+          onError,
+          cropText,
+          hasCrop
         }}
       />
     </Container>

--- a/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
+++ b/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
@@ -25,8 +25,9 @@ export const _AvatarUploader = () => {
   const cropToolConfirmTxt = text('CropTool Confirm Text', 'Crop and Save');
   const baseImg = boolean('Current Image', false);
   const hasCrop = boolean('Has Crop', true);
-  const showValue = action('Input Callback');
-  const errorValue = action('Error');
+  const showValue = action('Update Callback');
+  const errorValue = action('On Error');
+  const onRemoveValue = action('On Remove');
 
   const uploadReady = (imgFile: File) => {
     console.log('file', imgFile);
@@ -37,6 +38,10 @@ export const _AvatarUploader = () => {
     console.log(msg);
     errorValue(msg);
   };
+
+  const onRemove = () => {
+    onRemoveValue('The user has deleted Avatar image');
+  }
 
   return (
     <Container>
@@ -49,6 +54,7 @@ export const _AvatarUploader = () => {
           buttonText,
           buttonReplaceText,
           onError,
+          onRemove,
           uploaderCropText,
           hasCrop,
           cropToolTitle,

--- a/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
+++ b/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
@@ -15,11 +15,14 @@ export default {
 
 export const _AvatarUploader = () => {
 
-  const title = text('Title', 'Photograph');
+  const uploaderTitle = text('Uploader Title', 'Photograph');
   const photoText = text('Photo Text', 'Drop Photo');
   const buttonText = text('Button Text', 'Select File');
   const buttonReplaceText = text('Button Replace Text', 'Replace Photo');
-  const cropText = text('Crop Text','Crop Image');
+  const uploaderCropText = text('Uploader Crop Text','Crop Image');
+  const cropToolTitle = text('CropTool Title', 'Crop utility');
+  const cropToolCancelTxt = text('CropTool Cancel Text', 'Cancel');
+  const cropToolConfirmTxt = text('CropTool Confirm Text', 'Crop and Save');
   const baseImg = boolean('Default Photo', false);
   const hasCrop = boolean('Has Crop', true);
   const showValue = action('Input Callback');
@@ -41,13 +44,16 @@ export const _AvatarUploader = () => {
         onAvatarUpdate={uploadReady}
         defaultImg={baseImg ? photo : ''}
         {...{
-          title,
+          uploaderTitle,
           photoText,
           buttonText,
           buttonReplaceText,
           onError,
-          cropText,
-          hasCrop
+          uploaderCropText,
+          hasCrop,
+          cropToolTitle,
+          cropToolCancelTxt,
+          cropToolConfirmTxt
         }}
       />
     </Container>


### PR DESCRIPTION
### Requirements
This is an update for  the Croptool
- Allow to pass a image
- Update hasCroptool
- Add props to pass button text to Croptools

closes #141

### Implementation

**Default img**
The Avatar uploader didn't have the option before.

**hasCrop update**
After the hasCrop was updated the logic with both was implemented this way, please confirm this is the expected.
basically if an image is provided and has crop will only edit that image in any other case the feature will allow the user to update the image and crop it if the crop feature is enabled.

Please confirm the logic of both together.

| initial button text  | defaultImg   | hasCrop   | button text after actions  |
|------------------|-------------|------------|------------------|
| Crop Image.        |     ✅              |  ✅               |  Crop Image         | 
|  Select file           |                       |  ✅              |  Replace photo    |
|  Replace photo   |      ✅              |                   |  Replace photo    |
|  Select file            |                      |                    |  Replace photo    |


Currently this feature can be reviewed in the [demo link](https://future-standard.github.io/scorer-ui-kit/storybook/?path=/story/form-file-management--avatar-uploader)

**Screenshots**

<img width="955" alt="Screen Shot 2021-08-04 at 11 30 44" src="https://user-images.githubusercontent.com/10409078/128112456-21ed96b2-cf8c-4360-afa0-434e43c9feb8.png">

<img width="946" alt="Screen Shot 2021-08-04 at 11 30 51" src="https://user-images.githubusercontent.com/10409078/128112469-64041fde-6d28-4e03-9bc9-e5dd95bb8930.png">


<img width="918" alt="Screen Shot 2021-08-04 at 11 30 56" src="https://user-images.githubusercontent.com/10409078/128112486-8cc301f8-730f-4578-8114-730c8ed2a948.png">

