### PR TITLE
Fix: bug in tab component when onClick gets washed out by local onclick

### DIFF
--- a/src/Tabs/atoms/Tab.tsx
+++ b/src/Tabs/atoms/Tab.tsx
@@ -30,15 +30,16 @@ interface OwnProps {
 
 type Props = OwnProps & HTMLAttributes<HTMLDivElement>
 
-const Tab: React.FC<Props> = ({ children, tabFor, ...props }) => {
+const Tab: React.FC<Props> = ({ children, tabFor, onClick, ...props }) => {
   const { selected, setSelected }: ContextProps = useContext(TabContext);
 
-  const onChangeTab = useCallback((tabId: string) => {
-    setSelected(tabId);
-  }, [setSelected]);
+  const onChangeTab = useCallback((event:React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    onClick && onClick(event);
+    setSelected(tabFor);
+  }, [onClick, setSelected, tabFor]);
 
   return (
-    <TabComponent {...props} onClick={() => onChangeTab(tabFor)}>
+    <TabComponent {...props} onClick={onChangeTab}>
       <TabLabel active={selected === tabFor}>
         {children}
       </TabLabel>

--- a/src/Tabs/index.ts
+++ b/src/Tabs/index.ts
@@ -1,4 +1,4 @@
-export { Tabs } from './Tabs';
+export { Tabs, TabContext } from './Tabs';
 export { TabList } from './TabList';
 export { Tab } from './atoms/Tab';
 export { TabContent } from './TabContent';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,6 +166,7 @@ import {
 // Tabs
 import {
   Tabs,
+  TabContext,
   Tab,
   TabList,
   TabContent,
@@ -288,6 +289,7 @@ export {
 
   // Tabs
   Tabs,
+  TabContext,
   Tab,
   TabList,
   TabContent,


### PR DESCRIPTION
### Description

Fix but in tab component where `onClick` is not passed down to tab component. 
Also exported Tabs context so we can make custom tab components that subscribe to the context.

 ### Reviewing/Testing steps

Test Tab with onClick