### PR TITLE
Add video options to LineUIRTC with modal example

### DIFF
--- a/example/src/pages/LineRTCPage.tsx
+++ b/example/src/pages/LineRTCPage.tsx
@@ -13,12 +13,19 @@ import {
   Logo,
   Button,
   AlertBar,
-  Switch
+  Switch,
+  useMediaModal
 } from 'scorer-ui-kit';
-import { LineUIOptions } from '../../../dist/LineUI';
+import { LineUIOptions, LineUIVideoOptions } from '../../../dist/LineUI';
 
 const SwitchBox = styled.div`
   margin-bottom: 15px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  margin: 20px 0;
+  justify-content: flex-end;
 `;
 
 const Line: React.FC<{}> = () => {
@@ -27,6 +34,12 @@ const Line: React.FC<{}> = () => {
   const [ws, setWS] = useState('localhost/wsapp');
   const [wsURL, setWsURL] = useState('');
   const [isShowDirection, setShowDirection] = useState<boolean>(false);
+  const {createMediaModal} = useMediaModal();
+
+  const [videoOptions, setVideoOptions]= useState<LineUIVideoOptions>({
+    loop: true,
+    autoPlay: true
+  });
 
   const options : LineUIOptions = {
     showSetIndex: true,
@@ -104,6 +117,23 @@ const Line: React.FC<{}> = () => {
     setShowDirection(isChecked);
   }, []);
 
+  const handleModalClose = useCallback(() => {
+    setVideoOptions({
+      loop: true,
+      autoPlay: true
+    })
+  }, []);
+
+  const handleMediaModal = useCallback(() => {
+    setVideoOptions({
+      loop: false,
+      autoPlay: false,
+      muted: true,
+    })
+
+    createMediaModal({ mediaType: 'video', src: `ws://${wsURL}/`, dismissCallback: handleModalClose })
+  }, [createMediaModal, handleModalClose])
+
   return (
     <Layout >
       <Sidebar>
@@ -126,10 +156,15 @@ const Line: React.FC<{}> = () => {
         <TextField label='Host' name='host' fieldState='default' value={ws} onChange={({target:{value}})=> setWS(value)} ></TextField>
         <Button onClick={connect}>Connect</Button>
         {
-          wsURL &&
+          wsURL && <>
             <LineSetContext.Provider value={{ state, dispatch }}>
-              <LineUIRTC options={options} ws={`ws://${wsURL}/`} />
+              <LineUIRTC ws={`ws://${wsURL}/`} {...{videoOptions, options}}/>
             </LineSetContext.Provider>
+            <ButtonWrapper>
+              <Button onClick={handleMediaModal}>Open Video Modal</Button>
+            </ButtonWrapper>
+          </>
+
         }
       </Content>
     </Layout>

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -12,6 +12,8 @@ import {
   Logo,
   ButtonWithIcon,
   Switch,
+  Button,
+  useMediaModal,
 } from 'scorer-ui-kit';
 import styled from 'styled-components';
 import {LineUIOptions} from '../../../dist/LineUI';
@@ -22,9 +24,16 @@ const StyledButton = styled(ButtonWithIcon)`
   margin-bottom: 15px;
 `
 
+const ButtonWrapper = styled.div`
+  display: flex;
+  margin: 20px 0;
+  justify-content: flex-end;
+`;
+
 const Line: React.FC<{}> = () => {
   const [state, dispatch] = useReducer(LineReducer, []);
   const [error] = useState<string | null>('');
+  const {createMediaModal} = useMediaModal();
 
   const [options, setOptions] = useState<LineUIOptions>({
     showSetIndex: true,
@@ -34,7 +43,7 @@ const Line: React.FC<{}> = () => {
     showDirectionMark: false
   });
 
-  const [videoOptions]= useState<LineUIVideoOptions>({
+  const [videoOptions, setVideoOptions]= useState<LineUIVideoOptions>({
     loop: true,
     autoPlay: true
   });
@@ -142,6 +151,23 @@ const Line: React.FC<{}> = () => {
     setOptions(previous => ({...previous, showDirectionMark: isChecked}));
   }, []);
 
+  const handleModalClose = useCallback(() => {
+    setVideoOptions({
+      loop: true,
+      autoPlay: true
+    })
+  }, []);
+
+  const handleMediaModal = useCallback(() => {
+    setVideoOptions({
+      loop: false,
+      autoPlay: false,
+      muted: true,
+    })
+
+    createMediaModal({ mediaType: 'video', src: '/scorer-ui-kit/traffic.mp4', dismissCallback: handleModalClose })
+  }, [createMediaModal, handleModalClose])
+
   return (
     <Layout >
       <Sidebar>
@@ -170,6 +196,9 @@ const Line: React.FC<{}> = () => {
         <LineSetContext.Provider value={{ state, dispatch }}>
           <LineUIVideo options={options} videoOptions={videoOptions} src='/scorer-ui-kit/traffic.mp4' />
         </LineSetContext.Provider>
+        <ButtonWrapper>
+          <Button onClick={handleMediaModal}>Open Video Modal</Button>
+        </ButtonWrapper>
       </Content>
     </Layout>
   );

--- a/src/LineUI/LineUIRTC.tsx
+++ b/src/LineUI/LineUIRTC.tsx
@@ -5,7 +5,7 @@ import LineSet from './LineSet';
 import { LineSetContext } from './Contexts';
 import WebRTCClient from '../WebRTCClient';
 import Spinner from '../Indicators/Spinner';
-import { LineUIOptions, IBoundary } from '.';
+import { LineUIOptions, IBoundary, LineUIVideoOptions } from '.';
 
 
 const Container = styled.div`
@@ -69,12 +69,14 @@ interface LineUIProps {
   onLineMoveEnd?: ()=> void;
   onLoaded?: (metadata: {height: number; width: number; }) => void;
   options?: LineUIOptions;
+  videoOptions?: LineUIVideoOptions;
 }
 const LineUI : React.FC<LineUIProps> = ({
   ws,
   onSizeChange = ()=>{},
   onLineMoveEnd = ()=>{},
   onLoaded = ()=>{},
+  videoOptions,
   options: {
     showHandleFinder,
     showSetIndex,
@@ -184,7 +186,7 @@ const LineUI : React.FC<LineUIProps> = ({
 
   return (
     <Container>
-      <Video onLoadedMetadata={onLoadedMetadata} peerAddress={ws} id='1' enabled> </Video>
+      <Video onLoadedMetadata={onLoadedMetadata} peerAddress={ws} id='1' {...videoOptions} enabled> </Video>
       {!loaded && <LoadingOverlay><Spinner size='large' styling='primary' /></LoadingOverlay>}
       {
         loaded &&


### PR DESCRIPTION
### Description

closes #282 

- #282 

### Implementation
Added the video options and also tried to add to examples the case of stoping the looping of the video while opening a modal. This for Video and RTC

### Screenshoot

<img width="1162" alt="Screen Shot 2022-03-14 at 23 19 29" src="https://user-images.githubusercontent.com/10409078/158311948-8af5d96d-32e8-46c3-9ba6-871b9f6f7ce9.png">

