### PR TITLE
Fix height to big for a short list

### DIFF
--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -35,7 +35,8 @@ const StyledFilterOption = styled(FilterOption)`
 `;
 
 const OptionList = styled.div`
-  height: 162px;
+  max-height: 162px;
+  min-height: 40px;
   overflow-y: scroll;
   ::-webkit-scrollbar {  /* Hide scrollbar for Chrome, Safari and Opera */
     display: none;


### PR DESCRIPTION
### Description

Related to 648 request
https://app.zenhub.com/workspaces/platform-team-61b9b760a8454700107d1a50/issues/future-standard/scorer-surveillance-dashboard/648

```
At the moment the dropdown filter is limiting the choices to 5 but there are no pagination controls to see any others and it relys on knowing how to search for the remaining tags to show them.

The filter should instead allow for scrolling of this area internally after 5-7 entries are included.
```


### Implementation
It was visually not well the implementation of the height of the dropdowns, decided to update so when there is less choices it will grow with the choices yet continue to crop when there is more than 5 to show scrolling.

### Screenshots

**Before**

![Screen Shot 2022-06-06 at 17 00 22](https://user-images.githubusercontent.com/10409078/172123578-272ced96-9ecd-4035-9314-758040476fc5.png)

**After**
![Screen Shot 2022-06-06 at 17 20 51](https://user-images.githubusercontent.com/10409078/172123493-c0c0a3c8-eb55-4357-9417-523612fd37ab.png)

