### PR TITLE
Add alignment options for Action buttons

### DIFF
--- a/src/Form/molecules/ActionButtons.tsx
+++ b/src/Form/molecules/ActionButtons.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
 import IconButton, { IconButtonData } from '../atoms/IconButton';
 
 const StyledIconButton = styled(IconButton)``;
 
-const Container = styled.div`
+const Container = styled.div<{alignment?: IAlignmentOptions}>`
   display: flex;
   ${StyledIconButton} {
     margin-left: 15px;
@@ -12,16 +12,31 @@ const Container = styled.div`
   ${StyledIconButton}:first-child {
     margin-left: 0px;
   }
+
+  ${({alignment}) => alignment === 'left' && css`
+    justify-content: flex-start;
+  `};
+
+  ${({alignment}) => alignment === 'center' && css`
+    justify-content: center;
+  `};
+
+  ${({alignment}) => alignment === 'right' && css`
+    justify-content: flex-end;
+  `};
 `;
+
+type IAlignmentOptions = 'left' | 'center' | 'right'
 
 type IGroupButtonsData = {
   buttonsConfig: IconButtonData []
+  alignment?: IAlignmentOptions
 }
 
-const ActionButtons : React.FC<IGroupButtonsData> = ({buttonsConfig}) => {
-  
+const ActionButtons : React.FC<IGroupButtonsData> = ({buttonsConfig, alignment}) => {
+
   return(
-    <Container>
+    <Container {...{alignment}}>
       {
         buttonsConfig.map((btn) => {
           const {icon, size, weight, color, hoverColor, onClick} = btn;

--- a/src/Form/molecules/ActionButtons.tsx
+++ b/src/Form/molecules/ActionButtons.tsx
@@ -33,7 +33,7 @@ type IGroupButtonsData = {
   alignment?: IAlignmentOptions
 }
 
-const ActionButtons : React.FC<IGroupButtonsData> = ({buttonsConfig, alignment}) => {
+const ActionButtons : React.FC<IGroupButtonsData> = ({buttonsConfig, alignment = 'right' }) => {
 
   return(
     <Container {...{alignment}}>

--- a/storybook/src/stories/Tables/molecules/ActionsTable.stories.tsx
+++ b/storybook/src/stories/Tables/molecules/ActionsTable.stories.tsx
@@ -145,7 +145,7 @@ const initialRows : ITypeTableData = [
       {customComponent: <div style={{fontStyle:'italic'}}>Just Now</div>},
       {text: `00:00:12`},
       {text: `Complete`},
-      { customComponent: <ActionButtons alignment='right' buttonsConfig = {generateConfigButtons('device1')}/>},
+      { customComponent: <ActionButtons buttonsConfig = {generateConfigButtons('device1')}/>},
     ]
   },
   {
@@ -160,7 +160,7 @@ const initialRows : ITypeTableData = [
       {text: `2020/06/11 - 17:30`},
       {text: `00:00:12`},
       {text: `Complete`},
-      { customComponent: <ActionButtons alignment='right' buttonsConfig = {generateConfigButtons('device2')}/>},
+      { customComponent: <ActionButtons buttonsConfig = {generateConfigButtons('device2')}/>},
     ]
   },
   {
@@ -175,7 +175,7 @@ const initialRows : ITypeTableData = [
       {text: `2020/05/10 - 12:30`},
       {text: `00:00:12`},
       {text: `Complete`},
-      { customComponent: <ActionButtons alignment='right' buttonsConfig = {generateConfigButtons('device2')}/>},
+      { customComponent: <ActionButtons buttonsConfig = {generateConfigButtons('device2')}/>},
     ]
   }
 ];

--- a/storybook/src/stories/Tables/molecules/ActionsTable.stories.tsx
+++ b/storybook/src/stories/Tables/molecules/ActionsTable.stories.tsx
@@ -59,6 +59,7 @@ const columnConfigSample : ITableColumnConfig[] = [
     header: 'Actions',
     sortable: false,
     cellStyle: 'normalImportance',
+    alignment: 'right'
   },
 
 ];
@@ -144,7 +145,7 @@ const initialRows : ITypeTableData = [
       {customComponent: <div style={{fontStyle:'italic'}}>Just Now</div>},
       {text: `00:00:12`},
       {text: `Complete`},
-      { customComponent: <ActionButtons buttonsConfig = {generateConfigButtons('device1')}/>},
+      { customComponent: <ActionButtons alignment='right' buttonsConfig = {generateConfigButtons('device1')}/>},
     ]
   },
   {
@@ -159,7 +160,7 @@ const initialRows : ITypeTableData = [
       {text: `2020/06/11 - 17:30`},
       {text: `00:00:12`},
       {text: `Complete`},
-      { customComponent: <ActionButtons buttonsConfig = {generateConfigButtons('device2')}/>},
+      { customComponent: <ActionButtons alignment='right' buttonsConfig = {generateConfigButtons('device2')}/>},
     ]
   },
   {
@@ -174,7 +175,7 @@ const initialRows : ITypeTableData = [
       {text: `2020/05/10 - 12:30`},
       {text: `00:00:12`},
       {text: `Complete`},
-      { customComponent: <ActionButtons buttonsConfig = {generateConfigButtons('device2')}/>},
+      { customComponent: <ActionButtons alignment='right' buttonsConfig = {generateConfigButtons('device2')}/>},
     ]
   }
 ];


### PR DESCRIPTION
### Description

There was the request to have right align the action buttons on typetable.

I'm adding the capability of having alignment prop to generate this without loosing  previous compatibility.



### Screenshoots
<img width="1382" alt="Screen Shot 2022-03-17 at 23 53 59" src="https://user-images.githubusercontent.com/10409078/158946138-fc4a8242-32f3-4a97-b891-326999e96b8f.png">

