### PR TITLE
Fix closeText in Modal over screen and improve MediaModal hook

### DIFF
--- a/example/src/pages/TablePage.tsx
+++ b/example/src/pages/TablePage.tsx
@@ -96,7 +96,7 @@ const initialRows : ITypeTableData = [
     id: 'device-id-4',
     header: {
       image: "http://placekitten.com/2934/3102",
-      mediaUrl:"http://placekiten.com/2934/3102",
+      mediaUrl:"http://wrong-url-placekitten.com/2934/3102",
       mediaType: 'img'
     },
     columns:

--- a/example/src/pages/TablePage.tsx
+++ b/example/src/pages/TablePage.tsx
@@ -80,8 +80,8 @@ const initialRows : ITypeTableData = [
   {
     id: 'device-id-3',
     header: {
-      image: "http://placekitten.com/1300/1300",
-      mediaUrl:"http://placekitten.com/1300/1300",
+      image: "http://placekitten.com/1934/3102",
+      mediaUrl:"http://placekitten.com/1934/3102",
       mediaType: 'img'
     },
     columns:

--- a/example/src/pages/TablePage.tsx
+++ b/example/src/pages/TablePage.tsx
@@ -94,10 +94,25 @@ const initialRows : ITypeTableData = [
   },
   {
     id: 'device-id-4',
+    header: {
+      image: "http://placekitten.com/2934/3102",
+      mediaUrl:"http://placekiten.com/2934/3102",
+      mediaType: 'img'
+    },
     columns:
     [
       { text: 'Magic Edge Cloud', href: '#' },
       { text: '2nd April 2020' },
+      { text: '153', unit: 'mb' },
+      { text: '¥25,000' }
+    ]
+  },
+  {
+    id: 'device-id-5',
+    columns:
+    [
+      { text: 'Special Camera', href: '#' },
+      { text: '16th June 2020' },
       { text: '153', unit: 'mb' },
       { text: '¥25,000' }
     ]

--- a/example/src/pages/TablePage.tsx
+++ b/example/src/pages/TablePage.tsx
@@ -79,6 +79,11 @@ const initialRows : ITypeTableData = [
   },
   {
     id: 'device-id-3',
+    header: {
+      image: "http://placekitten.com/1300/1300",
+      mediaUrl:"http://placekitten.com/1300/1300",
+      mediaType: 'img'
+    },
     columns:
     [
       { text: 'Old Device', href: '#' },

--- a/src/Misc/atoms/MediaBox.tsx
+++ b/src/Misc/atoms/MediaBox.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, VideoHTMLAttributes } from 'react';
-import styled, {css} from 'styled-components';
+import styled, { css } from 'styled-components';
 import Spinner from '../../Indicators/Spinner';
-import {IMediaType} from '../../index';
+import { IMediaType } from '../../index';
 
 const Container = styled.div`
   position: relative;
@@ -31,7 +31,7 @@ const Video = styled.video<{ isLoaded?: boolean, hasModalLimits?: boolean }>`
   ${mediaStyle};
   outline: none;
 
-  ${({theme, isLoaded, hasModalLimits}) => css`
+  ${({ theme, isLoaded, hasModalLimits }) => css`
     transition: opacity ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeOut};
     opacity: ${isLoaded ? `1` : `0`};
 
@@ -40,22 +40,20 @@ const Video = styled.video<{ isLoaded?: boolean, hasModalLimits?: boolean }>`
       max-width: calc(100vw - 100px);
     `};
   `};
-
 `;
 
 const StyledImage = styled.img<{ isLoaded?: boolean, hasModalLimits?: boolean }>`
   ${mediaStyle};
 
-  ${({theme, isLoaded, hasModalLimits}) => css`
+  ${({ theme, isLoaded, hasModalLimits }) => css`
     transition: opacity ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeOut};
     opacity: ${isLoaded ? `1` : `0`};
 
     ${hasModalLimits && css`
-    max-height: calc(100vh - 100px);
-    max-width: calc(100vw - 100px);
+      max-height: calc(100vh - 100px);
+      max-width: calc(100vw - 100px);
+    `};
   `};
-  `};
-
 `;
 
 export interface IMediaModal {
@@ -64,13 +62,18 @@ export interface IMediaModal {
   alt?: string
   videoOptions?: VideoHTMLAttributes<HTMLVideoElement>
   hasModalLimits?: boolean
+  onError?: () => void
+  onMediaLoad?: () => void
 }
 
 const MediaBox: React.FC<IMediaModal> = ({
   src,
   alt,
   videoOptions = {},
-  mediaType
+  mediaType,
+  hasModalLimits,
+  onError = () => { },
+  onMediaLoad = () => { },
 }) => {
 
   const {
@@ -84,29 +87,25 @@ const MediaBox: React.FC<IMediaModal> = ({
   const [loaded, setLoaded] = useState(false);
 
   const handleLoad = useCallback(() => {
-      setLoaded(true);
-  },[]);
+    onMediaLoad();
+    setLoaded(true);
+  }, [onMediaLoad, setLoaded]);
 
   return (
     <Container>
       {mediaType === 'video'
         ? <Video
-            loop={loop}
-            autoPlay={autoPlay}
-            controls={controls}
-            muted={muted}
-            {...videoValues}
-            src={src}
-            isLoaded={loaded}
-            preload='metadata'
-            onCanPlay={handleLoad}
-          />
+          {...{ src, loop, autoPlay, controls, muted, onError, hasModalLimits }}
+          {...videoValues}
+          isLoaded={loaded}
+          preload='metadata'
+          onCanPlayThrough={handleLoad}
+        />
         : <StyledImage
-            src={src}
-            alt={alt}
-            onLoad={handleLoad}
-            isLoaded={loaded}
-          />}
+          {...{ src, alt, onError, hasModalLimits }}
+          onLoad={handleLoad}
+          isLoaded={loaded}
+        />}
       {(!loaded) && <LoadingOverlay><Spinner size='large' styling='primary' /></LoadingOverlay>}
     </Container>
   );

--- a/src/Misc/atoms/MediaBox.tsx
+++ b/src/Misc/atoms/MediaBox.tsx
@@ -9,8 +9,8 @@ const Container = styled.div`
 `;
 
 const mediaStyle = `
-  width:  100%;
-  height: 100%;
+  max-width:  100%;
+  max-height: 100%;
   border-radius: 3px;
   background-color: hsla(0deg, 0%, 0%, 35%);
 `;

--- a/src/Misc/atoms/MediaBox.tsx
+++ b/src/Misc/atoms/MediaBox.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, VideoHTMLAttributes, useRef } from 'react';
+import React, { useState, useCallback, VideoHTMLAttributes } from 'react';
 import styled, {css} from 'styled-components';
 import Spinner from '../../Indicators/Spinner';
 import {IMediaType} from '../../index';
@@ -27,64 +27,43 @@ const LoadingOverlay = styled.div`
   justify-content: center;
 `;
 
-const Video = styled.video<{ isLoaded?: boolean, maxDimensions: IImageDimensions | null }>`
+const Video = styled.video<{ isLoaded?: boolean, hasModalLimits?: boolean }>`
   ${mediaStyle};
   outline: none;
 
-  ${({theme, isLoaded}) => css`
+  ${({theme, isLoaded, hasModalLimits}) => css`
     transition: opacity ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeOut};
     opacity: ${isLoaded ? `1` : `0`};
+
+    ${hasModalLimits && css`
+      max-height: calc(100vh - 100px);
+      max-width: calc(100vw - 100px);
+    `};
   `};
-  ${({maxDimensions}) => (maxDimensions !== null) &&`
-    max-width: ${maxDimensions.width};
-    max-height: ${maxDimensions.height};
-  `}
+
 `;
 
-const StyledImage = styled.img<{ isLoaded?: boolean, maxDimensions: IImageDimensions | null}>`
+const StyledImage = styled.img<{ isLoaded?: boolean, hasModalLimits?: boolean }>`
   ${mediaStyle};
 
-  ${({theme, isLoaded}) => css`
+  ${({theme, isLoaded, hasModalLimits}) => css`
     transition: opacity ${theme.animation.speed.slow} ${theme.animation.easing.primary.easeOut};
     opacity: ${isLoaded ? `1` : `0`};
+
+    ${hasModalLimits && css`
+    max-height: calc(100vh - 100px);
+    max-width: calc(100vw - 100px);
+  `};
   `};
 
-  ${({maxDimensions}) => (maxDimensions !== null) &&`
-      max-width: ${maxDimensions.width};
-      max-height: ${maxDimensions.height};
-  `}
 `;
-
-
 
 export interface IMediaModal {
   src: string
   mediaType: IMediaType
   alt?: string
   videoOptions?: VideoHTMLAttributes<HTMLVideoElement>
-}
-
-interface IImageDimensions {
-  width: string
-  height: string
-};
-
-const getMaxDimensions = (width: number, height: number): IImageDimensions => {
-
-    // 100 will be reduce to prevent the close button to be overloaded
-    const maxHeight = window.innerHeight - 100;
-    const maxWidth = window.innerWidth - 100;
-
-  // prevent 0 division
-  if(width === 0) { return {width: `${maxWidth}px`, height: `${maxHeight}`}}
-
-  const aspectRatio = height / width;
-
-  const modalMaxHeightPx : number = maxWidth * aspectRatio;
-  const modalMaxWidthPx : number = maxHeight / aspectRatio;
-  const dimensions : IImageDimensions = {width: `${modalMaxWidthPx}px`, height:`${modalMaxHeightPx}px` }
-
-  return dimensions;
+  hasModalLimits?: boolean
 }
 
 const MediaBox: React.FC<IMediaModal> = ({
@@ -103,39 +82,19 @@ const MediaBox: React.FC<IMediaModal> = ({
   } = videoOptions;
 
   const [loaded, setLoaded] = useState(false);
-  const [maxDimensions, setMaxDimensions] = useState<IImageDimensions | null>(null);
-
-  const imgRef = useRef<HTMLImageElement>(null);
-  const videoRef = useRef<HTMLVideoElement>(null);
 
   const handleLoad = useCallback(() => {
-
-      if(mediaType === 'img' && imgRef.current && imgRef.current.width && imgRef.current.width) {
-        const dimensions = getMaxDimensions(imgRef.current.width, imgRef.current.height);
-
-        if(dimensions) {
-          setMaxDimensions(dimensions);
-        }
-      }
-
-      if(mediaType === 'video' && videoRef.current) {
-        const dimensions = getMaxDimensions(videoRef.current.videoWidth, videoRef.current.videoHeight);
-
-        if(dimensions) {
-          setMaxDimensions(dimensions);
-        }
-      }
-
       setLoaded(true);
-
-  },[mediaType]);
+  },[]);
 
   return (
     <Container>
       {mediaType === 'video'
         ? <Video
-            ref={videoRef}
-            {...{loop, autoPlay, controls, muted, maxDimensions}}
+            loop={loop}
+            autoPlay={autoPlay}
+            controls={controls}
+            muted={muted}
             {...videoValues}
             src={src}
             isLoaded={loaded}
@@ -143,8 +102,8 @@ const MediaBox: React.FC<IMediaModal> = ({
             onCanPlay={handleLoad}
           />
         : <StyledImage
-            ref={imgRef}
-            {...{src, alt, maxDimensions}}
+            src={src}
+            alt={alt}
             onLoad={handleLoad}
             isLoaded={loaded}
           />}

--- a/src/Tables/atoms/TableRowThumbnail.tsx
+++ b/src/Tables/atoms/TableRowThumbnail.tsx
@@ -6,7 +6,7 @@ import Icon, { IconWrapper } from '../../Icons/Icon';
 
 type VideoAspects = '4:3' | '16:9';
 
-const Container = styled.div<{ hoverZoom?: boolean, aspect?: VideoAspects, mediaUrl?: string, hasPreview: boolean }>`
+const Container = styled.div<{ hoverZoom?: boolean, aspect?: VideoAspects, mediaUrl?: string, isImageValid: boolean, hasPreview: boolean }>`
   position: relative;
   height: inherit;
   background: grey;
@@ -37,7 +37,7 @@ const Container = styled.div<{ hoverZoom?: boolean, aspect?: VideoAspects, media
       cursor: pointer;
     `};
 
-    ${({ theme, hoverZoom, mediaUrl, hasPreview }) => theme && hoverZoom && mediaUrl && hasPreview && css`
+    ${({ theme, hoverZoom, isImageValid }) => theme && hoverZoom && isImageValid && css`
       transform: scale(1.5);
       opacity: 1;
       transition: transform ${theme.animation.speed.normal} ${theme.animation.easing.primary.easeOut};
@@ -92,6 +92,7 @@ interface IProps {
 const TableRowThumbnail: React.FC<IProps> = ({ hoverZoom = true, image, mediaUrl, mediaType }) => {
 
   const [hasPreview, setHasPreview] = useState(false);
+  const [isImageValid, setIsImageValid] = useState(false);
   const { createMediaModal, isMediaUrlValid } = useMediaModal();
 
   const handleModal = useCallback(async () => {
@@ -103,32 +104,52 @@ const TableRowThumbnail: React.FC<IProps> = ({ hoverZoom = true, image, mediaUrl
   }, [createMediaModal, mediaType, mediaUrl, hasPreview]);
 
   const verifyPreview = useCallback(async (currentMediaUrl: string, currentMediaType: IMediaType) => {
-    const isValidUrl : boolean = await isMediaUrlValid(currentMediaUrl, currentMediaType);
+    const isValidUrl: boolean = await isMediaUrlValid(currentMediaUrl, currentMediaType);
 
     setHasPreview((prev) => {
 
-      if(prev === isValidUrl) {
+      if (prev === isValidUrl) {
         return prev;
       }
-
       return isValidUrl;
     });
 
   }, []);
 
   useEffect(() => {
-    let loading = true;
-    if (mediaUrl && mediaType) {
+    let active = true;
+    if (active && mediaUrl && mediaType) {
       verifyPreview(mediaUrl, mediaType);
     }
 
     return () => {
-      loading = false;
+      active = false;
     }
   }, [mediaUrl, mediaType])
 
+  const validateImage = useCallback(async (currentImg: string) => {
+
+    const isValidUrl: boolean = await isMediaUrlValid(currentImg, 'img');
+    setIsImageValid((prev) => {
+      if (prev === isValidUrl) {
+        return prev;
+      }
+      return isValidUrl;
+    })
+
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    if (active && image) {
+      validateImage(image);
+    }
+
+  }, [image]);
+
   return (
-    <Container {...{ hoverZoom, mediaUrl, hasPreview }} aspect='16:9' onClick={handleModal}>
+    <Container {...{ hoverZoom, mediaUrl, isImageValid, hasPreview }} aspect='16:9' onClick={handleModal}>
       <Image {...{ image }} />
       {mediaUrl && (mediaType === 'video') &&
         <PlayableDrop>

--- a/src/Tables/atoms/TableRowThumbnail.tsx
+++ b/src/Tables/atoms/TableRowThumbnail.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, VideoHTMLAttributes} from 'react';
 import styled, { css } from 'styled-components';
 import MediaBox  from '../../Misc/atoms/MediaBox';
 import  { useModal } from '../../hooks/useModal';
+import { useMediaModal } from '../../hooks/useMediaModal';
 import { IMediaType } from '../..';
 import Icon, {IconWrapper} from '../../Icons/Icon';
 
@@ -90,22 +91,16 @@ interface IProps {
 // Image
 // No Image Placeholder
 
-// default options for media box
-const videoDefaultOptions : VideoHTMLAttributes<HTMLVideoElement> = {controls: true};
-
 const TableRowThumbnail : React.FC<IProps> = ({hoverZoom = true, image, mediaUrl, mediaType }) => {
 
-  const {createModal} = useModal();
+  const { createMediaModal } = useMediaModal();
 
   const handleModal = useCallback(() => {
-    if(mediaUrl && mediaType) {
-      createModal({
-        padding:false,
-        width:'60%',
-        customComponent: <MediaBox src={mediaUrl} mediaType={mediaType} videoOptions={videoDefaultOptions} />
-      });
+    if (mediaUrl && mediaType) {
+
+      createMediaModal({src: mediaUrl, mediaType});
     }
-  },[createModal, mediaType, mediaUrl]);
+  }, [createMediaModal, mediaType, mediaUrl]);
 
   return (
     <Container {...{hoverZoom}} mediaUrl={mediaUrl} aspect='16:9' onClick={handleModal}>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,6 +8,7 @@ import {useClickOutside} from './useClickOutside';
 import {usePoll} from './usePoll';
 import useBreakpoints from './useBreakpoints';
 import useMediaQuery from './useMediaQuery';
+import { useMediaModal } from './useMediaModal';
 
 export {
   useInterval,
@@ -20,5 +21,6 @@ export {
   usePoll,
   useMediaQuery,
   useBreakpoints,
+  useMediaModal
 };
 export type { IModal };

--- a/src/hooks/useMediaModal.tsx
+++ b/src/hooks/useMediaModal.tsx
@@ -1,32 +1,74 @@
-import React, { useCallback, VideoHTMLAttributes } from 'react';
+import React, { ReactElement, useCallback, VideoHTMLAttributes } from 'react';
 import { IMediaType } from '..';
 import MediaBox, { IMediaModal } from "../Misc/atoms/MediaBox";
 import { useModal } from "./useModal";
+
+
+let hasMediaError = false
 
 export const useMediaModal = () => {
 
   // default options for media box
   const videoDefaultOptions: VideoHTMLAttributes<HTMLVideoElement> = { controls: true };
-
   const { createModal } = useModal();
 
+
+  async function isMediaUrlValid(src: string, mediaType: IMediaType): Promise<boolean> {
+    let isValid = false;
+
+    if (mediaType === 'img') {
+      const img = new Image();
+      img.src = src;
+      try {
+        await new Promise((resolve, reject) => {
+          img.onload = () => resolve(isValid = true);
+          img.onerror = reject;
+        })
+      } catch (error) {
+        isValid = false;
+        console.log(`[useMediaModal Hook] ${src} load image failed`, error);
+      }
+    }
+
+    if (mediaType === 'video') {
+      const videoElement = document.createElement('video');
+      videoElement.src = src;
+
+      try {
+        await new Promise((resolve, reject) => {
+          videoElement.oncanplaythrough = () => resolve(isValid = true);
+          videoElement.onerror = reject;
+        })
+
+      } catch (error) {
+        isValid = false;
+        console.log(`[useMediaModal Hook] ${src} load image failed`, error);
+      }
+    }
+
+    return isValid;
+  }
+
+
   const createMediaModal = useCallback(async (media: IMediaModal) => {
-    const {
-      src,
-      mediaType,
-      alt,
-      videoOptions,
-    } = media;
+    const { videoOptions } = media;
 
     createModal({
       padding: false,
       width: 'auto',
-      customComponent: <MediaBox {...{ src, mediaType, alt }} videoOptions={videoOptions || videoDefaultOptions} hasModalLimits/>
+      customComponent: (
+        <MediaBox
+          {...media}
+          videoOptions={videoOptions || videoDefaultOptions}
+          hasModalLimits
+        />
+      )
     });
 
-  }, [createModal]);
+  }, [createModal, hasMediaError]);
 
   return {
     createMediaModal,
+    isMediaUrlValid,
   }
 };

--- a/src/hooks/useMediaModal.tsx
+++ b/src/hooks/useMediaModal.tsx
@@ -1,16 +1,16 @@
-import React, { ReactElement, useCallback, VideoHTMLAttributes } from 'react';
+import React, {useCallback, VideoHTMLAttributes } from 'react';
 import { IMediaType } from '..';
 import MediaBox, { IMediaModal } from "../Misc/atoms/MediaBox";
-import { useModal } from "./useModal";
+import { useModal, IModal } from "./useModal";
 
 
-let hasMediaError = false
+export type ICreateMediaModal = IMediaModal & IModal;
 
 export const useMediaModal = () => {
 
   // default options for media box
   const videoDefaultOptions: VideoHTMLAttributes<HTMLVideoElement> = { controls: true };
-  const { createModal } = useModal();
+  const { createModal, isModalOpen, setModalOpen } = useModal();
 
 
   async function isMediaUrlValid(src: string, mediaType: IMediaType): Promise<boolean> {
@@ -50,25 +50,44 @@ export const useMediaModal = () => {
   }
 
 
-  const createMediaModal = useCallback(async (media: IMediaModal) => {
-    const { videoOptions } = media;
+  const createMediaModal = useCallback(async (mediaModal: ICreateMediaModal) => {
+    const {
+      src,
+      mediaType,
+      alt,
+      videoOptions = videoDefaultOptions,
+      onError,
+      onMediaLoad,
+      closeText,
+      dismissCallback,
+    } = mediaModal;
 
     createModal({
       padding: false,
       width: 'auto',
+      closeText,
+      dismissCallback,
       customComponent: (
         <MediaBox
-          {...media}
-          videoOptions={videoOptions || videoDefaultOptions}
+          {...{
+            src,
+            mediaType,
+            alt,
+            videoOptions,
+            onError,
+            onMediaLoad
+          }}
           hasModalLimits
         />
       )
     });
 
-  }, [createModal, hasMediaError]);
+  }, [createModal]);
 
   return {
     createMediaModal,
     isMediaUrlValid,
+    isMediaModalOpen: isModalOpen,
+    setMediaModalOpen: setModalOpen,
   }
 };

--- a/src/hooks/useMediaModal.tsx
+++ b/src/hooks/useMediaModal.tsx
@@ -26,7 +26,7 @@ export const useMediaModal = () => {
         })
       } catch (error) {
         isValid = false;
-        console.log(`[useMediaModal Hook] ${src} load image failed`, error);
+        console.log(`[useMediaModal - isMediaUrlValid] Invalid preview url ${src} - image load failed, modal will not be open`, error);
       }
     }
 
@@ -42,7 +42,7 @@ export const useMediaModal = () => {
 
       } catch (error) {
         isValid = false;
-        console.log(`[useMediaModal Hook] ${src} load image failed`, error);
+        console.log(`[useMediaModal - isMediaUrlValid] Invalid preview url ${src} - video load failed, modal will not be open`, error);
       }
     }
 

--- a/src/hooks/useMediaModal.tsx
+++ b/src/hooks/useMediaModal.tsx
@@ -21,7 +21,7 @@ export const useMediaModal = () => {
     createModal({
       padding: false,
       width: 'auto',
-      customComponent: <MediaBox {...{ src, mediaType, alt }} videoOptions={videoOptions || videoDefaultOptions} />
+      customComponent: <MediaBox {...{ src, mediaType, alt }} videoOptions={videoOptions || videoDefaultOptions} hasModalLimits/>
     });
 
   }, [createModal]);

--- a/src/hooks/useMediaModal.tsx
+++ b/src/hooks/useMediaModal.tsx
@@ -1,0 +1,32 @@
+import React, { useCallback, VideoHTMLAttributes } from 'react';
+import { IMediaType } from '..';
+import MediaBox, { IMediaModal } from "../Misc/atoms/MediaBox";
+import { useModal } from "./useModal";
+
+export const useMediaModal = () => {
+
+  // default options for media box
+  const videoDefaultOptions: VideoHTMLAttributes<HTMLVideoElement> = { controls: true };
+
+  const { createModal } = useModal();
+
+  const createMediaModal = useCallback(async (media: IMediaModal) => {
+    const {
+      src,
+      mediaType,
+      alt,
+      videoOptions,
+    } = media;
+
+    createModal({
+      padding: false,
+      width: 'auto',
+      customComponent: <MediaBox {...{ src, mediaType, alt }} videoOptions={videoOptions || videoDefaultOptions} />
+    });
+
+  }, [createModal]);
+
+  return {
+    createMediaModal,
+  }
+};

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -5,7 +5,7 @@ import {useState, useLayoutEffect } from "react";
  */
 
 export default function useMediaQuery(query: string) {
-  
+
   const [matches, setMatches] = useState(false);
   useLayoutEffect(
     () => {
@@ -13,7 +13,7 @@ export default function useMediaQuery(query: string) {
       const mediaQuery = window.matchMedia(query);
       setMatches(mediaQuery.matches);
       const handler = (event: MediaQueryListEvent) => setMatches(event.matches);
-      
+
       mediaQuery.addEventListener("change", handler);
 
       return () => mediaQuery.removeEventListener("change", handler);

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -4,7 +4,7 @@ import { IModalProps } from '../Modals/Modal';
 
 /**
  * This type is a reduced version of the modalProps
- * but with the posibilities to grow beyond the basic modal
+ * but with the possibilities to grow beyond the basic modal
  * features
  */
 export type IModal = {
@@ -54,6 +54,7 @@ export const useModal = () => {
 
   return {
     createModal,
+    isModalOpen: modalProps.isOpen,
     setModalOpen,
   };
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -108,6 +108,7 @@ import {
   useModal,
   useNotification,
   useClickOutside,
+  useMediaModal,
   IModal,
   usePoll,
 } from './hooks';
@@ -232,6 +233,7 @@ export {
   useCopyToClipboard,
   useClickOutside,
   usePoll,
+  useMediaModal,
   resetButtonStyles,
   Spinner,
   WebRTCClient,

--- a/storybook/src/stories/Alerts/Modals/MediaModal.stories.tsx
+++ b/storybook/src/stories/Alerts/Modals/MediaModal.stories.tsx
@@ -6,6 +6,7 @@ import {
   MediaBox,
   Button
 } from 'scorer-ui-kit';
+import { boolean } from '@storybook/addon-knobs';
 
 export default {
   title: 'Alerts/Modals',
@@ -15,14 +16,19 @@ export default {
 
 const Container = styled.div``;
 
+interface IExampleModal {
+  hasModalLimitsValue: boolean
+}
 
-const MediaImageModal = () => {
+const MediaImageModal : React.FC<IExampleModal> = ({hasModalLimitsValue}) => {
   const { createModal } = useModal();
 
-  const mediaImage: ReactElement = <MediaBox mediaType="img" alt="city" src="https://i.picsum.photos/id/1026/4621/3070.jpg?hmac=OJ880cIneqAKIwHbYgkRZxQcuMgFZ4IZKJasZ5c5Wcw" />
+  const mediaImage: ReactElement = <MediaBox hasModalLimits={hasModalLimitsValue} mediaType="img" alt="city" src="https://i.picsum.photos/id/1026/4621/3070.jpg?hmac=OJ880cIneqAKIwHbYgkRZxQcuMgFZ4IZKJasZ5c5Wcw" />
+
+  const modalWidth = hasModalLimitsValue ? 'auto' : '60%';
 
   const openImageModal = () => {
-    createModal({ customComponent: mediaImage, padding: false, width: '60%' })
+    createModal({ customComponent: mediaImage, padding: false, width: modalWidth  })
   }
 
   return (
@@ -37,10 +43,12 @@ const MediaImageModal = () => {
 
   // Provider should be at main Index level, it's here just for the story example
 export const _MediaModal = () => {
+
+  const hasModalLimits = boolean('Has Modal Limits', true);
   return (
     <Container>
       <ModalProvider>
-        <MediaImageModal />
+        <MediaImageModal hasModalLimitsValue={hasModalLimits} />
       </ModalProvider>
     </Container>
   )

--- a/storybook/src/stories/Tables/molecules/ActionsTable.stories.tsx
+++ b/storybook/src/stories/Tables/molecules/ActionsTable.stories.tsx
@@ -5,13 +5,14 @@ import { action } from '@storybook/addon-actions';
 
 
 import {
-TypeTable as TypeTableCustom,
-ActionButtons,
-IconButtonData,
-MultilineContent,
+  TypeTable as TypeTableCustom,
+  ActionButtons,
+  IconButtonData,
+  MultilineContent,
+  ModalProvider,
 } from 'scorer-ui-kit';
 import photo from '../../assets/placeholder.jpg';
-import { 
+import {
   ITableColumnConfig,
   ITypeTableData
 } from 'scorer-ui-kit/dist/Tables';
@@ -123,7 +124,7 @@ const generateConfigButtons  = (rowId: string) : IconButtonData[] => {
 
 const generateTimeRows = (initTime: string, endTime: string) : ReactElement[] =>  {
   return (
-    [ 
+    [
       <TimeText>{`${initTime} ${String.fromCharCode(160)} →`}</TimeText>,
       <TimeText>{endTime}<span>{` JST`}</span></TimeText>
     ]
@@ -135,6 +136,8 @@ const initialRows : ITypeTableData = [
     id: 'row1',
     header: {
       image: photo,
+      mediaUrl: photo,
+      mediaType: 'img',
     },
     columns: [
       {customComponent: <MultilineContent contentArray={generateTimeRows('2020/06/11 - 16:00','2020/06/11 - 21:30')}/>},
@@ -148,6 +151,8 @@ const initialRows : ITypeTableData = [
     id: 'row2',
     header: {
       image: photo,
+      mediaUrl: photo,
+      mediaType: 'img',
     },
     columns: [
       {customComponent: <MultilineContent contentArray={generateTimeRows('2020/06/11 - 13:00','2020/06/11 - 17:30')}/>},
@@ -161,6 +166,8 @@ const initialRows : ITypeTableData = [
     id: 'row3',
     header: {
       image: photo,
+      mediaUrl: photo,
+      mediaType: 'img',
     },
     columns: [
       {customComponent: <MultilineContent contentArray={generateTimeRows('2020/05/10 - 10:00','2020/05/10 - 12:30')}/>},
@@ -195,21 +202,23 @@ export const ActionsTable = () => {
     setRows(newRows);
 
   }, [rows, setRows]);
-  
 
+  // Provider should be at main Index level, it's here just for the example
   return (
-      <Container>
+    <Container>
+      <ModalProvider>
         <TypeTableCustom
           {...{
-              columnConfig,
-              rows,
-              selectable,
-              selectCallback,
-              toggleAllCallback,
-              hasThumbnail,
-            }
-          } 
+            columnConfig,
+            rows,
+            selectable,
+            selectCallback,
+            toggleAllCallback,
+            hasThumbnail,
+          }
+          }
         />
-      </Container>
-      )
+      </ModalProvider>
+    </Container>
+  )
 };

--- a/storybook/src/stories/Tables/molecules/EditableTable.stories.tsx
+++ b/storybook/src/stories/Tables/molecules/EditableTable.stories.tsx
@@ -4,12 +4,13 @@ import { object } from "@storybook/addon-knobs";
 
 
 import {TypeTable as EditableTable,
-  EditCell
+  EditCell,
+  ModalProvider,
 } from 'scorer-ui-kit';
 import photo from '../../assets/placeholder.jpg';
 import {sleep} from '../../helpers';
 
-import { 
+import {
   IRowData,
   IDeviceStatus,
   ITableColumnConfig,
@@ -129,6 +130,8 @@ export const _EditableTable = () => {
         id,
         header: {
           image: photo,
+          mediaUrl: photo,
+          mediaType: 'img',
         },
         columns:
         [ {text: jobName },
@@ -140,7 +143,7 @@ export const _EditableTable = () => {
       })
       return row;
     })
-  
+
     return newRows;
   },[updateCameraName])
 
@@ -156,15 +159,18 @@ export const _EditableTable = () => {
     }
   }, [data, buildDataRows]);
 
-  return(
+  // Provider should be at main Index level, it's here just for the example
+  return (
     <Container>
-      <EditableTable {
-        ...{
-          columnConfig: columnConfig,
-          rows,
-          hasThumbnail: true,
-        }
-      }/>
+      <ModalProvider>
+        <EditableTable {
+          ...{
+            columnConfig: columnConfig,
+            rows,
+            hasThumbnail: true,
+          }
+        } />
+      </ModalProvider>
     </Container>
   )
 };

--- a/storybook/src/stories/Tables/molecules/TypeTable.stories.tsx
+++ b/storybook/src/stories/Tables/molecules/TypeTable.stories.tsx
@@ -2,7 +2,7 @@ import React, {useState, useCallback, useEffect} from 'react';
 import styled from 'styled-components';
 import { object, boolean } from "@storybook/addon-knobs";
 
-import {TypeTable} from 'scorer-ui-kit';
+import {TypeTable, ModalProvider} from 'scorer-ui-kit';
 import photo from '../../assets/placeholder.jpg';
 import {
   IRowData,
@@ -212,6 +212,8 @@ const rowMaker = (rowData: IExampleData[]) : ITypeTableData=> {
       id,
       header: {
         image: photo,
+        mediaUrl: photo,
+        mediaType: 'img',
         icon: 'Location',
         status,
       },
@@ -330,5 +332,12 @@ export const _TypeTable = () => {
     setRows(rowMaker(data));
   }, [data])
 
-  return <Container><TypeTable {...{columnConfig, selectable, selectCallback, toggleAllCallback, rows, hasStatus, hasThumbnail, hasTypeIcon, defaultAscending:true, sortCallback, hasHeaderGroups}} /></Container>;
+  // Provider should be at main Index level, it's here just for the example
+  return (
+    <Container>
+      <ModalProvider>
+        <TypeTable {...{ columnConfig, selectable, selectCallback, toggleAllCallback, rows, hasStatus, hasThumbnail, hasTypeIcon, defaultAscending: true, sortCallback, hasHeaderGroups }} />
+      </ModalProvider>
+    </Container>
+  );
 };


### PR DESCRIPTION
### Requirements
closes Bug #142 The video currently there is no limit to he height in modal probably we should limit it
closes Feature #155 - useMediaModal hook

### Implementation

- Updated MediaBox component to limit height and width space for modal but it's retro-compatible because this is only added if prop hasModalLimits is true
- Updated modal to have isModalOpen value available since it was mention that it would be helpful
- created useMediaModal hook to manage modal and MediaBox together with some strict values like width: auto, no padding and should always be close able.
- onError, onLoad props features for MediaBox
- Zoom in TableThumbnail only available if there is preview

currently this feature can be reviewed in the demo link.
https://future-standard.github.io/scorer-ui-kit/#/table

### Screenshoot

<img width="1164" alt="Screen Shot 2021-08-06 at 11 41 04" src="https://user-images.githubusercontent.com/10409078/128447905-049378c7-de97-41ad-b502-392575ec2701.png">

Video of interaction
Basically TableThumbnail component verifies preview link works if it doesn't zoom and click is not available. 
Video and image are now responsive width and hight.

https://drive.google.com/file/d/1Qe31NbonhWJB4oqB4rw4P7wlvbbxUwVN/view?usp=sharing

