### PR TITLE
Fix submenu getting max-height 0 in language transition

### DIFF
--- a/src/Global/atoms/NavigationItem.tsx
+++ b/src/Global/atoms/NavigationItem.tsx
@@ -156,7 +156,7 @@ const NavigationItem : React.FC<IProps> = ({item, menuOpen, submenuOpen, context
   const hasSubmenu : boolean = submenus.length > 0;
 
   useEffect(() => {
-    if(refSubmenu && refSubmenu.current){
+    if(refSubmenu && refSubmenu.current && refSubmenu.current.clientHeight !== 0){
       setSubmenuHeight(refSubmenu.current.clientHeight);
     }
 


### PR DESCRIPTION
### Description

 closes #224 - SubMenu missing after translation

 ### Considerations on Implementation
There is a ref to the div of the submenu and it seems that it becomes 0 when it changes from one language to another.
I have added a condition to prevent to be updated to 0, but want to do beta test to verify.

<img width="1777" alt="Screen Shot 2021-11-19 at 16 44 27" src="https://user-images.githubusercontent.com/10409078/142589837-8df89855-7441-465b-963a-42385eab923f.png">


