### PR TITLE
[AlertBar] Add hideCloseIcon prop to AlertBar Component

### DIFF
--- a/src/Alerts/atom/AlertBar.tsx
+++ b/src/Alerts/atom/AlertBar.tsx
@@ -60,9 +60,9 @@ export interface IAlert {
 interface Props {
   type?: AlertType
   message?: string
-  hideCloseIcon?: boolean
+  hideCloseButton?: boolean
 }
-const AlertBar: React.FC<Props> = ({type='info', message, hideCloseIcon= false}) => {
+const AlertBar: React.FC<Props> = ({type='info', message, hideCloseButton= false}) => {
   const [dismiss, setDismiss] = useState(false);
 
   useEffect(()=>{
@@ -75,7 +75,7 @@ const AlertBar: React.FC<Props> = ({type='info', message, hideCloseIcon= false})
       <Icon icon={IconNames[type]} color='inverse' />
       <MessageBox>{message}</MessageBox>
 
-      {!hideCloseIcon && <IconButton onClick={() => setDismiss(true)}><Icon icon='CloseCompact' color='inverse' /></IconButton>}
+      {!hideCloseButton && <IconButton onClick={() => setDismiss(true)}><Icon icon='CloseCompact' color='inverse' /></IconButton>}
     </AlertWrapper>
     :
     null

--- a/src/Alerts/atom/AlertBar.tsx
+++ b/src/Alerts/atom/AlertBar.tsx
@@ -59,9 +59,10 @@ export interface IAlert {
 
 interface Props {
   type?: AlertType
-  message?: string;
+  message?: string
+  hideCloseIcon?: boolean
 }
-const AlertBar: React.FC<Props> = ({type='info', message}) => {
+const AlertBar: React.FC<Props> = ({type='info', message, hideCloseIcon= false}) => {
   const [dismiss, setDismiss] = useState(false);
 
   useEffect(()=>{
@@ -74,7 +75,7 @@ const AlertBar: React.FC<Props> = ({type='info', message}) => {
       <Icon icon={IconNames[type]} color='inverse' />
       <MessageBox>{message}</MessageBox>
 
-      <IconButton onClick={() => setDismiss(true)}><Icon icon='CloseCompact' color='inverse' /></IconButton>
+      {!hideCloseIcon && <IconButton onClick={() => setDismiss(true)}><Icon icon='CloseCompact' color='inverse' /></IconButton>}
     </AlertWrapper>
     :
     null

--- a/storybook/src/stories/Alerts/AlertBar.stories.tsx
+++ b/storybook/src/stories/Alerts/AlertBar.stories.tsx
@@ -17,8 +17,8 @@ export default {
 export const _AlertBar = () => {
   const message = text("Message", 'Look Out!');
   const type = select("Type", { Error: 'error', Warning: 'warning', Info: 'info', Success:'success', Neutral:'neutral'}, 'error');
-  const hideCloseIcon = boolean('Hide close icon', false);
+  const hideCloseButton = boolean('Hide close icon', false);
 
-  return <Container><AlertBar {...{message, type, hideCloseIcon}} ></AlertBar></Container>;
+  return <Container><AlertBar {...{message, type, hideCloseButton}} ></AlertBar></Container>;
 
 };

--- a/storybook/src/stories/Alerts/AlertBar.stories.tsx
+++ b/storybook/src/stories/Alerts/AlertBar.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import {  text, select } from "@storybook/addon-knobs";
+import {  text, select, boolean } from "@storybook/addon-knobs";
 
 import {AlertBar} from 'scorer-ui-kit';
 
@@ -17,7 +17,8 @@ export default {
 export const _AlertBar = () => {
   const message = text("Message", 'Look Out!');
   const type = select("Type", { Error: 'error', Warning: 'warning', Info: 'info', Success:'success', Neutral:'neutral'}, 'error');
+  const hideCloseIcon = boolean('Hide close icon', false);
 
-  return <Container><AlertBar message={message} type={type}></AlertBar></Container>;
+  return <Container><AlertBar {...{message, type, hideCloseIcon}} ></AlertBar></Container>;
 
 };


### PR DESCRIPTION
### Description

closes #326
- #326

### Implementation
Adding the hiding prop will not affect behaviour since dismiss button was just not rendering the bar but actually this component was "cleared" in the developers component by their own state.

### Screenshoot

**Common usage**
<img width="1391" alt="Screen Shot 2022-06-13 at 15 41 03" src="https://user-images.githubusercontent.com/10409078/173295869-3a100742-456b-44c2-aba0-a58d6fee3e48.png">


### hideCloseButton prop activated

<img width="709" alt="Screen Shot 2022-06-13 at 15 40 54" src="https://user-images.githubusercontent.com/10409078/173295951-10751031-cdfb-44f0-8baf-0b18776a3b59.png">


