### PR TITLE
[Menus] preserve keep-open/auto-hide state in menu

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,6 +17,7 @@ import LoginPage from './pages/Login';
 import TablePage from './pages/TablePage';
 import CustomUserDrawerPage from './pages/CustomUserDrawerPage';
 import TabsPage from './pages/TabsPage';
+import GlobalUIComp from './pages/GlobalUIComp';
 
 const App: React.FC<{}> = () => {
   return (
@@ -37,6 +38,7 @@ const App: React.FC<{}> = () => {
           </PTZProvider>
         </Route>
         <Route path={`/tabs`} exact={true} component={TabsPage} />
+        <Route path={`/globalUI`} exact={true} component={GlobalUIComp} />
       </Switch>
     </Router>
   )

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -38,7 +38,7 @@ const App: React.FC<{}> = () => {
           </PTZProvider>
         </Route>
         <Route path={`/tabs`} exact={true} component={TabsPage} />
-        <Route path={`/globalUI`} exact={true} component={GlobalUIComp} />
+        <Route path='/globalUI' exact component={GlobalUIComp} />
       </Switch>
     </Router>
   )

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,7 +17,7 @@ import LoginPage from './pages/Login';
 import TablePage from './pages/TablePage';
 import CustomUserDrawerPage from './pages/CustomUserDrawerPage';
 import TabsPage from './pages/TabsPage';
-import GlobalUIComp from './pages/GlobalUIComp';
+import GlobalUIPage from './pages/GlobalUIPage';
 
 const App: React.FC<{}> = () => {
   return (
@@ -38,7 +38,7 @@ const App: React.FC<{}> = () => {
           </PTZProvider>
         </Route>
         <Route path={`/tabs`} exact={true} component={TabsPage} />
-        <Route path='/globalUI' exact component={GlobalUIComp} />
+        <Route path='/globalUI' exact component={GlobalUIPage} />
       </Switch>
     </Router>
   )

--- a/example/src/pages/GlobalUIComp.tsx
+++ b/example/src/pages/GlobalUIComp.tsx
@@ -3,181 +3,180 @@ import { GlobalUI } from "scorer-ui-kit";
 
 const GlobalUIComp = () => {
   return (
-    <div>
-      <GlobalUI
-        accountOptionText="Account Options"
-        canAlwaysPin
-        content={{
-          items: [
-            {
-              href: "/welcome",
-              icon: "Home",
-              title: "Welcome",
-            },
-            {
-              href: "/company",
-              icon: "Detection",
-              submenu: [
-                {
-                  href: "/company/about",
-                  title: "About us",
-                },
-                {
-                  href: "/company/team",
-                  title: "Team",
-                },
-                {
-                  href: "/company/contact",
-                  title: "Contact",
-                },
-                {
-                  href: "/company/table-example",
-                  title: "Table Example",
-                },
-                {
-                  href: "https://www.google.com/",
-                  isExternalLink: true,
-                  title: "External link",
-                },
-              ],
-              title: "Company",
-            },
-            {
-              href: "/services",
-              icon: "Usage",
-              submenu: [
-                {
-                  title: "Online Services",
-                },
-                {
-                  href: "/services/custom",
-                  title: "Service custom",
-                },
-                {
-                  href: "/services/special",
-                  title: "Service special",
-                },
-                {
-                  href: "/services/extra-special",
-                  title: "Service extra special",
-                },
-                {
-                  title: "On site Services",
-                },
-                {
-                  href: "/services/special",
-                  title: "Service special",
-                },
-                {
-                  href: "/services/extra-special",
-                  title: "Service extra special",
-                },
-              ],
-              title: "Services",
-            },
-            {
-              href: "https://www.google.com/maps",
-              icon: "Zone",
-              isExternalLink: true,
-              title: "External link",
-            },
-          ],
-        }}
-        currentUserText="Current User"
-        customDrawer={{
-          customComponent: <h1>Hello Drawer</h1>,
-          icon: "Add",
-          status: "danger",
-          width: "280px;",
-        }}
-        hasCurrentUser
-        hasLanguage
-        hasLogout
-        hasNotifications
-        hasSearch
-        home="#"
-        loggedInUser="full.name@example.com"
-        logoutLink="#"
-        logoutText="Logout"
-        maxWidth="1200px"
-        notificationsHistory={{
-          noNotificationsText: "No new notifications",
-          read: [
-            {
-              imgUrl: "",
-              message: "The device has correctly turn off",
-              time: "3 days ago",
-              title: "Device is off",
-            },
-            {
-              imgUrl: "",
-              message: "The device has correctly turn on",
-              time: "3 days ago",
-              title: "Device is on",
-            },
-            {
-              imgUrl: "",
-              message: "The device has bean correctly added",
-              time: "3 days ago",
-              title: "A new device was added",
-            },
-          ],
-          readNotificationsText: "New",
-          unread: [
-            {
-              imgUrl: "",
-              message:
-                "A short message limited to two lines. Extra text will just truncat...",
-              time: "Just Now",
-              title: "Event Type",
-            },
-            {
-              imgUrl: "",
-              message: "The device has correctly turn off",
-              time: "1 min ago",
-              title: "Device is off",
-            },
-            {
-              imgUrl: "",
-              message: "The device has correctly turn on",
-              time: "6 mins ago",
-              title: "Device is on",
-            },
-            {
-              imgUrl: "",
-              message:
-                "The connections is not working properly. Please verify your connection or contact your personal support.",
-              time: "1 hour ago",
-              title: "Connection was interrupted",
-            },
-            {
-              imgUrl: "",
-              message: "The device has correctly turn off",
-              time: "3 hour ago",
-              title: "Device is off",
-            },
-          ],
-          unreadNotificationsText: "Read",
-        }}
-        paddingOverride="70px 90px"
-        searchPlaceholder="Search area names, etc."
-        supportUrl="/support"
-        userSubmenu={[
+    <GlobalUI
+      accountOptionText="Account Options"
+      canAlwaysPin
+      content={{
+        items: [
           {
-            href: "/user/accounts",
-            text: "Accounts",
+            href: "/welcome",
+            icon: "Home",
+            title: "Welcome",
           },
           {
-            href: "/user/billing",
-            text: "Billing",
+            href: "/company",
+            icon: "Detection",
+            submenu: [
+              {
+                href: "/company/about",
+                title: "About us",
+              },
+              {
+                href: "/company/team",
+                title: "Team",
+              },
+              {
+                href: "/company/contact",
+                title: "Contact",
+              },
+              {
+                href: "/company/table-example",
+                title: "Table Example",
+              },
+              {
+                href: "https://www.google.com/",
+                isExternalLink: true,
+                title: "External link",
+              },
+            ],
+            title: "Company",
           },
           {
-            href: "/user/payments",
-            text: "Payments",
+            href: "/services",
+            icon: "Usage",
+            submenu: [
+              {
+                title: "Online Services",
+              },
+              {
+                href: "/services/custom",
+                title: "Service custom",
+              },
+              {
+                href: "/services/special",
+                title: "Service special",
+              },
+              {
+                href: "/services/extra-special",
+                title: "Service extra special",
+              },
+              {
+                title: "On site Services",
+              },
+              {
+                href: "/services/special",
+                title: "Service special",
+              },
+              {
+                href: "/services/extra-special",
+                title: "Service extra special",
+              },
+            ],
+            title: "Services",
           },
-        ]}
-      ></GlobalUI>
-    </div>
+          {
+            href: "https://www.google.com/maps",
+            icon: "Zone",
+            isExternalLink: true,
+            title: "External link",
+          },
+        ],
+      }}
+      currentUserText="Current User"
+      customDrawer={{
+        customComponent: <h1>Hello Drawer</h1>,
+        icon: "Add",
+        status: "danger",
+        width: "280px;",
+      }}
+      hasCurrentUser
+      hasLanguage
+      hasLogout
+      hasNotifications
+      hasSearch
+      home="#"
+      loggedInUser="full.name@example.com"
+      logoutLink="#"
+      logoutText="Logout"
+      maxWidth="1200px"
+      notificationsHistory={{
+        noNotificationsText: "No new notifications",
+        read: [
+          {
+            imgUrl: "",
+            message: "The device has correctly turn off",
+            time: "3 days ago",
+            title: "Device is off",
+          },
+          {
+            imgUrl: "",
+            message: "The device has correctly turn on",
+            time: "3 days ago",
+            title: "Device is on",
+          },
+          {
+            imgUrl: "",
+            message: "The device has bean correctly added",
+            time: "3 days ago",
+            title: "A new device was added",
+          },
+        ],
+        readNotificationsText: "New",
+        unread: [
+          {
+            imgUrl: "",
+            message:
+              "A short message limited to two lines. Extra text will just truncat...",
+            time: "Just Now",
+            title: "Event Type",
+          },
+          {
+            imgUrl: "",
+            message: "The device has correctly turn off",
+            time: "1 min ago",
+            title: "Device is off",
+          },
+          {
+            imgUrl: "",
+            message: "The device has correctly turn on",
+            time: "6 mins ago",
+            title: "Device is on",
+          },
+          {
+            imgUrl: "",
+            message:
+              "The connections is not working properly. Please verify your connection or contact your personal support.",
+            time: "1 hour ago",
+            title: "Connection was interrupted",
+          },
+          {
+            imgUrl: "",
+            message: "The device has correctly turn off",
+            time: "3 hour ago",
+            title: "Device is off",
+          },
+        ],
+        unreadNotificationsText: "Read",
+      }}
+      paddingOverride="70px 90px"
+      searchPlaceholder="Search area names, etc."
+      supportUrl="/support"
+      userSubmenu={[
+        {
+          href: "/user/accounts",
+          text: "Accounts",
+        },
+        {
+          href: "/user/billing",
+          text: "Billing",
+        },
+        {
+          href: "/user/payments",
+          text: "Payments",
+        },
+      ]}
+    >
+    </GlobalUI>
   );
 };
 

--- a/example/src/pages/GlobalUIComp.tsx
+++ b/example/src/pages/GlobalUIComp.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+import { GlobalUI } from "scorer-ui-kit";
+
+const GlobalUIComp = () => {
+  return (
+    <div>
+      <GlobalUI
+        accountOptionText="Account Options"
+        canAlwaysPin
+        content={{
+          items: [
+            {
+              href: "/welcome",
+              icon: "Home",
+              title: "Welcome",
+            },
+            {
+              href: "/company",
+              icon: "Detection",
+              submenu: [
+                {
+                  href: "/company/about",
+                  title: "About us",
+                },
+                {
+                  href: "/company/team",
+                  title: "Team",
+                },
+                {
+                  href: "/company/contact",
+                  title: "Contact",
+                },
+                {
+                  href: "/company/table-example",
+                  title: "Table Example",
+                },
+                {
+                  href: "https://www.google.com/",
+                  isExternalLink: true,
+                  title: "External link",
+                },
+              ],
+              title: "Company",
+            },
+            {
+              href: "/services",
+              icon: "Usage",
+              submenu: [
+                {
+                  title: "Online Services",
+                },
+                {
+                  href: "/services/custom",
+                  title: "Service custom",
+                },
+                {
+                  href: "/services/special",
+                  title: "Service special",
+                },
+                {
+                  href: "/services/extra-special",
+                  title: "Service extra special",
+                },
+                {
+                  title: "On site Services",
+                },
+                {
+                  href: "/services/special",
+                  title: "Service special",
+                },
+                {
+                  href: "/services/extra-special",
+                  title: "Service extra special",
+                },
+              ],
+              title: "Services",
+            },
+            {
+              href: "https://www.google.com/maps",
+              icon: "Zone",
+              isExternalLink: true,
+              title: "External link",
+            },
+          ],
+        }}
+        currentUserText="Current User"
+        customDrawer={{
+          customComponent: <h1>Hello Drawer</h1>,
+          icon: "Add",
+          status: "danger",
+          width: "280px;",
+        }}
+        hasCurrentUser
+        hasLanguage
+        hasLogout
+        hasNotifications
+        hasSearch
+        home="#"
+        loggedInUser="full.name@example.com"
+        logoutLink="#"
+        logoutText="Logout"
+        maxWidth="1200px"
+        notificationsHistory={{
+          noNotificationsText: "No new notifications",
+          read: [
+            {
+              imgUrl: "",
+              message: "The device has correctly turn off",
+              time: "3 days ago",
+              title: "Device is off",
+            },
+            {
+              imgUrl: "",
+              message: "The device has correctly turn on",
+              time: "3 days ago",
+              title: "Device is on",
+            },
+            {
+              imgUrl: "",
+              message: "The device has bean correctly added",
+              time: "3 days ago",
+              title: "A new device was added",
+            },
+          ],
+          readNotificationsText: "New",
+          unread: [
+            {
+              imgUrl: "",
+              message:
+                "A short message limited to two lines. Extra text will just truncat...",
+              time: "Just Now",
+              title: "Event Type",
+            },
+            {
+              imgUrl: "",
+              message: "The device has correctly turn off",
+              time: "1 min ago",
+              title: "Device is off",
+            },
+            {
+              imgUrl: "",
+              message: "The device has correctly turn on",
+              time: "6 mins ago",
+              title: "Device is on",
+            },
+            {
+              imgUrl: "",
+              message:
+                "The connections is not working properly. Please verify your connection or contact your personal support.",
+              time: "1 hour ago",
+              title: "Connection was interrupted",
+            },
+            {
+              imgUrl: "",
+              message: "The device has correctly turn off",
+              time: "3 hour ago",
+              title: "Device is off",
+            },
+          ],
+          unreadNotificationsText: "Read",
+        }}
+        paddingOverride="70px 90px"
+        searchPlaceholder="Search area names, etc."
+        supportUrl="/support"
+        userSubmenu={[
+          {
+            href: "/user/accounts",
+            text: "Accounts",
+          },
+          {
+            href: "/user/billing",
+            text: "Billing",
+          },
+          {
+            href: "/user/payments",
+            text: "Payments",
+          },
+        ]}
+      ></GlobalUI>
+    </div>
+  );
+};
+
+export default GlobalUIComp;

--- a/example/src/pages/GlobalUIPage.tsx
+++ b/example/src/pages/GlobalUIPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { GlobalUI } from "scorer-ui-kit";
 
-const GlobalUIComp = () => {
+const GlobalUIPage = () => {
   return (
     <GlobalUI
       accountOptionText="Account Options"
@@ -180,4 +180,4 @@ const GlobalUIComp = () => {
   );
 };
 
-export default GlobalUIComp;
+export default GlobalUIPage;

--- a/example/src/pages/GlobalUIPage.tsx
+++ b/example/src/pages/GlobalUIPage.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { FC } from "react";
 import { GlobalUI } from "scorer-ui-kit";
 
-const GlobalUIPage = () => {
+const GlobalUIPage: FC = () => {
   return (
     <GlobalUI
       accountOptionText="Account Options"

--- a/example/src/pages/LinksPage.tsx
+++ b/example/src/pages/LinksPage.tsx
@@ -16,7 +16,7 @@ const LinksPage : React.FC = () => {
     <div><Link to={`/ptz`}>PTZ</Link></div>
     <div><Link to={`/login`}>Login</Link></div>
     <div><Link to={`/tabs`}>Tabs Example</Link></div>
-    <div><Link to={`/globalUI`}>Global UI</Link></div>
+    <div><Link to='/globalUI'>Global UI</Link></div>
     <div><a href='/scorer-ui-kit/storybook'>Storybook</a></div>
   </Container>
 };

--- a/example/src/pages/LinksPage.tsx
+++ b/example/src/pages/LinksPage.tsx
@@ -16,6 +16,7 @@ const LinksPage : React.FC = () => {
     <div><Link to={`/ptz`}>PTZ</Link></div>
     <div><Link to={`/login`}>Login</Link></div>
     <div><Link to={`/tabs`}>Tabs Example</Link></div>
+    <div><Link to={`/globalUI`}>Global UI</Link></div>
     <div><a href='/scorer-ui-kit/storybook'>Storybook</a></div>
   </Container>
 };

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -152,7 +152,7 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
     * The -1 value is important in the mobile version of this menu
   */
   const setFocusedContextCb = useCallback(contextKey => {
-    if (contextKey === -1) { return; }
+    if(contextKey === -1) { return; }
 
     setFocusedContext(focusedContext !== contextKey ? contextKey : -1);
   }, [setFocusedContext, focusedContext]);
@@ -184,17 +184,17 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
 
             <NavigationContainer>
               {content.items.map((item, key) => {
-                return (
-                  <NavigationItem
-                    topLevelPath={getTopLevelPath(location.pathname)}
-                    key={key}
-                    contextKey={key}
-                    menuOpen={menuState.isMenuOpen}
-                    submenuOpen={key === focusedContext && menuState.isMenuOpen}
-                    onClickCallback={setFocusedContextCb}
-                    {...{ item, loading, focusedContext, readyCallback }}
-                  />
-                );
+              return (
+                <NavigationItem
+                  topLevelPath={getTopLevelPath(location.pathname)}
+                  key={key}
+                  contextKey={key}
+                  menuOpen={menuState.isMenuOpen}
+                  submenuOpen={key === focusedContext && menuState.isMenuOpen}
+                  onClickCallback={setFocusedContextCb}
+                  {...{ item, loading, focusedContext, readyCallback }}
+                />
+              );
               })}
             </NavigationContainer>
 
@@ -207,23 +207,23 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
               )}
 
               {(menuState.canPin)
-                ? (
-                  <FooterItemContainer>
-                    <ContextItem
-                      compact
-                      isActive={false}
-                      icon={menuState.isMenuOpen && menuState.isMenuPinned ? 'Left' : 'Menu'}
-                      title={menuState.isMenuPinned ? keepOpenText : autoHideText}
-                      onClickCallback={toggleMenuPin}
-                      menuOpen={menuState.isMenuOpen}
-                    />
-                  </FooterItemContainer>
-                )
-                : null}
+              ? (
+                <FooterItemContainer>
+                  <ContextItem
+                    compact
+                    isActive={false}
+                    icon={menuState.isMenuOpen && menuState.isMenuPinned ? 'Left' : 'Menu'}
+                    title={menuState.isMenuPinned ? keepOpenText : autoHideText}
+                    onClickCallback={toggleMenuPin}
+                    menuOpen={menuState.isMenuOpen}
+                  />
+                </FooterItemContainer>
+              )
+              : null}
             </MenuFooter>
           </ContainerInner>
         </Container>,
-        document.body)}
+      document.body)}
     </PushContainer>
   );
 };

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -154,9 +154,9 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
         <Container
           open={menuState.isMenuOpen}
           desktopSize={menuState.desktopSize}
-          onPointerEnter={menuState.isMenuPinned ? ()=>{} : autoMenuOpen}
+          onPointerEnter={menuState.isMenuPinned ? () => {} : autoMenuOpen}
           onTouchStart={() => console.log('touch')}
-          onMouseLeave={menuState.isMenuPinned ? ()=>{} : autoMenuClose}
+          onMouseLeave={menuState.isMenuPinned ? () => {} : autoMenuClose}
         >
           <ContainerInner>
             <Logo to={home}>

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -106,17 +106,17 @@ const ContainerInner = styled.div`
 
 const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true, canAlwaysPin = false }) => {
 
-  const { menuState, setMenuOpen, setMenuClose, togglePinned, pinnedMenu } = useMenu(defaultMenuOpen, canAlwaysPin);
+  const [showMenuOpen, setShowMenuOpen] = useState<boolean>(false);
+  const { menuState, setMenuOpen, setMenuClose, togglePinned, pinnedMenu } = useMenu(defaultMenuOpen, canAlwaysPin, showMenuOpen);
 
   const [focusedContext, setFocusedContext] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);
-  const [showMenuOpen, setShowMenuOpen] = useState<boolean>(false);
   const location = useLocation();
   let checkedInItems: number = 0;
 
   useLayoutEffect(() => {
     const isMenuOpen = localStorage.getItem('isMenuOpen');
-    if (isMenuOpen == 'true') {
+    if (isMenuOpen === 'true') {
       pinnedMenu();
       setShowMenuOpen(true);
     } else {

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -154,9 +154,9 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
         <Container
           open={menuState.isMenuOpen}
           desktopSize={menuState.desktopSize}
-          onPointerEnter={menuState.isMenuPinned ? undefined : autoMenuOpen}
+          onPointerEnter={menuState.isMenuPinned ? ()=>{} : autoMenuOpen}
           onTouchStart={() => console.log('touch')}
-          onMouseLeave={menuState.isMenuPinned ? undefined : autoMenuClose}
+          onMouseLeave={menuState.isMenuPinned ? ()=>{} : autoMenuClose}
         >
           <ContainerInner>
             <Logo to={home}>

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useLayoutEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import ReactDom from 'react-dom';
 import styled, { css } from 'styled-components';
 
@@ -106,23 +106,12 @@ const ContainerInner = styled.div`
 
 const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true, canAlwaysPin = false }) => {
 
-  const [showMenuOpen, setShowMenuOpen] = useState<boolean>(false);
-  const { menuState, setMenuOpen, setMenuClose, togglePinned, pinnedMenu } = useMenu(defaultMenuOpen, canAlwaysPin, showMenuOpen);
+  const { menuState, setMenuOpen, setMenuClose, togglePinned } = useMenu(defaultMenuOpen, canAlwaysPin);
 
   const [focusedContext, setFocusedContext] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);
   const location = useLocation();
   let checkedInItems: number = 0;
-
-  useLayoutEffect(() => {
-    const isMenuOpen = localStorage.getItem('isMenuOpen');
-    if (isMenuOpen === 'true') {
-      pinnedMenu();
-      setShowMenuOpen(true);
-    } else {
-      setShowMenuOpen(false);
-    }
-  }, [pinnedMenu]);
 
   /* Handling of menu open, closing and pinning. */
   const autoMenuOpen = useCallback((e: any) => {
@@ -138,14 +127,7 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
   const toggleMenuPin = useCallback((e: any) => {
     if (e.pointerType === 'touch') { return; }
     togglePinned();
-    if (showMenuOpen) {
-      setShowMenuOpen(false);
-      localStorage.setItem('isMenuOpen', 'false');
-    } else {
-      setShowMenuOpen(true);
-      localStorage.setItem('isMenuOpen', 'true');
-    }
-  }, [togglePinned, showMenuOpen]);
+  }, [togglePinned]);
 
   /** Manage which context is open. */
   /** Submenu sends -1 because context only is for the parent
@@ -172,9 +154,9 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
         <Container
           open={menuState.isMenuOpen}
           desktopSize={menuState.desktopSize}
-          onPointerEnter={showMenuOpen ? undefined : autoMenuOpen}
+          onPointerEnter={menuState.isMenuPinned ? undefined : autoMenuOpen}
           onTouchStart={() => console.log('touch')}
-          onMouseLeave={showMenuOpen ? undefined : autoMenuClose}
+          onMouseLeave={menuState.isMenuPinned ? undefined : autoMenuClose}
         >
           <ContainerInner>
             <Logo to={home}>

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -1,4 +1,4 @@
-import {useReducer, useCallback, useLayoutEffect} from 'react';
+import { useReducer, useCallback, useLayoutEffect } from 'react';
 
 import useBreakpoints, { IBreakpoints } from './useBreakpoints';
 
@@ -39,7 +39,7 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
 
     // initial State based in props and desktop size
     case 'SET_MENU': {
-      const openMenu = localStorage.getItem('isMenuOpen');
+      const openMenu = localStorage.getItem(window.location.hostname + '_isMenuOpen');
       let isMenuOpen = openMenu === 'true';
       let isMenuPinned = openMenu === 'true';
       let canPin = false;
@@ -51,7 +51,7 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
       if (action.data.desktopSize === 'xxlarge' && action.data.canAlwaysPin === false) {
         isMenuOpen = true;
         isMenuPinned = true;
-      } else if(action.data.desktopSize === 'xxlarge'){
+      } else if (action.data.desktopSize === 'xxlarge') {
         isMenuOpen = action.data.defaultMenuOpen;
         isMenuPinned = false;
       }
@@ -89,15 +89,15 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
     }
 
     case 'TOGGLE_PIN': {
-      if(!state.canPin) { return state; }
+      if (!state.canPin) { return state; }
 
       let isMenuOpen = true;
 
-      if(state.isMenuPinned) {
-        localStorage.setItem('isMenuOpen', 'false');
+      if (state.isMenuPinned) {
+        localStorage.removeItem(window.location.hostname + '_isMenuOpen');
         isMenuOpen = false;
       } else {
-        localStorage.setItem('isMenuOpen', 'true');
+        localStorage.setItem(window.location.hostname + '_isMenuOpen', 'true');
       }
 
       return {
@@ -122,24 +122,24 @@ const menuState: IMenuState = {
 
 const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
 
-  const {activeScreen} = useBreakpoints();
+  const { activeScreen } = useBreakpoints();
   const [state, dispatch] = useReducer(menuReducer, menuState);
 
   const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,) => {
-    dispatch({type: 'SET_MENU', data: {defaultMenuOpen, desktopSize, canAlwaysPin}});
-  },[]);
+    dispatch({ type: 'SET_MENU', data: { defaultMenuOpen, desktopSize, canAlwaysPin } });
+  }, []);
 
   const setMenuOpen = useCallback(() => {
-    dispatch({type: 'SET_OPEN'});
-  },[]);
+    dispatch({ type: 'SET_OPEN' });
+  }, []);
 
   const setMenuClose = useCallback(() => {
-    dispatch({type: 'SET_CLOSE'});
-  },[]);
+    dispatch({ type: 'SET_CLOSE' });
+  }, []);
 
   const togglePinned = useCallback(() => {
-    dispatch({type: 'TOGGLE_PIN'});
-  },[]);
+    dispatch({ type: 'TOGGLE_PIN' });
+  }, []);
 
   useLayoutEffect(() => {
     setMenu(defaultMenuOpen, canAlwaysPin, activeScreen);

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -30,11 +30,7 @@ interface TOGGLE_PIN {
   type: 'TOGGLE_PIN'
 }
 
-interface PIN_MENU {
-  type: 'PIN_MENU'
-}
-
-type IMenuActions = SET_MENU | SET_OPEN | SET_CLOSE | TOGGLE_PIN | PIN_MENU
+type IMenuActions = SET_MENU | SET_OPEN | SET_CLOSE | TOGGLE_PIN
 
 
 const menuReducer = (state: IMenuState, action: IMenuActions) => {
@@ -111,15 +107,6 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
       };
     }
 
-    case 'PIN_MENU': {
-      return {
-        ...state,
-        isMenuPinned: true,
-        isMenuOpen: true,
-        canPin: true,
-      };
-    }
-
     default:
       console.error(`Action ${action['type']} not registered.`);
       return state;
@@ -156,7 +143,7 @@ const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
 
   useLayoutEffect(() => {
     setMenu(defaultMenuOpen, canAlwaysPin, activeScreen);
-  }, [defaultMenuOpen, canAlwaysPin, activeScreen, setMenu]);
+  }, [activeScreen, defaultMenuOpen, canAlwaysPin, setMenu]);
 
   return {
     menuState: state,

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -94,7 +94,7 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
       let isMenuOpen = true;
 
       if (state.isMenuPinned) {
-        localStorage.removeItem(window.location.hostname + '_isMenuOpen');
+        localStorage.setItem(window.location.hostname + '_isMenuOpen', 'false');
         isMenuOpen = false;
       } else {
         localStorage.setItem(window.location.hostname + '_isMenuOpen', 'true');

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -1,4 +1,4 @@
-import { useReducer, useCallback, useLayoutEffect } from 'react';
+import {useReducer, useCallback, useLayoutEffect} from 'react';
 
 import useBreakpoints, { IBreakpoints } from './useBreakpoints';
 
@@ -54,7 +54,7 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
       if (action.data.desktopSize === 'xxlarge' && action.data.canAlwaysPin === false) {
         isMenuOpen = true;
         isMenuPinned = true;
-      } else if (action.data.desktopSize === 'xxlarge') {
+      } else if(action.data.desktopSize === 'xxlarge'){
         isMenuOpen = action.data.defaultMenuOpen;
         isMenuPinned = false;
       }
@@ -92,11 +92,11 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
     }
 
     case 'TOGGLE_PIN': {
-      if (!state.canPin) { return state; }
+      if(!state.canPin) { return state; }
 
       let isMenuOpen = true;
 
-      if (state.isMenuPinned) {
+      if(state.isMenuPinned) {
         isMenuOpen = false;
       }
 
@@ -131,32 +131,32 @@ const menuState: IMenuState = {
 
 const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
 
-  const { activeScreen } = useBreakpoints();
+  const {activeScreen} = useBreakpoints();
   const [state, dispatch] = useReducer(menuReducer, menuState);
 
-  const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,) => {
-    dispatch({ type: 'SET_MENU', data: { defaultMenuOpen, desktopSize, canAlwaysPin } });
-  }, []);
+  const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,)=>{
+    dispatch({type: 'SET_MENU', data: {defaultMenuOpen, desktopSize, canAlwaysPin}});
+  },[]);
 
   const setMenuOpen = useCallback(() => {
-    dispatch({ type: 'SET_OPEN' });
-  }, []);
+    dispatch({type: 'SET_OPEN'});
+  },[]);
 
   const setMenuClose = useCallback(() => {
-    dispatch({ type: 'SET_CLOSE' });
-  }, []);
+    dispatch({type: 'SET_CLOSE'});
+  },[]);
 
   const togglePinned = useCallback(() => {
-    dispatch({ type: 'TOGGLE_PIN' });
-  }, []);
+    dispatch({type: 'TOGGLE_PIN'});
+  },[]);
 
   useLayoutEffect(() => {
     setMenu(defaultMenuOpen, canAlwaysPin, activeScreen);
   }, []);
 
   const pinnedMenu = useCallback(() => {
-    dispatch({ type: 'PIN_MENU' });
-  }, []);
+    dispatch({type: 'PIN_MENU'});
+  },[]);
 
   return {
     menuState: state,

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -129,14 +129,15 @@ const menuState: IMenuState = {
   canPin: false
 };
 
-const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
+const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean, showMenuOpen: boolean) => {
 
   const {activeScreen} = useBreakpoints();
   const [state, dispatch] = useReducer(menuReducer, menuState);
 
-  const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,)=>{
+  const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,) => {
+    if(showMenuOpen) { return; }
     dispatch({type: 'SET_MENU', data: {defaultMenuOpen, desktopSize, canAlwaysPin}});
-  },[]);
+  },[showMenuOpen]);
 
   const setMenuOpen = useCallback(() => {
     dispatch({type: 'SET_OPEN'});
@@ -152,7 +153,7 @@ const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
 
   useLayoutEffect(() => {
     setMenu(defaultMenuOpen, canAlwaysPin, activeScreen);
-  }, []);
+  }, [defaultMenuOpen, canAlwaysPin, activeScreen, setMenu]);
 
   const pinnedMenu = useCallback(() => {
     dispatch({type: 'PIN_MENU'});

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -1,4 +1,4 @@
-import {useReducer, useCallback, useLayoutEffect} from 'react';
+import { useReducer, useCallback, useLayoutEffect } from 'react';
 
 import useBreakpoints, { IBreakpoints } from './useBreakpoints';
 
@@ -30,7 +30,11 @@ interface TOGGLE_PIN {
   type: 'TOGGLE_PIN'
 }
 
-type IMenuActions = SET_MENU | SET_OPEN | SET_CLOSE | TOGGLE_PIN
+interface PIN_MENU {
+  type: 'PIN_MENU'
+}
+
+type IMenuActions = SET_MENU | SET_OPEN | SET_CLOSE | TOGGLE_PIN | PIN_MENU
 
 
 const menuReducer = (state: IMenuState, action: IMenuActions) => {
@@ -50,7 +54,7 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
       if (action.data.desktopSize === 'xxlarge' && action.data.canAlwaysPin === false) {
         isMenuOpen = true;
         isMenuPinned = true;
-      } else if(action.data.desktopSize === 'xxlarge'){
+      } else if (action.data.desktopSize === 'xxlarge') {
         isMenuOpen = action.data.defaultMenuOpen;
         isMenuPinned = false;
       }
@@ -88,18 +92,27 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
     }
 
     case 'TOGGLE_PIN': {
-      if(!state.canPin) { return state; }
+      if (!state.canPin) { return state; }
 
       let isMenuOpen = true;
 
-      if(state.isMenuPinned) {
+      if (state.isMenuPinned) {
         isMenuOpen = false;
       }
 
       return {
         ...state,
         isMenuOpen,
-        isMenuPinned : !state.isMenuPinned,
+        isMenuPinned: !state.isMenuPinned,
+      };
+    }
+
+    case 'PIN_MENU': {
+      return {
+        ...state,
+        isMenuPinned: true,
+        isMenuOpen: true,
+        canPin: true,
       };
     }
 
@@ -118,34 +131,39 @@ const menuState: IMenuState = {
 
 const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
 
-  const {activeScreen} = useBreakpoints();
+  const { activeScreen } = useBreakpoints();
   const [state, dispatch] = useReducer(menuReducer, menuState);
 
-  const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,)=>{
-      dispatch({type: 'SET_MENU', data: {defaultMenuOpen, desktopSize, canAlwaysPin}});
-  },[]);
+  const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,) => {
+    dispatch({ type: 'SET_MENU', data: { defaultMenuOpen, desktopSize, canAlwaysPin } });
+  }, []);
 
   const setMenuOpen = useCallback(() => {
-    dispatch({type: 'SET_OPEN'});
-  },[]);
+    dispatch({ type: 'SET_OPEN' });
+  }, []);
 
-  const setMenuClose = useCallback(()=> {
-    dispatch({type: 'SET_CLOSE'});
-  },[]);
+  const setMenuClose = useCallback(() => {
+    dispatch({ type: 'SET_CLOSE' });
+  }, []);
 
-  const togglePinned = useCallback(()=>{
-    dispatch({type:'TOGGLE_PIN'});
-  },[]);
+  const togglePinned = useCallback(() => {
+    dispatch({ type: 'TOGGLE_PIN' });
+  }, []);
 
   useLayoutEffect(() => {
     setMenu(defaultMenuOpen, canAlwaysPin, activeScreen);
-  }, [activeScreen, defaultMenuOpen, canAlwaysPin, setMenu]);
+  }, []);
+
+  const pinnedMenu = useCallback(() => {
+    dispatch({ type: 'PIN_MENU' });
+  }, []);
 
   return {
     menuState: state,
     setMenuOpen,
     setMenuClose,
     togglePinned,
+    pinnedMenu
   };
 };
 

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -43,8 +43,9 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
 
     // initial State based in props and desktop size
     case 'SET_MENU': {
-      let isMenuOpen = false;
-      let isMenuPinned = false;
+      const openMenu = localStorage.getItem('isMenuOpen');
+      let isMenuOpen = openMenu === 'true';
+      let isMenuPinned = openMenu === 'true';
       let canPin = false;
 
       if (action.data.canAlwaysPin || (action.data.defaultMenuOpen && action.data.desktopSize === 'xlarge')) {
@@ -97,7 +98,10 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
       let isMenuOpen = true;
 
       if(state.isMenuPinned) {
+        localStorage.setItem('isMenuOpen', 'false');
         isMenuOpen = false;
+      } else {
+        localStorage.setItem('isMenuOpen', 'true');
       }
 
       return {
@@ -129,15 +133,14 @@ const menuState: IMenuState = {
   canPin: false
 };
 
-const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean, showMenuOpen: boolean) => {
+const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean) => {
 
   const {activeScreen} = useBreakpoints();
   const [state, dispatch] = useReducer(menuReducer, menuState);
 
   const setMenu = useCallback((defaultMenuOpen: boolean, canAlwaysPin: boolean, desktopSize: IBreakpoints,) => {
-    if(showMenuOpen) { return; }
     dispatch({type: 'SET_MENU', data: {defaultMenuOpen, desktopSize, canAlwaysPin}});
-  },[showMenuOpen]);
+  },[]);
 
   const setMenuOpen = useCallback(() => {
     dispatch({type: 'SET_OPEN'});
@@ -155,16 +158,11 @@ const useMenu = (defaultMenuOpen: boolean, canAlwaysPin: boolean, showMenuOpen: 
     setMenu(defaultMenuOpen, canAlwaysPin, activeScreen);
   }, [defaultMenuOpen, canAlwaysPin, activeScreen, setMenu]);
 
-  const pinnedMenu = useCallback(() => {
-    dispatch({type: 'PIN_MENU'});
-  },[]);
-
   return {
     menuState: state,
     setMenuOpen,
     setMenuClose,
-    togglePinned,
-    pinnedMenu
+    togglePinned
   };
 };
 


### PR DESCRIPTION
### Description
In Support site one issue was reported to menu's Keep Open and Auto Hide state. In this requirement it was expected that Keep Open / Auto-Hide state must be preserve while we navigate to another page or reload the page.

Ref: https://www.bugherd.com/projects/281466/tasks/44

![Screenshot 2022-04-15 183719](https://user-images.githubusercontent.com/91055033/163574309-d8c32733-dde7-4fe2-aa37-d5354a813575.jpg)

### Reviewing/Testing steps

Follow the steps given at :
https://github.com/future-standard/scorer-ui-kit/
When project runs, Open http://localhost:3000/scorer-ui-kit#/globalUI in browser you will see

![image](https://user-images.githubusercontent.com/91055033/163574634-1b608357-6faf-4e07-885a-cd990a9a1d26.png)

Click on KeepOpen  bottom and refresh menu.

