### PR TITLE
Feature/svg mode for icons

### DIFF
--- a/src/Icons/Icon.tsx
+++ b/src/Icons/Icon.tsx
@@ -25,11 +25,6 @@ export interface IconProps {
   weight?: 'light' | 'regular' | 'heavy' | 'strong'
   color?: ISvgIcons['color']
 }
-interface ISvgIcon extends React.SVGProps<SVGSVGElement> {
-  size: number
-  color: string
-  weight: number
-}
 
 const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'mono' }) => {
 

--- a/src/Icons/Icon.tsx
+++ b/src/Icons/Icon.tsx
@@ -1,42 +1,54 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 import { IconSVGs } from '@future-standard/icons';
 
 import { dimensions } from '../themes/common';
 
-const IconWrapper = styled.div<{ color: string }>`
-  [stroke]{
-    stroke: ${({ theme, color }) => theme.colors.icons[color]};
-  }
+const wrapperCss = css`
   svg {
     overflow: visible;
     vector-effect: non-scaling-stroke;
+
     line, path, circle, ellipse, foreignObject, polygon, polyline, rect, text, textPath, tspan {
-    vector-effect: non-scaling-stroke;
+      vector-effect: non-scaling-stroke;
+    }
   }
-  }
+`
+const IconWrapper = styled.div`
+  ${wrapperCss};
 `;
 
-export { IconWrapper, IconSVGs };
+const IconWrapperForSVG = styled.g`
+  ${wrapperCss};
+`;
+
+export { IconWrapper, IconWrapperForSVG, IconSVGs };
 
 export interface IconProps {
   icon: string;
   size?: number;
   weight?: 'light' | 'regular' | 'heavy' | 'strong'
   color?: ISvgIcons['color']
+  forSvgUsage?: boolean
 }
 
-const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'mono' }) => {
+const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'mono', forSvgUsage = false }) => {
 
+  const theme : any = useTheme();
   const iconWeight: number = dimensions.icons.weights[weight];
   //@ts-ignore
   const IconSVG = IconSVGs[icon];
 
   return (
     IconSVG != null ?
-      <IconWrapper color={color}>
-        {IconSVG({ size: size, weight: iconWeight, color: '#666' })}
-      </IconWrapper>
+      forSvgUsage ?
+        <IconWrapperForSVG>
+          {IconSVG({ size: size, weight: iconWeight, color: theme.colors.icons[color] })}
+        </IconWrapperForSVG>
+        :
+        <IconWrapper>
+          {IconSVG({ size: size, weight: iconWeight, color: theme.colors.icons[color] })}
+        </IconWrapper>
       :
       null
   );

--- a/src/Icons/Icon.tsx
+++ b/src/Icons/Icon.tsx
@@ -13,7 +13,7 @@ const wrapperCss = css`
       vector-effect: non-scaling-stroke;
     }
   }
-`
+`;
 const IconWrapper = styled.div`
   ${wrapperCss};
 `;

--- a/storybook/src/stories/Misc/Icons.stories.tsx
+++ b/storybook/src/stories/Misc/Icons.stories.tsx
@@ -48,10 +48,11 @@ export const _Icons = () => {
   const iconList = generateIconList();
 
   const showAll = boolean("Show All", false);
-  const iconName = select("Name", iconList, Object.keys(iconList)[0]);
-  const iconColor = select("Color", { Mono: "mono", Dimmed: "dimmed", Subtle: "subtle", Inverse: "inverse", Primary: "primary" , Danger: "danger"}, "mono");
-  const iconWeight = select("Weight", { Light: "light", Regular: "regular", Heavy: "heavy", Strong: 'strong' }, "regular");
-  const iconSize = number("Size", 24);
+  const forSvgUsage = boolean("For SVG Usage", false);
+  const icon = select("Name", iconList, Object.keys(iconList)[0]);
+  const color = select("Color", { Mono: "mono", Dimmed: "dimmed", Subtle: "subtle", Inverse: "inverse", Primary: "primary" , Danger: "danger"}, "mono");
+  const weight = select("Weight", { Light: "light", Regular: "regular", Heavy: "heavy", Strong: 'strong' }, "regular");
+  const size = number("Size", 24);
 
   /**
    * Generate a grid of all the icons for easy browsing and hovering to find names.
@@ -66,8 +67,8 @@ export const _Icons = () => {
 
   return <Container>
     {showAll ? <>
-      <Grid>{generateIconGrid({ color: iconColor, weight:iconWeight, size: iconSize })}</Grid>
-    </> : <Icon icon={iconName} weight={iconWeight} color={iconColor} size={iconSize} />}
+      <Grid>{generateIconGrid({...{color, weight, size, forSvgUsage}})}</Grid>
+    </> : <Icon {...{icon, weight, color, size, forSvgUsage}} />}
 
   </Container>;
 };


### PR DESCRIPTION
### Description

As there was a need to use icons within an SVG (for Line UI purposes) we needed to add an option to make this SVG friendly as the `div` wrapper was invalid.

As part of this, to avoid repeating code I moved the color selection to the icon SVG prop as originally intended. I also refactored the story to make the Storybook Knobs control use the same naming as props to be consistent with our standard approach.

### Known issue.
The `useTheme()` hook needed to have a type for the variable. Currently as everyone is extremely busy preparing for a demo, I've just used `any` but would suggest an actual type we could use for this.