### PR TITLE
Fix for cache error in main deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy gh-pages
 
 on:
   push:
-    branches: [ 'main', 'demo', 'deploy-test2']
+    branches: [ 'main', 'demo', 'deploy-test3']
 
 jobs:
   deploy:
@@ -18,7 +18,7 @@ jobs:
         node-version: '12.x'
 
     - name: Cache node modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3.0.3
       env:
         cache-name: cache-node-modules
       with:


### PR DESCRIPTION
### Description

Currently the deploy is failing at github deploy

https://github.com/future-standard/scorer-ui-kit/runs/6703647712?check_suite_focus=true
<img width="1411" alt="Screen Shot 2022-06-03 at 15 02 49" src="https://user-images.githubusercontent.com/10409078/171796188-228d6bf9-b725-4782-8848-1ededaf618ac.png">

I read online that this is a problem with cache 
https://github.community/t/error-cant-use-tar-xzf-extract-archive-file-return-code-2/254034

I have updated version in this branch with automatic deploy passed without problems