### PR TITLE
Fix aligment mismaches in Filter results

### DIFF
--- a/src/Filters/molecules/FilterInputs.tsx
+++ b/src/Filters/molecules/FilterInputs.tsx
@@ -40,7 +40,7 @@ const Container = styled.div`
   display: flex;
   flex-wrap: wrap;
   ${SearchInputWrapper}, ${StyledDropdown}, ${StyledFilterButton}, ${StyledDropdownDatePicker} {
-    margin: 0 5px 10px 0;
+    margin: 0 3px 10px 3px;
   }
 `;
 

--- a/src/Filters/molecules/FiltersResults.tsx
+++ b/src/Filters/molecules/FiltersResults.tsx
@@ -25,7 +25,7 @@ const FilterLabel = styled.div`
   display: flex;
   align-items: center;
   padding: 0 11px 0 8px;
-  margin: 0 0 3px 3px;
+  margin-left: 3px;
   color: hsl(207, 5%, 57%);
 
   ${({ theme }) => theme && css`

--- a/src/Filters/organisms/FilterBar.tsx
+++ b/src/Filters/organisms/FilterBar.tsx
@@ -28,6 +28,7 @@ const StyledFilterResults = styled(FiltersResults)``;
 const Container = styled.div`
   ${StyledFilterResults} {
     margin-top: 29px;
+    min-height: 19px;
   }
 `;
 


### PR DESCRIPTION
### Description
Filter results had alignment broken for non Japanese. 
Since some min-height was added in a different PR that I though my contribute to avoid this issue but there was still things to improve.


https://www.bugherd.com/projects/281466/tasks/27

Previous PR
https://github.com/future-standard/scorer-ui-kit/pull/288

### Implementation
Removed unnecessary margins and made consistency in FilterInputs

### Screenshoots

**Before**
![Screen Shot 2022-06-06 at 19 41 35](https://user-images.githubusercontent.com/10409078/172146282-f185a36b-a55f-44de-b1f6-41abc49fb4e5.png)


**After**
![Screen Shot 2022-06-06 at 19 43 16](https://user-images.githubusercontent.com/10409078/172146295-c789afd4-7c83-4244-bcb1-b410326c1c3c.png)


