### PR TITLE
Update SelectField to prevent default value having placeholder style

### DIFF
--- a/src/Form/atoms/SelectField.tsx
+++ b/src/Form/atoms/SelectField.tsx
@@ -47,7 +47,7 @@ ${({ isCompact }) => isCompact && css`
     }
   `}
 
-${({isLabelSameRow}) => isLabelSameRow && css`
+${({ isLabelSameRow }) => isLabelSameRow && css`
   ${StyledLabel} {
     display: flex;
     align-items: center;
@@ -95,7 +95,7 @@ ${({isLabelSameRow}) => isLabelSameRow && css`
 interface ILabel {
   htmlFor: string
   text: string
-  isSameRow? : boolean
+  isSameRow?: boolean
 }
 
 interface OwnProps {
@@ -117,20 +117,20 @@ const SelectField: React.FC<ISelect> = ({
   ...props
 }) => {
 
-  const [activePlaceholder, setPlaceholderInactive] = useState<boolean>(true);
+  const [activePlaceholder, setPlaceholderStatus] = useState<boolean>(!defaultValue ? true : false);
 
   const handleOnChange = useCallback((e) => {
 
     const { value } = e.target;
 
-    setPlaceholderInactive(prev => {
+    setPlaceholderStatus(prev => {
       if (prev) { return false; }
       return prev;
     });
     changeCallback(value);
   }, [changeCallback]);
 
-  const renderSelect = (htmlFor?: string) => (
+  const renderSelect = useCallback((htmlFor?: string) => (
     <SelectWrapper>
       <StyledSelect
         id={htmlFor}
@@ -143,10 +143,10 @@ const SelectField: React.FC<ISelect> = ({
       </StyledSelect>
       <Icon icon='Down' color='dimmed' size={11} />
     </SelectWrapper>
-  );
+  ), [children, defaultValue, handleOnChange, placeholder, props]);
 
   return (
-    <Container {...{ isCompact, activePlaceholder}} isLabelSameRow={label?.isSameRow}>
+    <Container {...{ isCompact, activePlaceholder }} isLabelSameRow={label?.isSameRow}>
       {label
         ? (
           <Label htmlFor={label.htmlFor} labelText={label.text}>

--- a/storybook/src/stories/Form/SelectField.stories.tsx
+++ b/storybook/src/stories/Form/SelectField.stories.tsx
@@ -24,6 +24,7 @@ export const _SelectField = () => {
 
   const isCompact = boolean('isCompact', false);
   const placeholder = text('Placeholder free width', 'Choose an option...');
+  const defaultValue = text('Default Value free width','option3');
   const disabled = boolean('Disabled', false);
   const freeSelectValue = action('Free select value');
   const fixedSelectValue = action('Free select value');
@@ -57,7 +58,8 @@ export const _SelectField = () => {
           placeholder,
           label,
           selectWidth,
-          disabled
+          disabled,
+          defaultValue
         }}
         changeCallback={freeOnChange}
       >


### PR DESCRIPTION
### Description

This is a bug reported in zenhub 
https://app.zenhub.com/workspaces/platform-team-61b9b760a8454700107d1a50/issues/future-standard/scorer-surveillance-dashboard/726

Select Dropdowns - Default value appearing as placeholder / disabled option

I think bug this is causing a bit of confusion in regards to usability. We just need to make sure that if it's a selected value that is shows the style correctly. At the moment the default values that are loaded are displayed how only the no selection / placeholder state should appear. 


### Screenshot

<img width="912" alt="Screen Shot 2022-04-26 at 23 48 43" src="https://user-images.githubusercontent.com/10409078/165443144-501f1021-82ce-4f0c-9a90-aedb1f597bf0.png">


