### PR TITLE
Fix bug in preserve keep-open/auto-hide state in menu

### DIFF
--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -43,7 +43,7 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
 
       let isMenuOpen = (openValueStorage === 'true') || (openValueStorage === null && (!!action.data.defaultMenuOpen));
       let isMenuPinned = (openValueStorage === 'true') && !!action.data.canAlwaysPin;
-      let canPin = (action.data.desktopSize === 'xlarge') || !!action.data.canAlwaysPin;
+      const canPin = (action.data.desktopSize === 'xlarge') || !!action.data.canAlwaysPin;
 
       if (action.data.desktopSize === 'xxlarge' && action.data.canAlwaysPin === false) {
         isMenuOpen = true;

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -37,23 +37,17 @@ const menuReducer = (state: IMenuState, action: IMenuActions) => {
 
   switch (action.type) {
 
-    // initial State based in props and desktop size
+    // initial State based in props and desktop size and local storage
     case 'SET_MENU': {
-      const openMenu = localStorage.getItem(window.location.hostname + '_isMenuOpen');
-      let isMenuOpen = openMenu === 'true';
-      let isMenuPinned = openMenu === 'true';
-      let canPin = false;
+      const openValueStorage = localStorage.getItem(window.location.hostname + '_isMenuOpen');
 
-      if (action.data.canAlwaysPin || (action.data.defaultMenuOpen && action.data.desktopSize === 'xlarge')) {
-        canPin = true;
-      }
+      let isMenuOpen = (openValueStorage === 'true') || (openValueStorage === null && (!!action.data.defaultMenuOpen));
+      let isMenuPinned = (openValueStorage === 'true') && !!action.data.canAlwaysPin;
+      let canPin = (action.data.desktopSize === 'xlarge') || !!action.data.canAlwaysPin;
 
       if (action.data.desktopSize === 'xxlarge' && action.data.canAlwaysPin === false) {
         isMenuOpen = true;
         isMenuPinned = true;
-      } else if (action.data.desktopSize === 'xxlarge') {
-        isMenuOpen = action.data.defaultMenuOpen;
-        isMenuPinned = false;
       }
 
       return {


### PR DESCRIPTION
### Description

 This PR for fixing a Bug in the previous PR  [preserve keep-open/auto-hide state in menu](https://github.com/future-standard/scorer-ui-kit/pull/296) 

Bug found if pass props canAlwaysPin = true then if screen resolution width more than 1400px and refresh the page then it shows Auto-Hide and auto close menu, it's not expected behavior.

### Reviewing/Testing steps
Please follow the previous PR instructions. [LINK](https://github.com/future-standard/scorer-ui-kit/pull/296)