### PR TITLE
Add missing disable values of theme of SmallInput

### DIFF
--- a/src/Form/atoms/SmallInput.tsx
+++ b/src/Form/atoms/SmallInput.tsx
@@ -32,6 +32,9 @@ const StyledInput = styled.input<{ fieldState : TypeFieldState, padRight?: numbe
     padding-right: ${p.padRight + 17}px;
   `}
 
+  &:disabled {
+    cursor: not-allowed;
+  }
 `;
 
 const InputContainer = styled.div<{hasAction?: boolean}>`

--- a/src/themes/light/styles.js
+++ b/src/themes/light/styles.js
@@ -24,7 +24,13 @@ export const styles = {
                 "normal": {
                     "backgroundColor": "hsla(206, 36.8%, 96.3%, 1.000)",
                     "borderColor": "hsla(120, 1.3%, 85.3%, 1.000)"
-                }
+                },
+                "focused": {
+                  "boxShadow": "0px 3px 7px 0px hsla(207, 65.8%, 31%, 0.078)",
+                  "backgroundColor": "hsla(0, 0%, 100%, 1.000)",
+                  "borderColor": "hsla(205, 58.9%, 71.4%, 1.000)"
+                },
+
             },
             "subdivision": {
                 "backgroundColor": "hsla(120, 1.3%, 85.3%, 1.000)"

--- a/storybook/src/stories/Form/Input/SmallInput.stories.tsx
+++ b/storybook/src/stories/Form/Input/SmallInput.stories.tsx
@@ -22,6 +22,16 @@ export const _SmallInput = () => {
   const inputPlaceholder = text("Placeholder", "Placeholder...");
   const inputState = select("State", { Default: "default",  Disabled: 'disabled', Required: 'required',  Valid: 'valid',  Invalid: 'invalid', Processing: 'processing' }, "default");
 
-  return <Container><SmallInput type={inputType} unit={inputUnit} name={inputName} label={inputLabel} placeholder={inputPlaceholder} fieldState={inputState} /></Container>;
+  return <Container>
+    <SmallInput
+      type={inputType}
+      unit={inputUnit}
+      name={inputName}
+      label={inputLabel}
+      placeholder={inputPlaceholder}
+      fieldState={inputState}
+      disabled={inputState === 'disabled'}
+    />
+  </Container>;
 
 };


### PR DESCRIPTION
### Requirements

closes #118 
[Storybook] In Form -> Input -> Small Input, error appears when State=Disabled. 

### Implementation
It was failing because disable focus was assigned but missing in theme.
Copied the values of disable normal.

No disable assignation value provided in storybook for the input value, although it doesn't break, the visual value would not appear correctly when disable "state" was provided. Also added the "not allowed" cursor when disable was true.

### Screenshoots
<img width="853" alt="Screen Shot 2021-08-24 at 12 56 50" src="https://user-images.githubusercontent.com/10409078/130553477-b2da201d-e369-4515-b7f0-949e515bbd2c.png">
