### PR TITLE
[Tab component] horizontal alignment for tab name when language is Japanese

### DIFF
--- a/example/src/pages/TabsPage.tsx
+++ b/example/src/pages/TabsPage.tsx
@@ -20,20 +20,16 @@ const Tab1Container = styled.div`
 const Tab2Container = styled.div`
   margin-top: 20px;
 `
-const LanguageButton = styled(Button)`
-  margin-top: 20px;
-`;
 
-const TabsPage : React.FC = () => {
-  const [language, setLanguage] = React.useState(false);
+const TabsPage: React.FC = () => {
 
   return <Container>
     <Content>
       <PageHeader title="Tabs Example" areaTitle="Examples" areaHref={'/'} />
       <Tabs>
         <TabList defaultTabId='tab1'>
-          <Tab tabFor='tab1'>{language ? 'タブ 1' : 'Tab 1'}</Tab>
-          <Tab tabFor='tab2'>{language ? 'タブ 2' : 'Tab 2'}</Tab>
+          <Tab tabFor='tab1'>Tab 1</Tab>
+          <Tab tabFor='tab2'>Tab 2</Tab>
         </TabList>
         <Divider />
         <TabContent tabId='tab1'>
@@ -52,7 +48,6 @@ const TabsPage : React.FC = () => {
           </Tab2Container>
         </TabContent>
       </Tabs>
-      <LanguageButton design='secondary' size='small' onClick={() => { setLanguage(!language) }}>Change Language</LanguageButton>
     </Content>
   </Container>
 };

--- a/example/src/pages/TabsPage.tsx
+++ b/example/src/pages/TabsPage.tsx
@@ -20,16 +20,20 @@ const Tab1Container = styled.div`
 const Tab2Container = styled.div`
   margin-top: 20px;
 `
+const LanguageButton = styled(Button)`
+  margin-top: 20px;
+`;
 
 const TabsPage : React.FC = () => {
+  const [language, setLanguage] = React.useState(false);
 
   return <Container>
     <Content>
       <PageHeader title="Tabs Example" areaTitle="Examples" areaHref={'/'} />
       <Tabs>
         <TabList defaultTabId='tab1'>
-          <Tab tabFor='tab1'>Tab 1</Tab>
-          <Tab tabFor='tab2'>Tab 2</Tab>
+          <Tab tabFor='tab1'>{language ? 'タブ 1' : 'Tab 1'}</Tab>
+          <Tab tabFor='tab2'>{language ? 'タブ 2' : 'Tab 2'}</Tab>
         </TabList>
         <Divider />
         <TabContent tabId='tab1'>
@@ -48,6 +52,7 @@ const TabsPage : React.FC = () => {
           </Tab2Container>
         </TabContent>
       </Tabs>
+      <LanguageButton design='secondary' size='small' onClick={() => { setLanguage(!language) }}>Change Language</LanguageButton>
     </Content>
   </Container>
 };

--- a/src/Tabs/atoms/Tab.tsx
+++ b/src/Tabs/atoms/Tab.tsx
@@ -6,6 +6,7 @@ const TabComponent = styled.div`
   margin-right: 39px;
   display: flex;
   align-items: center;
+  line-height: 20px;
 `;
 
 const TabLabel = styled.label<{ active: boolean }>`


### PR DESCRIPTION
### Description

In Support Site an issue was reported for selected and normal tab. When we clicks on tab name then horizontal alignment of selected tab and normal tab was not correct when selected language is Japanese. We have fixed this issue in this PR.
Ref: https://www.bugherd.com/projects/281466/tasks/42


![image](https://user-images.githubusercontent.com/91055033/164214365-d4962107-caad-4a22-abe8-a1429630c77d.png)

 ### Reviewing/Testing steps

Follow the steps given at :
https://github.com/future-standard/scorer-ui-kit/

When project runs, Open http://localhost:3000/scorer-ui-kit#/tabs in browser you will see
![image](https://user-images.githubusercontent.com/91055033/164626647-cc440385-47c0-4012-ad68-c00254ab0123.png)


