### PR TITLE
Fix  Message of no data going over line of Grouping Header

### DIFF
--- a/src/Tables/molecules/TypeTableHeader.tsx
+++ b/src/Tables/molecules/TypeTableHeader.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useCallback, Fragment, useRef, useEffect } from 'react';
+import React, { useState, useCallback, Fragment} from 'react';
 import styled, { css } from 'styled-components';
 import { TypeCellAlignment, ITableColumnConfig } from '..';
 import Checkbox from '../../Form/atoms/Checkbox';
 import TableHeaderTitle from '../atoms/TableHeaderTitle';
-import useBreakpoints from '../../hooks/useBreakpoints';
 
 const HeaderRow = styled.div`
   display: table-row;
@@ -145,7 +144,6 @@ interface ITableHeader {
   defaultAscending: boolean
   toggleAllCallback?: (checked: boolean) => void
   sortCallback?: (ascending: boolean, columnId: string) => void
-  handleHeightCallback?: (newHeight: number) => void
 }
 
 const TypeTableHeader: React.FC<ITableHeader> = ({
@@ -161,7 +159,6 @@ const TypeTableHeader: React.FC<ITableHeader> = ({
   defaultAscending,
   toggleAllCallback = () => { },
   sortCallback = () => { },
-  handleHeightCallback = () => { },
 }) => {
 
   const [sortSpec, setSortSpec] = useState(columnConfig);
@@ -204,20 +201,8 @@ const TypeTableHeader: React.FC<ITableHeader> = ({
     setAscendingState(newAscending);
   }, [ascendingState, sortCallback, sortSpec]);
 
-  const headerRef = useRef<HTMLDivElement>(null);
-  const { activeScreen } = useBreakpoints();
-
-  useEffect(() => {
-    if (headerRef !== null && headerRef.current) {
-      const newHeight = headerRef.current.getBoundingClientRect().height;
-      if (newHeight) {
-        handleHeightCallback(newHeight);
-      }
-    }
-  }, [headerRef, activeScreen]);
-
   return (
-    <HeaderRow ref={headerRef}>
+    <HeaderRow>
       {selectable ? (
         <HeaderItem headerStyle='header' fixedWidth={30}>
           <Checkbox checked={allChecked} disabled={isEmptyTable || isLoading} onChangeCallback={toggleAllCallbackWrapper} />

--- a/src/Tables/molecules/TypeTableHeader.tsx
+++ b/src/Tables/molecules/TypeTableHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, Fragment} from 'react';
+import React, { useState, useCallback, Fragment } from 'react';
 import styled, { css } from 'styled-components';
 import { TypeCellAlignment, ITableColumnConfig } from '..';
 import Checkbox from '../../Form/atoms/Checkbox';

--- a/src/Tables/molecules/TypeTableHeader.tsx
+++ b/src/Tables/molecules/TypeTableHeader.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useCallback, Fragment } from 'react';
+import React, { useState, useCallback, Fragment, useRef, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { TypeCellAlignment, ITableColumnConfig } from '..';
 import Checkbox from '../../Form/atoms/Checkbox';
 import TableHeaderTitle from '../atoms/TableHeaderTitle';
+import useBreakpoints from '../../hooks/useBreakpoints';
 
-const HeaderRow = styled.div<{ HEADER_HEIGHT: string }>`
+const HeaderRow = styled.div`
   display: table-row;
-  height: ${({ HEADER_HEIGHT }) => HEADER_HEIGHT};
+  height: 50px;
 `;
 
 const HeaderItem = styled.div<{ fixedWidth?: number, alignment?: TypeCellAlignment, hasCopyButton?: boolean, minWidth?: number, headerStyle: string, isSortActive?: boolean }>`
@@ -142,9 +143,9 @@ interface ITableHeader {
   hasHeaderGroups: boolean
   columnConfig: ITableColumnConfig[]
   defaultAscending: boolean
-  HEADER_HEIGHT: string
   toggleAllCallback?: (checked: boolean) => void
   sortCallback?: (ascending: boolean, columnId: string) => void
+  handleHeightCallback?: (newHeight: number) => void
 }
 
 const TypeTableHeader: React.FC<ITableHeader> = ({
@@ -158,9 +159,9 @@ const TypeTableHeader: React.FC<ITableHeader> = ({
   hasHeaderGroups,
   columnConfig,
   defaultAscending,
-  HEADER_HEIGHT,
   toggleAllCallback = () => { },
   sortCallback = () => { },
+  handleHeightCallback = () => { },
 }) => {
 
   const [sortSpec, setSortSpec] = useState(columnConfig);
@@ -203,8 +204,20 @@ const TypeTableHeader: React.FC<ITableHeader> = ({
     setAscendingState(newAscending);
   }, [ascendingState, sortCallback, sortSpec]);
 
+  const headerRef = useRef<HTMLDivElement>(null);
+  const { activeScreen } = useBreakpoints();
+
+  useEffect(() => {
+    if (headerRef !== null && headerRef.current) {
+      const newHeight = headerRef.current.getBoundingClientRect().height;
+      if (newHeight) {
+        handleHeightCallback(newHeight);
+      }
+    }
+  }, [headerRef, activeScreen]);
+
   return (
-    <HeaderRow {...{ HEADER_HEIGHT }}>
+    <HeaderRow ref={headerRef}>
       {selectable ? (
         <HeaderItem headerStyle='header' fixedWidth={30}>
           <Checkbox checked={allChecked} disabled={isEmptyTable || isLoading} onChangeCallback={toggleAllCallbackWrapper} />

--- a/src/Tables/organisms/TypeTable.tsx
+++ b/src/Tables/organisms/TypeTable.tsx
@@ -1,11 +1,9 @@
-import React, {useEffect, useState} from 'react';
-import styled from 'styled-components';
+import React, {useCallback, useEffect, useState} from 'react';
+import styled, {css} from 'styled-components';
 import Spinner from '../../Indicators/Spinner';
 import TypeTableRow from '../atoms/TypeTableRow';
 import {ITableColumnConfig, ITypeTableData, IRowData} from '..';
 import TypeTableHeader from '../molecules/TypeTableHeader';
-
-const HEADER_HEIGHT = `50px`;
 
 const Container = styled.div``;
 
@@ -19,17 +17,20 @@ const LoadingText = styled.div`
   color: hsla(195, 10%, 52%, 0.72);
 `;
 
-const LoadingBox = styled.div`
+const LoadingBox = styled.div<{headerHeight: number}>`
   position: absolute;
   top: 0;
   left: 0;
   z-index: 99;
   background-color: ${({ theme }) => theme.colors["pureBase"]};
+  ${({headerHeight}) => headerHeight && css`
+    height: calc(100% - ${headerHeight}px);
+    margin-top: ${headerHeight}px;
+  `}
+
   opacity: 85%;
   width: 100%;
   min-height: 100px;
-  height: calc(100% - ${HEADER_HEIGHT});
-  margin-top: ${HEADER_HEIGHT};
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -41,12 +42,13 @@ const LoadingBox = styled.div`
   }
 `;
 
-const EmptyTableBox = styled.div`
+const EmptyTableBox = styled.div<{headerHeight: number}>`
   position: absolute;
   top: 0;
   left: 0;
   z-index: 99;
-  margin-top: ${HEADER_HEIGHT};
+  margin-top: ${({headerHeight}) => headerHeight}px;
+  padding: 20px;
   width: 100%;
   min-height: 100px;
   text-align: center;
@@ -106,6 +108,7 @@ const TypeTable: React.FC<IProps> = ({
   */
 
   const [allChecked, setAllChecked] = useState(false);
+  const [headerHeight, setHeaderHeight] = useState<number>(50);
   const isEmptyTable = (rows.length === 1) && (rows[0].columns.length === 0) && (!isLoading);
 
   useEffect(() => {
@@ -115,6 +118,10 @@ const TypeTable: React.FC<IProps> = ({
     }
     setAllChecked(areAllChecked);
   }, [isEmptyTable, rows]);
+
+  const handleHeightCallback = useCallback((newValue: number) => {
+    setHeaderHeight(newValue);
+  },[]);
 
   return (
     <Container>
@@ -133,18 +140,18 @@ const TypeTable: React.FC<IProps> = ({
             columnConfig,
             toggleAllCallback,
             sortCallback,
-            HEADER_HEIGHT,
+            handleHeightCallback,
             }}
         />
         {isLoading ? (
-          <LoadingBox>
+          <LoadingBox {...{headerHeight}}>
             <Spinner size='large' styling='primary' />
             <LoadingText>{loadingText}</LoadingText>
           </LoadingBox>
         ) : null}
         {isEmptyTable
           ? (
-            <EmptyTableBox>
+            <EmptyTableBox {...{headerHeight}}>
               <h3>{emptyTableTitle}</h3>
               <p>{emptyTableText}</p>
             </EmptyTableBox>

--- a/src/Tables/organisms/TypeTable.tsx
+++ b/src/Tables/organisms/TypeTable.tsx
@@ -1,5 +1,5 @@
-import React, {useCallback, useEffect, useState} from 'react';
-import styled, {css} from 'styled-components';
+import React, {useEffect, useState} from 'react';
+import styled from 'styled-components';
 import Spinner from '../../Indicators/Spinner';
 import TypeTableRow from '../atoms/TypeTableRow';
 import {ITableColumnConfig, ITypeTableData, IRowData} from '..';
@@ -17,17 +17,12 @@ const LoadingText = styled.div`
   color: hsla(195, 10%, 52%, 0.72);
 `;
 
-const LoadingBox = styled.div<{headerHeight: number}>`
+const LoadingBox = styled.div`
   position: absolute;
-  top: 0;
   left: 0;
   z-index: 99;
   background-color: ${({ theme }) => theme.colors["pureBase"]};
-  ${({headerHeight}) => headerHeight && css`
-    height: calc(100% - ${headerHeight}px);
-    margin-top: ${headerHeight}px;
-  `}
-
+  height: calc(100% - 50px);
   opacity: 85%;
   width: 100%;
   min-height: 100px;
@@ -42,12 +37,10 @@ const LoadingBox = styled.div<{headerHeight: number}>`
   }
 `;
 
-const EmptyTableBox = styled.div<{headerHeight: number}>`
+const EmptyTableBox = styled.div`
   position: absolute;
-  top: 0;
   left: 0;
   z-index: 99;
-  margin-top: ${({headerHeight}) => headerHeight}px;
   padding: 20px;
   width: 100%;
   min-height: 100px;
@@ -61,7 +54,7 @@ const EmptyTableBox = styled.div<{headerHeight: number}>`
 
 const isChecked = ({ _checked = false }: IRowData) => {
   return _checked === true;
-}
+};
 
 interface IProps {
   columnConfig: ITableColumnConfig[]
@@ -108,7 +101,6 @@ const TypeTable: React.FC<IProps> = ({
   */
 
   const [allChecked, setAllChecked] = useState(false);
-  const [headerHeight, setHeaderHeight] = useState<number>(50);
   const isEmptyTable = (rows.length === 1) && (rows[0].columns.length === 0) && (!isLoading);
 
   useEffect(() => {
@@ -119,15 +111,11 @@ const TypeTable: React.FC<IProps> = ({
     setAllChecked(areAllChecked);
   }, [isEmptyTable, rows]);
 
-  const handleHeightCallback = useCallback((newValue: number) => {
-    setHeaderHeight(newValue);
-  },[]);
-
   return (
     <Container>
       <TableContainer>
         <TypeTableHeader
-            {...{
+          {...{
             selectable,
             hasStatus,
             hasThumbnail,
@@ -140,18 +128,17 @@ const TypeTable: React.FC<IProps> = ({
             columnConfig,
             toggleAllCallback,
             sortCallback,
-            handleHeightCallback,
-            }}
+          }}
         />
         {isLoading ? (
-          <LoadingBox {...{headerHeight}}>
+          <LoadingBox>
             <Spinner size='large' styling='primary' />
             <LoadingText>{loadingText}</LoadingText>
           </LoadingBox>
         ) : null}
         {isEmptyTable
           ? (
-            <EmptyTableBox {...{headerHeight}}>
+            <EmptyTableBox>
               <h3>{emptyTableTitle}</h3>
               <p>{emptyTableText}</p>
             </EmptyTableBox>

--- a/src/Tables/organisms/TypeTable.tsx
+++ b/src/Tables/organisms/TypeTable.tsx
@@ -1,8 +1,8 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Spinner from '../../Indicators/Spinner';
 import TypeTableRow from '../atoms/TypeTableRow';
-import {ITableColumnConfig, ITypeTableData, IRowData} from '..';
+import { ITableColumnConfig, ITypeTableData, IRowData } from '..';
 import TypeTableHeader from '../molecules/TypeTableHeader';
 
 const Container = styled.div``;
@@ -92,20 +92,20 @@ const TypeTable: React.FC<IProps> = ({
   toggleAllCallback = () => { },
 }) => {
 
-    /* Note about Empty table
-    Currently IRowData Type enforces user to send columns
-    so rows length will always be at least 1
-    I wasn't sure if I should edit IRowData to have columns optional
-    If we allow columns to be optional, previous implementations
-    wont be able to have "No data" Message
-  */
+  /* Note about Empty table
+  Currently IRowData Type enforces user to send columns
+  so rows length will always be at least 1
+  I wasn't sure if I should edit IRowData to have columns optional
+  If we allow columns to be optional, previous implementations
+  wont be able to have "No data" Message
+*/
 
   const [allChecked, setAllChecked] = useState(false);
   const isEmptyTable = (rows.length === 1) && (rows[0].columns.length === 0) && (!isLoading);
 
   useEffect(() => {
     let areAllChecked = false;
-    if(rows.every(isChecked) && (rows.length > 0) && !isEmptyTable) {
+    if (rows.every(isChecked) && (rows.length > 0) && !isEmptyTable) {
       areAllChecked = true;
     }
     setAllChecked(areAllChecked);
@@ -149,14 +149,15 @@ const TypeTable: React.FC<IProps> = ({
           return (
             <TypeTableRow
               key={key} {...{
-              rowData,
-              isLastRow,
-              selectable,
-              selectCallback,
-              columnConfig,
-              hasStatus,
-              hasThumbnail,
-              hasTypeIcon}}
+                rowData,
+                isLastRow,
+                selectable,
+                selectCallback,
+                columnConfig,
+                hasStatus,
+                hasThumbnail,
+                hasTypeIcon
+              }}
             />
           );
         })}

--- a/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
+++ b/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
@@ -5,7 +5,7 @@ import {boolean, text, object} from "@storybook/addon-knobs";
 import {TypeTable as LoadingTable } from 'scorer-ui-kit';
 import photo from '../../assets/placeholder.jpg';
 
-import { 
+import {
   ITableColumnConfig,
   ITypeTableData
 } from 'scorer-ui-kit/dist/Tables';
@@ -24,19 +24,22 @@ const Container = styled.div`
 const columnConfigSample : ITableColumnConfig[] = [
   {
     header: 'When',
+    groupTitle: 'Time',
     sortable: false,
     cellStyle: 'normalImportance',
     minWidth: 200,
   },
   {
     header: 'Status',
+    groupTitle: 'Metadata',
     sortable: false,
     cellStyle: 'normalImportance',
     showStatus: true,
     minWidth: 200,
   },
   {
-    header: 'Temperature',
+    header: 'The Highest Temperature Recorded',
+    groupTitle: 'Metadata',
     sortable: false,
     cellStyle: 'normalImportance',
     minWidth: 200,
@@ -104,12 +107,12 @@ const dataRows : ITypeTableData = [
 export const _LoadingTable = () => {
   const isLoading = boolean("IsLoading", true);
   const emptyTable = boolean("Show Empty Table", true);
-  const emptyTableTitle = text("emptyTableTitle","No Data Available"); 
+  const emptyTableTitle = text("emptyTableTitle","No Data Available");
   const emptyTableText = text("emptyTableText", 'There is currently no data');
   const loadingText = text("loadingText", 'Loading Data..')
   const columnConfig = object("Column Configuration", columnConfigSample);
   const selectable = boolean("Selectable Rows", true);
-  
+
   const [rows, setRows] = useState<ITypeTableData>(initialRows);
 
   const toggleAllCallback = useCallback((checked:boolean) => {
@@ -127,9 +130,9 @@ export const _LoadingTable = () => {
       const newRows = [...rows];
       const targetRowIndex = newRows.findIndex(row => row.id === id)
       newRows[targetRowIndex]._checked = checked;
-  
+
       setRows(newRows);
-  
+
     }, [rows, setRows]);
 
   useEffect(() => {
@@ -143,10 +146,11 @@ export const _LoadingTable = () => {
     }
   }, [emptyTable])
 
-  return(
+  return (
     <Container>
-      <LoadingTable {
-        ...{
+      <LoadingTable
+        hasHeaderGroups
+        {...{
           columnConfig,
           rows,
           toggleAllCallback,
@@ -156,9 +160,9 @@ export const _LoadingTable = () => {
           loadingText,
           hasThumbnail: true,
           emptyTableTitle,
-          emptyTableText
-        }
-      }/>
+          emptyTableText,
+        }}
+      />
     </Container>
   )
 

--- a/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
+++ b/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
@@ -110,8 +110,10 @@ export const _LoadingTable = () => {
   const emptyTableTitle = text("emptyTableTitle","No Data Available");
   const emptyTableText = text("emptyTableText", 'There is currently no data');
   const loadingText = text("loadingText", 'Loading Data..')
-  const columnConfig = object("Column Configuration", columnConfigSample);
   const selectable = boolean("Selectable Rows", true);
+  const hasGroups = boolean('Has Header Groups', true);
+  const columnConfig = object("Column Configuration", columnConfigSample);
+
 
   const [rows, setRows] = useState<ITypeTableData>(initialRows);
 
@@ -149,7 +151,7 @@ export const _LoadingTable = () => {
   return (
     <Container>
       <LoadingTable
-        hasHeaderGroups
+        hasHeaderGroups={hasGroups}
         {...{
           columnConfig,
           rows,


### PR DESCRIPTION
### Requirement
This is a PR to fix the error on issue 144
closes #144  - Subheader of Grouping table goes over the message of no data 

### Implementation
The problem was that the Height Header was fixed to 50px (although because is display: table, height behaves as min-height).  Now with grouping is about 59px we need to contemplate this situation  and sometimes titles are long and have two lines which increments the height.

Now height is calculated and saved in a state and passed to the LoadingBox and the EmptyTableBox.
However notice that this is calculated on mount and re-calculated only onBreakpoint Change with the hook.

I added the hasHeaderGroups prop selection on Storybook but Storybook can't handle this well  because the Storybook wont remount the component when the hasHeaderGroups changes. 😞

I'm adding screenshoots that I took by sending false and true on the hasHeaderGroups from the beginning, to show that this will be rendered correctly although changing the prop on the fly will look like it doesn't.


### Screenshoots

#### No data with hasHeaderGroups
<img width="1177" alt="Screen Shot 2021-08-23 at 20 33 16" src="https://user-images.githubusercontent.com/10409078/130440976-9fc9eba7-07f1-42f6-b542-9eeb63ba4dd2.png">

#### No data without hasHeaderGroups

<img width="1026" alt="Screen Shot 2021-08-23 at 20 34 27" src="https://user-images.githubusercontent.com/10409078/130441112-af2c5d5b-c66f-4870-9d43-c9bcf5cb4e98.png">

#### Loading with hasHeaderGroups
<img width="1136" alt="Screen Shot 2021-08-23 at 20 35 31" src="https://user-images.githubusercontent.com/10409078/130441167-badc305c-6ee2-4e7c-ac55-b8e1960d50f9.png">


#### Loading without hasHeaderGroups

<img width="1096" alt="Screen Shot 2021-08-23 at 20 34 34" src="https://user-images.githubusercontent.com/10409078/130441193-e3e35a88-3c90-4a8c-9620-93f471cbb019.png">


