### PR TITLE
Add Direction Mark on LineUIRTC and LineUIVideo

### DIFF
--- a/example/src/pages/LineRTCPage.tsx
+++ b/example/src/pages/LineRTCPage.tsx
@@ -12,7 +12,8 @@ import {
   LineUIRTC,
   Logo,
   Button,
-  AlertBar
+  AlertBar,
+  Switch
 } from 'scorer-ui-kit';
 import { LineUIOptions } from '../../../dist/LineUI';
 
@@ -21,11 +22,12 @@ const Line: React.FC<{}> = () => {
   const [error] = useState<string | null>('');
   const [ws, setWS] = useState('localhost/wsapp');
   const [wsURL, setWsURL] = useState('');
+  const [isShowDirection, setShowDirection] = useState<boolean>(false);
 
   const options : LineUIOptions = {
     showSetIndex: true,
     setIndexOffset: 1,
-    showDirectionMark: true
+    showDirectionMark: isShowDirection
   }
 
   const fetchLine = useCallback(async () => {
@@ -94,6 +96,10 @@ const Line: React.FC<{}> = () => {
     setWsURL(ws);
   },[ws]);
 
+  const showDirection = useCallback((event) => {
+    setShowDirection(event);
+  }, []);
+
   return (
     <Layout >
       <Sidebar>
@@ -104,6 +110,8 @@ const Line: React.FC<{}> = () => {
           </pre>
         </SidebarBox>
         <SidebarBox>
+          <Switch checked={isShowDirection} labelText='Show Direction Mark' leftTheme='off' onChangeCallback={showDirection} rightTheme='on' state='default' />
+          <br />
           <Button design="secondary" onClick={fetchLine} >Cancel</Button>
           <Button style={{ marginLeft: '10px' }} onClick={saveLine}>Save</Button>
         </SidebarBox>

--- a/example/src/pages/LineRTCPage.tsx
+++ b/example/src/pages/LineRTCPage.tsx
@@ -24,7 +24,8 @@ const Line: React.FC<{}> = () => {
 
   const options : LineUIOptions = {
     showSetIndex: true,
-    setIndexOffset: 1
+    setIndexOffset: 1,
+    showDirectionMark: true
   }
 
   const fetchLine = useCallback(async () => {

--- a/example/src/pages/LineRTCPage.tsx
+++ b/example/src/pages/LineRTCPage.tsx
@@ -1,5 +1,5 @@
 import React, { useReducer, useCallback, useEffect, useState } from 'react';
-// import styled from 'styled-components';
+import styled from 'styled-components';
 
 import {
   LineReducer,
@@ -16,6 +16,10 @@ import {
   Switch
 } from 'scorer-ui-kit';
 import { LineUIOptions } from '../../../dist/LineUI';
+
+const SwitchBox = styled.div`
+  margin-bottom: 15px;
+`;
 
 const Line: React.FC<{}> = () => {
   const [state, dispatch] = useReducer(LineReducer, []);
@@ -96,8 +100,8 @@ const Line: React.FC<{}> = () => {
     setWsURL(ws);
   },[ws]);
 
-  const showDirection = useCallback((event) => {
-    setShowDirection(event);
+  const showDirection = useCallback((isChecked: boolean) => {
+    setShowDirection(isChecked);
   }, []);
 
   return (
@@ -110,8 +114,9 @@ const Line: React.FC<{}> = () => {
           </pre>
         </SidebarBox>
         <SidebarBox>
-          <Switch checked={isShowDirection} labelText='Show Direction Mark' leftTheme='off' onChangeCallback={showDirection} rightTheme='on' state='default' />
-          <br />
+          <SwitchBox>
+            <Switch checked={isShowDirection} labelText='Show Direction Mark' leftTheme='off' onChangeCallback={showDirection} rightTheme='on' state='default' />
+          </SwitchBox>
           <Button design="secondary" onClick={fetchLine} >Cancel</Button>
           <Button style={{ marginLeft: '10px' }} onClick={saveLine}>Save</Button>
         </SidebarBox>

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -138,8 +138,8 @@ const Line: React.FC<{}> = () => {
     fetchLine();
   }, [fetchLine])
 
-  const showDirection = useCallback((event) => {
-    setOptions(previous => ({...previous, showDirectionMark: event}));
+  const showDirection = useCallback((isChecked: boolean) => {
+    setOptions(previous => ({...previous, showDirectionMark: isChecked}));
   }, []);
 
   return (

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -11,6 +11,7 @@ import {
   Content,
   Logo,
   ButtonWithIcon,
+  Switch,
 } from 'scorer-ui-kit';
 import styled from 'styled-components';
 import {LineUIOptions} from '../../../dist/LineUI';
@@ -25,12 +26,12 @@ const Line: React.FC<{}> = () => {
   const [state, dispatch] = useReducer(LineReducer, []);
   const [error] = useState<string | null>('');
 
-  const [options] = useState<LineUIOptions>({
+  const [options, setOptions] = useState<LineUIOptions>({
     showSetIndex: true,
     pointIndexOffset: 1,
     showPointLabel: true,
     setIndexOffset: 1,
-    showDirectionMark: true
+    showDirectionMark: false
   });
 
   const [videoOptions]= useState<LineUIVideoOptions>({
@@ -137,6 +138,10 @@ const Line: React.FC<{}> = () => {
     fetchLine();
   }, [fetchLine])
 
+  const showDirection = useCallback((event) => {
+    setOptions(previous => ({...previous, showDirectionMark: event}));
+  }, []);
+
   return (
     <Layout >
       <Sidebar>
@@ -150,6 +155,8 @@ const Line: React.FC<{}> = () => {
           <StyledButton icon={'Delete'} design='danger' onClick={()=>removePoint(state.length-1)} >Remove Point</StyledButton>
 
           <StyledButton  icon={'Delete'}  design='danger' onClick={()=>removeSet(state.length-1)} >Remove Shape</StyledButton>
+
+          <Switch checked={options.showDirectionMark} labelText='Show Direction Mark' leftTheme='off' onChangeCallback={showDirection} rightTheme='on' state='default' />
 
         </SidebarBox>
         <SidebarBox style={{ flex: '1' }} >

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -30,6 +30,7 @@ const Line: React.FC<{}> = () => {
     pointIndexOffset: 1,
     showPointLabel: true,
     setIndexOffset: 1,
+    showDirectionMark: true
   });
 
   const [videoOptions]= useState<LineUIVideoOptions>({

--- a/src/LineUI/LineUIRTC.tsx
+++ b/src/LineUI/LineUIRTC.tsx
@@ -85,7 +85,8 @@ const LineUI : React.FC<LineUIProps> = ({
     setIndexOffset = 0,
     pointIndexOffset = 0,
     showPoint = false,
-    boundaryOffset = 0
+    boundaryOffset = 0,
+    showDirectionMark = false
   }={}
 }) => {
 
@@ -177,7 +178,8 @@ const LineUI : React.FC<LineUIProps> = ({
     showMoveHandle:  showMoveHandle || (showMoveHandle !== false && showGrabHandle !== false),
     setIndexOffset,
     pointIndexOffset,
-    showPoint
+    showPoint,
+    showDirectionMark
   };
 
   return (

--- a/src/LineUI/LineUIVideo.tsx
+++ b/src/LineUI/LineUIVideo.tsx
@@ -92,7 +92,8 @@ const LineUIVideo : React.FC<LineUIProps> = ({
     setIndexOffset = 0,
     pointIndexOffset = 0,
     showPoint = false,
-    boundaryOffset = 0
+    boundaryOffset = 0,
+    showDirectionMark = false
   }={}
 }) => {
 
@@ -183,7 +184,8 @@ const LineUIVideo : React.FC<LineUIProps> = ({
     showMoveHandle:  showMoveHandle || (showMoveHandle !== false && showGrabHandle !== false),
     setIndexOffset,
     pointIndexOffset,
-    showPoint
+    showPoint,
+    showDirectionMark
   };
 
   return (

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -171,7 +171,7 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
           <Icon color='inverse' icon='Up' size={12} weight='heavy' forSvgUsage />
         </g>
         <g transform={`translate(0,30) rotate(${dmCoordinate.labelRotate})`}>
-          <LabelText styling={styling} fontSize={`${14}px`} x={0} y={0} showIndex={revealSetIndex || handleFinderActive}>
+          <LabelText styling={styling} fontSize={`${14}px`} x={-10} y={0} showIndex={revealSetIndex || handleFinderActive}>
             {label}
           </LabelText>
         </g>

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -171,7 +171,7 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
           <Icon color='inverse' icon='Up' size={12} weight='heavy' forSvgUsage />
         </g>
         <g transform={`translate(0,30) rotate(${dmCoordinate.labelRotate})`}>
-          <LabelText styling={styling} fontSize={`${14}px`} x={-10} y={0} showIndex={revealSetIndex || handleFinderActive}>
+          <LabelText styling={styling} fontSize={`${14}px`} x={0} y={0} showIndex={revealSetIndex || handleFinderActive}>
             {label}
           </LabelText>
         </g>


### PR DESCRIPTION
This is an enhancement of previous PR (https://github.com/future-standard/scorer-ui-kit/pull/240) where we are adding direction mark on Line UI RTC and Line UI Video as well.


In Okinawa we have to show Direction mark on LineUI and LineUIRTC so this enhancement is required in this feature.

Zeplin design: https://app.zeplin.io/project/616e925cbde941134b0e7cbd/screen/61a4ad9c97d4ac134c19227d
image


Considerations on Implementation
The implementation is done for LineUIVideo and LineUIRTC components.

Reviewing/Testing steps
Follow the steps given at :
https://github.com/future-standard/scorer-ui-kit/tree/feature/line-ui-arrow-icon#readme

**Line WebRTC**
When project runs, Open http://localhost:3000/scorer-ui-kit#/linertc in browser you will see
![image](https://user-images.githubusercontent.com/91055033/150786636-4661db82-8f3e-4b4a-8928-e338676c4bc9.png)


**Line Video**
When project runs, Open http://localhost:3000/scorer-ui-kit#/linevideo in browser you will see
![image](https://user-images.githubusercontent.com/91055033/150786709-87088e26-744a-4253-9d83-4bc9e2b5f852.png)
