### PR TITLE
Filter dropdowns shouldn't paginate

### DIFF
--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -55,6 +55,12 @@ const StyledFilterOption = styled(FilterOption)`
 const OptionList = styled.div`
   height: 180px;
   overflow-y: scroll;
+  ::-webkit-scrollbar {  /* Hide scrollbar for Chrome, Safari and Opera */
+    display: none;
+  }
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+
   ${StyledFilterOption} {
     height: 35px;
     padding-left: 10px;

--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -53,6 +53,8 @@ const StyledFilterOption = styled(FilterOption)`
 `;
 
 const OptionList = styled.div`
+  height: 180px;
+  overflow-y: scroll;
   ${StyledFilterOption} {
     height: 35px;
     padding-left: 10px;
@@ -135,63 +137,52 @@ const getNewSelected = (item: IFilterItem, selected: IFilterValue, optionType: I
   return item;
 };
 
-/**
- * This is the list of values that will show in the dropdown
- *
- * @param list is all the items that can be in the dropdown
- * @param maxItems will define in case the dropdown has 300 options to only show until maxItems ( usually 4 or 6)
- * @param selected is a list of the values that are selected and that should be visible
- * although are not at the beginning of the list
- * @returns a FilterItem list to update the content of the dropdown
- */
-
-const getVisibleList = (list: IFilterItem[], maxItems: number, selected: IFilterValue): IFilterItem[] => {
+const selectedOrderList = (list: IFilterItem[], maxItems: number, selected: IFilterValue): IFilterItem[] => {
 
   if (list.length <= maxItems) {
     return list;
   }
 
-  if (selected === null) {
-    return list.slice(0, maxItems);
+  if(selected === null) {
+    return list;
   }
 
   if (isFilterItem(selected)) {
     const index = list.findIndex(item => item.value === selected.value);
 
     // if it doesn't exists return the list based in maxItems
-    if ((index !== -1)) {
-      return list.slice(0, maxItems);
+    if ((index === -1)) {
+      return list;
     }
 
     // if exists and is inside the visibleRange just return slice
     if ((index !== -1) && (index < maxItems)) {
-      return list.slice(0, maxItems);
+      return list;
     }
 
-    //If not is somewhere after the maxItems remove last item and add it to the end.
-    const newList = list.slice(0, maxItems - 1);
-    newList.push(selected);
+    const newList = list.filter(item => item.value !== selected.value);
+    newList.unshift(list[index]);
+
     return newList;
+
   }
 
   if (Array.isArray(selected)) {
-
-    if (selected.length > maxItems) {
-      return selected.slice(0, maxItems);
-    }
-
-    if (selected.length === maxItems) {
-      return selected;
-    }
-
     const selectedIndexList: number[] = [];
+    const newList: IFilterItem[] = [];
 
     selected.forEach((element: IFilterItem) => {
       const index = list.findIndex(item => item.value === element.value);
+      const foundItem = list.find(item => item.value === element.value);
+
 
       if (index !== -1) {
         selectedIndexList.push(index);
       }
+      if(foundItem) {
+        newList.push(foundItem);
+      }
+
     });
 
     selectedIndexList.sort(function (a, b) {
@@ -199,32 +190,19 @@ const getVisibleList = (list: IFilterItem[], maxItems: number, selected: IFilter
     });
 
     let selectedIndex = 0;
-    let visibleListAvailability = maxItems - selected.length;
-    const newList: IFilterItem[] = [];
 
-    for (let listIndex = 0; listIndex < list.length; listIndex++) {
-      if ((selectedIndex < selectedIndexList.length) && (listIndex === selectedIndexList[selectedIndex])) {
+    list.forEach((item, index) => {
+      if(index === selectedIndexList[selectedIndex]){
         selectedIndex++;
-      } else {
-        visibleListAvailability--;
+        return;
       }
-      newList.push(list[listIndex]);
-
-      if (visibleListAvailability === 0) {
-        break;
-      }
-    }
-
-    if ((newList.length < maxItems) && (selectedIndex < selectedIndexList.length)) {
-      for (; selectedIndex < selectedIndexList.length; selectedIndex++) {
-        newList.push(list[selectedIndexList[selectedIndex]]);
-      }
-    }
+      newList.push(item);
+    });
 
     return newList;
   }
 
-  return list.slice(0, maxItems - 1);
+  return list;
 };
 
 const getFilteredList = (list: IFilterItem[], newValue: string): IFilterItem[] => {
@@ -272,17 +250,17 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   ...props
 }) => {
 
-  const [visibleList, setVisibleList] = useState(getVisibleList(list, maxDisplayedItems, selected));
+  const [visibleList, setVisibleList] = useState(selectedOrderList(list, maxDisplayedItems, selected));
   const [searchText, setSearchText] = useState<string>('');
 
   const handleClose = useCallback(() => {
     setSearchText('');
-    setVisibleList(getVisibleList(list, maxDisplayedItems, selected));
+    setVisibleList(selectedOrderList(list, maxDisplayedItems, selected));
   }, [list, maxDisplayedItems, selected]);
 
   const handleToggleOpen = useCallback(() => {
     setSearchText('');
-    setVisibleList(getVisibleList(list, maxDisplayedItems, selected));
+    setVisibleList(selectedOrderList(list, maxDisplayedItems, selected));
   }, [list, maxDisplayedItems, selected]);
 
   const handleSelection = useCallback((item: IFilterItem) => {
@@ -295,7 +273,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
     setSearchText(value);
 
     if (value === '') {
-      setVisibleList(getVisibleList(list, maxDisplayedItems, selected));
+      setVisibleList(selectedOrderList(list, maxDisplayedItems, selected));
       return;
     }
 
@@ -303,14 +281,14 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
     const newList = getFilteredList(list, newValue);
 
     // sending null so the filtered list doesn't force the selected values to appear.
-    setVisibleList(getVisibleList(newList, maxDisplayedItems, null));
+    setVisibleList(selectedOrderList(newList, maxDisplayedItems, null));
   }, [list, maxDisplayedItems, selected]);
 
   useEffect(() => {
     let isActive = true;
     if (isActive) {
       setSearchText(''); // clears searchText if something was selected and the dropdown is still open
-      setVisibleList(getVisibleList(list, maxDisplayedItems, selected));
+      setVisibleList(selectedOrderList(list, maxDisplayedItems, selected));
     }
 
     return () => {

--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -53,7 +53,7 @@ const StyledFilterOption = styled(FilterOption)`
 `;
 
 const OptionList = styled.div`
-  height: 180px;
+  height: 162px;
   overflow-y: scroll;
   ::-webkit-scrollbar {  /* Hide scrollbar for Chrome, Safari and Opera */
     display: none;

--- a/storybook/src/stories/Filters/molecules/FilterDropdown.stories.tsx
+++ b/storybook/src/stories/Filters/molecules/FilterDropdown.stories.tsx
@@ -45,6 +45,8 @@ const englishDataList = [
   { text: 'Gyoza', value: 2 },
   { text: 'Tempura', value: 3 },
   { text: 'Sushi', value: 4 },
+  { text: 'Natto', value: 5 },
+  { text: 'Sashimi', value: 6 },
 ];
 
 const japaneseDataList = [
@@ -53,6 +55,8 @@ const japaneseDataList = [
   { text: '餃子', value: 2 },
   { text: '天婦羅', value: 3 },
   { text: 'すし', value: 4 },
+  { text: '納豆', value: 5 },
+  { text: 'お造り', value: 6 },
 ];
 
 const englishTextList = [
@@ -87,7 +91,10 @@ const baseExample = [
   { text: "Consectetur", value: 2 },
   { text: "Dolor sit", value: 3 },
   { text: "Lorem ipsum", value: 4 },
-  { text: "Vestibulum", value: 5 }
+  { text: "Vestibulum", value: 5 },
+  { text: "Minim Veniam", value: 6 },
+  { text: "Consequat", value: 7 },
+  { text: "Fugiat Nulla", value: 8 },
 ];
 
 export const _FilterDropdown = () => {


### PR DESCRIPTION
### Description
https://app.zenhub.com/workspaces/platform-team-61b9b760a8454700107d1a50/issues/future-standard/scorer-surveillance-dashboard/648

Filter dropdowns shouldn't paginate

At the moment the dropdown filter is limiting the choices to 5 but there are no pagination controls to see any others and it relys on knowing how to search for the remaining tags to show them.

The filter should instead allow for scrolling of this area internally after 5-7 entries are included.


### Screenshoots
https://drive.google.com/file/d/1l-Dzpm5ZuEh704DBpTFgRDqaG0Eka4eh/view?usp=sharing