### PR TITLE
Feature/main menu always collapsable

### DIFF
--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -52,6 +52,7 @@ export interface IMenuTop {
     keepOpenText?: string
     autoHideText? :string
     defaultMenuOpen?: boolean
+    canAlwaysPin?: boolean
   }
 
   export interface ICustomDrawer {

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -104,9 +104,9 @@ const ContainerInner = styled.div`
 `;
 
 
-const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true }) => {
+const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true, canAlwaysPin = false }) => {
 
-  const { menuState, setMenuOpen, setMenuClose, togglePinned } = useMenu(defaultMenuOpen);
+  const { menuState, setMenuOpen, setMenuClose, togglePinned } = useMenu(defaultMenuOpen, canAlwaysPin);
 
   const [focusedContext, setFocusedContext] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -186,11 +186,11 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
                 <FooterItemContainer>
                   <ContextItem compact isActive={false} icon='Question' title='Help &amp; Support' href={supportUrl} menuOpen={menuState.isMenuOpen} />
                 </FooterItemContainer>
-            )}
+              )}
 
-              <FooterItemContainer>
-                {(menuState.canPin)
-                ? (
+              {(menuState.canPin)
+              ? (
+                <FooterItemContainer>
                   <ContextItem
                     compact
                     isActive={false}
@@ -199,9 +199,9 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
                     onClickCallback={toggleMenuPin}
                     menuOpen={menuState.isMenuOpen}
                   />
-                )
-                : null}
-              </FooterItemContainer>
+                </FooterItemContainer>
+              )
+              : null}
             </MenuFooter>
           </ContainerInner>
         </Container>,

--- a/src/Global/templates/GlobalUI.tsx
+++ b/src/Global/templates/GlobalUI.tsx
@@ -22,6 +22,7 @@ const GlobalUI: React.FC<INavigation> = ({
   logoText,
   supportUrl,
   defaultMenuOpen,
+  canAlwaysPin,
   paddingOverride,
   maxWidth,
   children,
@@ -41,7 +42,8 @@ const GlobalUI: React.FC<INavigation> = ({
             logoMark,
             logoText,
             supportUrl,
-            defaultMenuOpen}
+            defaultMenuOpen,
+            canAlwaysPin}
           }
         />
         <MainContainer>

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -118,7 +118,7 @@ const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
   const {activeScreen} = useBreakpoints();
   const [state, dispatch] = useReducer(menuReducer, menuState);
 
-  const setMenu = useCallback((defaultMenuOpen: boolean, desktopSize: IBreakpoints)=>{
+  const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,)=>{
       dispatch({type: 'SET_MENU', data: {defaultMenuOpen, desktopSize, canAlwaysPin}});
   },[]);
 
@@ -135,8 +135,8 @@ const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
   },[]);
 
   useLayoutEffect(() => {
-    setMenu(defaultMenuOpen, activeScreen);
-  }, [activeScreen, defaultMenuOpen, setMenu]);
+    setMenu(defaultMenuOpen, canAlwaysPin, activeScreen);
+  }, [activeScreen, defaultMenuOpen, canAlwaysPin, setMenu]);
 
   return {
     menuState: state,

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -14,6 +14,7 @@ interface SET_MENU {
   data: {
     desktopSize: IBreakpoints
     defaultMenuOpen: boolean
+    canAlwaysPin?: boolean
   }
 }
 
@@ -42,7 +43,7 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
       let isMenuPinned = false;
       let canPin = false;
 
-      if (action.data.defaultMenuOpen && action.data.desktopSize === 'xlarge') {
+      if (action.data.canAlwaysPin || (action.data.defaultMenuOpen && action.data.desktopSize === 'xlarge')) {
         canPin = true;
       }
 
@@ -112,20 +113,20 @@ const menuState: IMenuState = {
   canPin: false
 };
 
-const useMenu = (defaultMenuOpen: boolean) => {
+const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
 
   const {activeScreen} = useBreakpoints();
   const [state, dispatch] = useReducer(menuReducer, menuState);
 
   const setMenu = useCallback((defaultMenuOpen: boolean, desktopSize: IBreakpoints)=>{
-      dispatch({type: 'SET_MENU', data: {defaultMenuOpen, desktopSize}});
+      dispatch({type: 'SET_MENU', data: {defaultMenuOpen, desktopSize, canAlwaysPin}});
   },[]);
 
   const setMenuOpen = useCallback(() => {
     dispatch({type: 'SET_OPEN'});
-  },[]); 
+  },[]);
 
-  const setMenuClose = useCallback(()=> { 
+  const setMenuClose = useCallback(()=> {
     dispatch({type: 'SET_CLOSE'});
   },[]);
 

--- a/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -384,12 +384,13 @@ export const _GlobalUI = () => {
   const currentUserText = text("Current User Text", "Current User");
   const logoutLink = text("Logout Url", "#")
   const logoutText = text("Logout Text", "Logout");
-  const accountOptionText = text("Account Options Text", "Account Options") 
+  const accountOptionText = text("Account Options Text", "Account Options")
   const searchPlaceholder = text("Search Placeholder", "Search area names, etc.")
   const logoMark = text("Logo Mark SVG", logoMarkSvg);
   const logoText = text("Logo Text SVG", logoTextSvg);
   const supportUrl = text("Support Url", "/support");
   const menuHomeLink = text("Home Link", "/welcome");
+  const canAlwaysPin = boolean("Can Always Pin", true);
   const menuConfig = object("Menu Config", {
     items: [
       {
@@ -491,6 +492,7 @@ export const _GlobalUI = () => {
         content={menuConfig}
         home={menuHomeLink}
         defaultMenuOpen={true}
+        canAlwaysPin={canAlwaysPin}
         {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory, customDrawer }}
         {...{ loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, logoutText, searchPlaceholder, hasLanguage, hasCurrentUser, currentUserText, accountOptionText }}
       >

--- a/storybook/src/stories/Global/MainMenu.stories.tsx
+++ b/storybook/src/stories/Global/MainMenu.stories.tsx
@@ -17,6 +17,7 @@ export const _MainMenu = () => {
 
   const logoMark = text("Logo Mark SVG", logoMarkSvg);
   const logoText = text("Logo Text SVG", logoTextSvg);
+  const canAlwaysPin = false;
 
   const supportUrl = text("Support Url", "#");
 
@@ -96,7 +97,7 @@ export const _MainMenu = () => {
 
   return (
     <Layout>
-      <MainMenu content={menuConfig} home={menuHomeLink} {...{ logoMark, logoText, supportUrl }} />
+      <MainMenu content={menuConfig} home={menuHomeLink} {...{ logoMark, logoText, supportUrl, canAlwaysPin }} />
     </Layout>
   );
 };


### PR DESCRIPTION
### Description

At larger screen resolutions, we pin the menu open. This makes sense for a lot of data based design patterns we've used it for but more full screen UI based designs (such as in map dashboard centric projects) the screen space is a lot more important and so we want to retain the option to keep the menu size streamlined. 

There is a new prop called `canAlwaysPin` to control this. 

Additionally, there is a small fix included that means when the menu pinning functionality isn't present, the help and support link sits at the bottom of the menu instead of hovering.