### PR TITLE
Update StatusIcon with or without status has same size

### DIFF
--- a/src/Icons/StatusIcon.tsx
+++ b/src/Icons/StatusIcon.tsx
@@ -53,7 +53,7 @@ const StatusIcon: React.FC<IStatusIcon> = ({icon, status, counter}) => {
       {status && (counter === undefined)
         ? <StatusDot color={status} />
         :  (counter === undefined) ? null : <StatusCounter color={status}>{counter}</StatusCounter>}
-      <Icon icon={icon} size={status && (counter === undefined) ? 14 : 18} color='dimmed' />
+      <Icon icon={icon} size={18} color='dimmed' />
     </Container>
   );
 };


### PR DESCRIPTION
### Description
Status icon is smaller than expected in real cases. 
There was a change request to have the same size regardless if it will have a Status Dot or not.


### Screenshots
Before
<img width="708" alt="Screen Shot 2021-09-23 at 21 30 06" src="https://user-images.githubusercontent.com/10409078/134506895-f1651aad-5627-46cb-a3e3-976bbf98e508.png">

After
<img width="1273" alt="Screen Shot 2021-09-23 at 21 25 42" src="https://user-images.githubusercontent.com/10409078/134506826-83aa683a-5a4d-47f5-ae5f-4b7dd63aeb62.png">
 
