### PR TITLE
Fix overlaping of titles and add hideAreaInDocTitle option

### DIFF
--- a/src/Pages/atoms/PageTitle.tsx
+++ b/src/Pages/atoms/PageTitle.tsx
@@ -60,13 +60,13 @@ interface IProps {
   areaTitle?: string
   areaHref?: string
   updateDocTitle?: boolean
+  hideAreaInDocTitle? : boolean
 }
 
-const PageTitle : React.FC<IProps> = ({title, icon, areaTitle, areaHref, updateDocTitle = true}) => {
+const PageTitle : React.FC<IProps> = ({title, icon, areaTitle, areaHref, updateDocTitle = true, hideAreaInDocTitle=false }) => {
   // Set <title> attribute automagically.
 
-  useTitle(title, areaTitle || '', undefined, updateDocTitle);
-
+  useTitle(title, hideAreaInDocTitle ? undefined : areaTitle || '', undefined, updateDocTitle);
 
   return (
     <Container>

--- a/src/Pages/molecules/PageHeader.tsx
+++ b/src/Pages/molecules/PageHeader.tsx
@@ -13,12 +13,13 @@ interface IProps {
   icon?: string
   introductionText?: string
   updateDocTitle?: boolean
+  hideAreaInDocTitle? : boolean
 }
 
-const PageHeader : React.FC<IProps> = ({title, icon, introductionText, areaHref, areaTitle, updateDocTitle = true}) => {
+const PageHeader : React.FC<IProps> = ({title, icon, introductionText, areaHref, areaTitle, updateDocTitle = true, hideAreaInDocTitle}) => {
   return (
     <Container>
-      <PageTitle {...{title, icon, areaHref, areaTitle, updateDocTitle}} />
+      <PageTitle {...{title, icon, areaHref, areaTitle, updateDocTitle, hideAreaInDocTitle}} />
       {introductionText ?
         <IntroductionText>{introductionText}</IntroductionText>
       : null}

--- a/src/hooks/useTitle.tsx
+++ b/src/hooks/useTitle.tsx
@@ -1,18 +1,16 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 
 export const useTitle = (title : string, area? : string, delimiter?: string, update= true) => {
 
 // Index Title
 const baseTitle = document.title.split('|').slice(-1)[0].trim();
-const location = useLocation();
 
 // on unmount will return the baseTitle to Index Title for pages not using this hook.
 useEffect(() => {
   return () => {
     document.title = baseTitle;
   };
-}, [baseTitle, location.pathname]);
+}, [baseTitle]);
 
   useEffect(() => {
     if(!update) return;

--- a/src/hooks/useTitle.tsx
+++ b/src/hooks/useTitle.tsx
@@ -25,7 +25,7 @@ useEffect(() => {
   },[title, area, delimiter, update, baseTitle]);
 };
 
-/**useT
+/**
  * Put the parts together for title use.
  * @param parts Each part to make up the title.
  * @param delimiter Character used for delimiting

--- a/src/hooks/useTitle.tsx
+++ b/src/hooks/useTitle.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 export const useTitle = (title : string, area? : string, delimiter?: string, update= true) => {
 
-  const [baseTitle] = useState<string>(document.title);
 
   useEffect(() => {
     if(!update) return;
     document.title = makeTitle([
       ...(title ? [title] : []),
-      ...(area ? [area] : []),
-      baseTitle
+      ...(area ? [area] : [])
     ], delimiter);
-  },[title, area, baseTitle, delimiter, update]);
+  },[title, area, delimiter, update]);
 };
 
 /**

--- a/src/hooks/useTitle.tsx
+++ b/src/hooks/useTitle.tsx
@@ -1,18 +1,31 @@
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 export const useTitle = (title : string, area? : string, delimiter?: string, update= true) => {
 
+// Index Title
+const baseTitle = document.title.split('|').slice(-1)[0].trim();
+const location = useLocation();
+
+// on unmount will return the baseTitle to Index Title for pages not using this hook.
+useEffect(() => {
+  return () => {
+    document.title = baseTitle;
+  };
+}, [baseTitle, location.pathname]);
 
   useEffect(() => {
     if(!update) return;
     document.title = makeTitle([
       ...(title ? [title] : []),
-      ...(area ? [area] : [])
+      ...(area ? [area] : []),
+      ...(baseTitle? [baseTitle] : [])
     ], delimiter);
-  },[title, area, delimiter, update]);
+
+  },[title, area, delimiter, update, baseTitle]);
 };
 
-/**
+/**useT
  * Put the parts together for title use.
  * @param parts Each part to make up the title.
  * @param delimiter Character used for delimiting


### PR DESCRIPTION
### Description

https://app.zenhub.com/workspaces/platform-team-61b9b760a8454700107d1a50/issues/future-standard/scorer-surveillance-dashboard/654

```
Page titles are stacking up!#654
As you can see from this screenshot of the back history, every time a new area is entered the page title is added to the start rather than replacing the previous area title.

```

### Implementation

I removed the state that is adding at the end the initial docTitle. 
I notice that when the title is empty it will add the delimiter then empty  `| `
When coming from another place the state is persisted so that is why is attached at the end.
Not sure which was the case scenario where this was necessary.

You can see in the after screen shot  how the "areaTitle" is attached at the end and it might not be ideal always (in surveillance project we use this title to come back to a different page). I added a hideAreaInDocTitle variable for this ocasions


### Screenshoots

Before can be check in examples

![Screen Shot 2022-05-25 at 19 04 26](https://user-images.githubusercontent.com/10409078/170239689-4f9cb2f1-c6b6-43fe-b6d1-ef69c133ff88.png)

After 

![Screen Shot 2022-05-25 at 19 04 20](https://user-images.githubusercontent.com/10409078/170239716-07f06596-b1c5-4614-93d8-1542a5576dd0.png)


