### PR TITLE
Fix missing display block in spans Label

### DIFF
--- a/src/Form/atoms/Label.tsx
+++ b/src/Form/atoms/Label.tsx
@@ -22,13 +22,13 @@ export const StyledLabel = styled.label<{ rightAlign: boolean }>`
 `;
 
 const LabelText = styled.span<{ rightAlign: boolean }>`
-${({ rightAlign }) => rightAlign
-    ? `
-      margin-left: 12px;
-      `
-    : `
-      display: block;
-      margin-bottom: 10px;
+  display: block;
+  ${({ rightAlign }) => rightAlign
+      ? `
+        margin-left: 12px;
+        `
+      : `
+        margin-bottom: 10px;
       `
   }
 `;

--- a/src/Form/atoms/Label.tsx
+++ b/src/Form/atoms/Label.tsx
@@ -22,8 +22,15 @@ export const StyledLabel = styled.label<{ rightAlign: boolean }>`
 `;
 
 const LabelText = styled.span<{ rightAlign: boolean }>`
-  margin-bottom: ${({ rightAlign }) => rightAlign ? '0px' : '10px'};
-  margin-left:  ${({ rightAlign }) => rightAlign ? '12px' : '0px'};
+${({ rightAlign }) => rightAlign
+    ? `
+      margin-left: 12px;
+      `
+    : `
+      display: block;
+      margin-bottom: 10px;
+      `
+  }
 `;
 
 interface OwnProps {


### PR DESCRIPTION
### Description

This PR fixes #216 - Missing bottom margin in label


 ### Considerations on Implementation
 I made an update in Filter Bars to have Labels that could be right align but I missed a display:block property in the span that previously had, now is fixed and all is retro-compatible.

 ### Screenshoot
 
You can review this in Text Input component
Here you can see the Fix and how it's behaving currently.

<img width="931" alt="Screen Shot 2021-11-17 at 10 24 21" src="https://user-images.githubusercontent.com/10409078/142092581-da6382e9-f72a-4831-8655-ea687b3c273e.png">
