### PR TITLE
Feature/icons multiple enhancements

### DIFF
--- a/src/Icons/Icon.tsx
+++ b/src/Icons/Icon.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import styled from 'styled-components';
-import {IconSVGs} from  '@future-standard/icons';
+import { IconSVGs } from '@future-standard/icons';
 
 import { dimensions } from '../themes/common';
 
-
-const IconWrapper = styled.div<{color:string}>`
-[stroke]{
-  stroke: ${({theme, color}) => theme.colors.icons[color]};
-}
+const IconWrapper = styled.div<{ color: string }>`
+  [stroke]{
+    stroke: ${({ theme, color }) => theme.colors.icons[color]};
+  }
+  svg {
+    overflow: visible;
+    vector-effect: non-scaling-stroke;
+    line, path, circle, ellipse, foreignObject, polygon, polyline, rect, text, textPath, tspan {
+    vector-effect: non-scaling-stroke;
+  }
+  }
 `;
 
-export {IconWrapper, IconSVGs};
+export { IconWrapper, IconSVGs };
 
 export interface IconProps {
   icon: string;
@@ -21,13 +27,13 @@ export interface IconProps {
 }
 interface ISvgIcon extends React.SVGProps<SVGSVGElement> {
   size: number
-  color:string
+  color: string
   weight: number
 }
 
-const Icon : React.FC<IconProps> = ({icon, size = 24, weight = 'regular', color = 'mono'}) => {
+const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'mono' }) => {
 
-  const iconWeight : number = dimensions.icons.weights[weight];
+  const iconWeight: number = dimensions.icons.weights[weight];
   //@ts-ignore
   const IconSVG = IconSVGs[icon];
 

--- a/src/Icons/Icon.tsx
+++ b/src/Icons/Icon.tsx
@@ -16,7 +16,7 @@ export {IconWrapper, IconSVGs};
 export interface IconProps {
   icon: string;
   size?: number;
-  weight?: 'light' | 'regular' | 'heavy'
+  weight?: 'light' | 'regular' | 'heavy' | 'strong'
   color?: ISvgIcons['color']
 }
 interface ISvgIcon extends React.SVGProps<SVGSVGElement> {

--- a/src/Misc/atoms/BasicSearchInput.tsx
+++ b/src/Misc/atoms/BasicSearchInput.tsx
@@ -68,13 +68,13 @@ export type IBasicSearchInput = OwnProps & InputHTMLAttributes<HTMLInputElement>
 const BasicSearchInput: React.FC<IBasicSearchInput> = ({
   color = 'subtle',
   hasBorder = true,
-  iconSize = 11,
+  iconSize = 12,
   disabled = false,
   ...props
 }) => {
   return (
     <Container {...{ hasBorder, disabled }}>
-      <Icon {...{ color }} icon='Search' weight='heavy' size={iconSize} />
+      <Icon {...{ color }} icon='Search' weight='regular' size={iconSize} />
       <StyledInput
         {...{ color, disabled }}
         {...props}

--- a/src/themes/common.tsx
+++ b/src/themes/common.tsx
@@ -8,7 +8,8 @@ export const dimensions = {
     weights: {
       light: 1,
       regular: 1.5,
-      heavy: 2
+      heavy: 3,
+      strong: 5
     }
   },
   form: {

--- a/storybook/src/stories/Misc/Icons.stories.tsx
+++ b/storybook/src/stories/Misc/Icons.stories.tsx
@@ -50,7 +50,7 @@ export const _Icons = () => {
   const showAll = boolean("Show All", false);
   const iconName = select("Name", iconList, Object.keys(iconList)[0]);
   const iconColor = select("Color", { Mono: "mono", Dimmed: "dimmed", Subtle: "subtle", Inverse: "inverse", Primary: "primary" , Danger: "danger"}, "mono");
-  const iconWeight = select("Weight", { Light: "light", Regular: "regular", Heavy: "heavy" }, "regular");
+  const iconWeight = select("Weight", { Light: "light", Regular: "regular", Heavy: "heavy", Strong: 'strong' }, "regular");
   const iconSize = number("Size", 24);
 
   /**

--- a/storybook/src/stories/Misc/Icons.stories.tsx
+++ b/storybook/src/stories/Misc/Icons.stories.tsx
@@ -66,7 +66,7 @@ export const _Icons = () => {
 
   return <Container>
     {showAll ? <>
-      <Grid>{generateIconGrid({ color: iconColor, weight: 'regular', size: 24  })}</Grid>
+      <Grid>{generateIconGrid({ color: iconColor, weight:iconWeight, size: iconSize })}</Grid>
     </> : <Icon icon={iconName} weight={iconWeight} color={iconColor} size={iconSize} />}
 
   </Container>;

--- a/storybook/src/stories/Misc/atoms/BasicSearchInput.stories.tsx
+++ b/storybook/src/stories/Misc/atoms/BasicSearchInput.stories.tsx
@@ -20,7 +20,7 @@ export const _BasicSearchInput = () => {
   const textValue = action('Search value');
   const hasBorder = boolean('Has border', true);
   const color = select("Color", { Mono: "mono", Dimmed: "dimmed", Subtle: "subtle"}, "subtle");
-  const iconSize = number('Icon size', 11);
+  const iconSize = number('Icon size', 12);
   const disabled = boolean('Disabled', false)
 
   const handleChange = useCallback((e) => {


### PR DESCRIPTION
## PR Template
 
 ### Description (Required)
 closes #166 
 Icon rendering issues



 ### Implementation
 I tried the CSS way, but I'm not sure it was achieved well. I compare it to the previous implementation and I see no difference. However the zeplin design shows that this is how it should look, but probably is also complicated to compare because the example icons are not heavy in lines. 

 Please advice in this point of vector-effect="non-scaling-stroke" before I proceed to try modifying the templating.
 
 
 ### Screenshoots
 
 
<img width="1015" alt="Screen Shot 2021-10-08 at 10 20 49" src="https://user-images.githubusercontent.com/10409078/136483418-d2399704-1ee3-41fb-81a9-c042878b1f9b.png">


 