### PR TITLE
Feature/LineUI handle double arrow

### DIFF
--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -73,7 +73,7 @@ const Line: React.FC<{}> = () => {
               y: 389
             }
         ],
-        showBothDirectionMark: true,
+        showSmallDirectionMark: true,
         readOnly: false,
         styling: 'primary'
       },
@@ -90,6 +90,7 @@ const Line: React.FC<{}> = () => {
           }
         ],
         showPointHandle: false,
+        showMoveHandle: false,
         readOnly: false,
         styling: 'primary'
       }

--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -49,7 +49,6 @@ const Line: React.FC<{}> = () => {
           }
         ],
         readOnly: false,
-        hidePointHandle: true,
         styling: 'primary'
       }
     ];
@@ -63,17 +62,18 @@ const Line: React.FC<{}> = () => {
   const fetchDirectionLine = useCallback(async () => {
 
     const state: IPointSet[] = [{
-      name: 'UP',
-      points: [
-          {
-            x: 343,
-            y: 281
-          },
-          {
-            x: 898,
-            y: 389
-          }
+        name: 'UP',
+        points: [
+            {
+              x: 343,
+              y: 281
+            },
+            {
+              x: 898,
+              y: 389
+            }
         ],
+        showDoubleDirectionMark: true,
         readOnly: false,
         styling: 'primary'
       },

--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -73,7 +73,7 @@ const Line: React.FC<{}> = () => {
               y: 389
             }
         ],
-        showDoubleDirectionMark: true,
+        showBothDirectionMark: true,
         readOnly: false,
         styling: 'primary'
       },
@@ -89,7 +89,7 @@ const Line: React.FC<{}> = () => {
             y: 576
           }
         ],
-        hidePointHandle: true,
+        showPointHandle: false,
         readOnly: false,
         styling: 'primary'
       }

--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -49,6 +49,7 @@ const Line: React.FC<{}> = () => {
           }
         ],
         readOnly: false,
+        hidePointHandle: true,
         styling: 'primary'
       }
     ];
@@ -87,10 +88,11 @@ const Line: React.FC<{}> = () => {
             x: 256,
             y: 576
           }
-          ],
-          readOnly: false,
-          styling: 'primary'
-        }
+        ],
+        hidePointHandle: true,
+        readOnly: false,
+        styling: 'primary'
+      }
     ];
 
     dispatch({

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -229,14 +229,14 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
       styling={styling}
       lineMoveCallback={lineDragUpdate}
       lineMoveStartCallback={lineDragStart}
-      doubleDirectionMark={!!lineSetData.showDoubleDirectionMark}
+      bothDirectionMark={!!lineSetData.showBothDirectionMark}
     />
   );});
 
   return (
     <g>
       {lines}
-      {!lineSetData.hidePointHandle && handles}
+      {(lineSetData.showPointHandle ?? true) && handles}
       {points}
       <AreaLabel lineSetData={lineSetData} unit={unit} />
     </g>

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -181,25 +181,26 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
     }
   }, [lineSetData, updateHandleAngles, handleUsesAngles]);
 
-  const handles = lineSetData.points.map(({x,y}, index) =>
-    <HandleUnit
-      key={index+lineSetId}
-      lineSetId={lineSetId}
-      rotate={lineSetData.rotate}
-      Icon={lineSetData.icon}
-      index={index}
-      unit={unit}
-      size={size}
-      useAngles={handleUsesAngles}
-      angle={handleAngles[index]}
-      x={x}
-      y={y}
-      moveEndCB={onLineMoveEnd}
-      moveCallback={handleMoveCallback}
-      options={options}
-      styling={lineSetData.styling}
-      readOnlyHandle={lineSetData.readOnly}
-    />
+  const handles = (lineSetData?.showPointHandle === undefined || lineSetData?.showPointHandle) &&
+    lineSetData.points.map(({ x, y }, index) =>
+      <HandleUnit
+        key={index+lineSetId}
+        lineSetId={lineSetId}
+        rotate={lineSetData.rotate}
+        Icon={lineSetData.icon}
+        index={index}
+        unit={unit}
+        size={size}
+        useAngles={handleUsesAngles}
+        angle={handleAngles[index]}
+        x={x}
+        y={y}
+        moveEndCB={onLineMoveEnd}
+        moveCallback={handleMoveCallback}
+        options={options}
+        styling={lineSetData.styling}
+        readOnlyHandle={lineSetData.readOnly}
+      />
   );
 
   const points = options.showPoint && (lineSetData.points.map(({x,y}, index) => <Point styling={lineSetData.styling||'primary'} key={index} r={unit} cx={x} cy={y} />));
@@ -237,7 +238,7 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
   return (
     <g>
       {lines}
-      {(lineSetData.showPointHandle ?? true) && handles}
+      {handles}
       {points}
       <AreaLabel lineSetData={lineSetData} unit={unit} />
     </g>

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -230,7 +230,7 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
       lineMoveCallback={lineDragUpdate}
       lineMoveStartCallback={lineDragStart}
       showSmallDirectionMark={lineSetData.showSmallDirectionMark}
-      hideMoveHandle={lineSetData.showMoveHandle}
+      overrideShowMoveHandle={lineSetData.showMoveHandle}
     />
   );});
 

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -229,6 +229,7 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
       styling={styling}
       lineMoveCallback={lineDragUpdate}
       lineMoveStartCallback={lineDragStart}
+      doubleDirectionMark={!!lineSetData.showDoubleDirectionMark}
     />
   );});
 

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -229,7 +229,8 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
       styling={styling}
       lineMoveCallback={lineDragUpdate}
       lineMoveStartCallback={lineDragStart}
-      bothDirectionMark={!!lineSetData.showBothDirectionMark}
+      bothDirectionMark={!!lineSetData.showSmallDirectionMark}
+      hideMoveHandle={lineSetData.showMoveHandle}
     />
   );});
 

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -229,7 +229,7 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
       styling={styling}
       lineMoveCallback={lineDragUpdate}
       lineMoveStartCallback={lineDragStart}
-      bothDirectionMark={!!lineSetData.showSmallDirectionMark}
+      showSmallDirectionMark={lineSetData.showSmallDirectionMark}
       hideMoveHandle={lineSetData.showMoveHandle}
     />
   );});

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -235,7 +235,7 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
   return (
     <g>
       {lines}
-      {handles}
+      {!lineSetData.hidePointHandle && handles}
       {points}
       <AreaLabel lineSetData={lineSetData} unit={unit} />
     </g>

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -107,6 +107,8 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
   // const b = y1 - y2;
   // const distance = Math.sqrt( a*a + b*b );
   //this distance 60 doesn't work now...
+  // const hideGrabHandle = showMoveHandle === false || (showMoveHandle !== true && distance < 60);
+  
   const hideGrabHandle = !showMoveHandle || !overrideShowMoveHandle;
 
 

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -94,20 +94,20 @@ interface ILineUnitProps {
   label?: string;
   styling?: string;
   showSmallDirectionMark?: boolean;
-  hideMoveHandle?: boolean;
+  overrideShowMoveHandle?: boolean;
 }
 
 
 
 const LineUnit : React.FC<ILineUnitProps> = (props) => {
-  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling = 'primary', moveEndCB = () => { }, showSmallDirectionMark = false, hideMoveHandle = true } = props;
+  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling = 'primary', moveEndCB = () => { }, showSmallDirectionMark = false, overrideShowMoveHandle = true } = props;
   const { handleFinderActive, revealSetIndex, showMoveHandle, setIndexOffset, showDirectionMark} = options;
 
   const a = x1 - x2;
   const b = y1 - y2;
   const distance = Math.sqrt( a*a + b*b );
   //this distance 60 doesn't work now...
-  const hideGrabHandle = hideMoveHandle ? (showMoveHandle === false || (showMoveHandle !== true && distance < 60)) : !hideMoveHandle;
+  const hideGrabHandle = (!showMoveHandle || !overrideShowMoveHandle);
 
 
   /** --- Toucher Events Section --- */

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -107,7 +107,7 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
   const b = y1 - y2;
   const distance = Math.sqrt( a*a + b*b );
   //this distance 60 doesn't work now...
-  const hideGrabHandle = (!showMoveHandle || !overrideShowMoveHandle);
+  const hideGrabHandle = !showMoveHandle || !overrideShowMoveHandle;
 
 
   /** --- Toucher Events Section --- */

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -93,12 +93,13 @@ interface ILineUnitProps {
   moveEndCB?: () => void;
   label?: string;
   styling?: string;
+  doubleDirectionMark: boolean;
 }
 
 
 
 const LineUnit : React.FC<ILineUnitProps> = (props) => {
-  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling='primary', moveEndCB=()=>{}} = props;
+  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling='primary', moveEndCB=()=>{}, doubleDirectionMark } = props;
   const { handleFinderActive, revealSetIndex, showMoveHandle, setIndexOffset, showDirectionMark} = options;
 
   const a = x1 - x2;
@@ -170,11 +171,17 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
           <DMCircle r={12} cx={6} cy={7} />
           <Icon color='inverse' icon='Up' size={12} weight='heavy' forSvgUsage />
         </g>
-        <g transform={`translate(0,30) rotate(${dmCoordinate.labelRotate})`}>
-          <LabelText styling={styling} fontSize={`${14}px`} x={0} y={0} showIndex={revealSetIndex || handleFinderActive}>
-            {label}
-          </LabelText>
-        </g>
+        {doubleDirectionMark &&
+          <g transform='translate(5,25) rotate(-180) scale(0.8)'>
+            <DMCircle r={8} cx={3.5} cy={4.5} />
+            <Icon color='inverse' icon='Up' size={7} weight='heavy' forSvgUsage />
+          </g>}
+        {label &&
+          <g transform={`translate(0,${doubleDirectionMark ? 45 : 30}) rotate(${dmCoordinate.labelRotate})`}>
+            <LabelText textAnchor='middle' dominantBaseline='middle' styling={styling} fontSize={`${14}px`} x={0} y={0} showIndex={revealSetIndex || handleFinderActive}>
+              {label}
+            </LabelText>
+          </g>}
       </g>
     );
   };

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -93,14 +93,14 @@ interface ILineUnitProps {
   moveEndCB?: () => void;
   label?: string;
   styling?: string;
-  bothDirectionMark: boolean;
+  showSmallDirectionMark?: boolean;
   hideMoveHandle?: boolean;
 }
 
 
 
 const LineUnit : React.FC<ILineUnitProps> = (props) => {
-  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling = 'primary', moveEndCB = () => { }, bothDirectionMark, hideMoveHandle = true } = props;
+  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling = 'primary', moveEndCB = () => { }, showSmallDirectionMark = false, hideMoveHandle = true } = props;
   const { handleFinderActive, revealSetIndex, showMoveHandle, setIndexOffset, showDirectionMark} = options;
 
   const a = x1 - x2;
@@ -172,13 +172,13 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
           <DMCircle r={12} cx={6} cy={7} />
           <Icon color='inverse' icon='Up' size={12} weight='heavy' forSvgUsage />
         </g>
-        {bothDirectionMark &&
+        {showSmallDirectionMark &&
           <g transform='translate(5,25) rotate(-180) scale(0.8)'>
             <DMCircle r={8} cx={3.5} cy={4.5} />
             <Icon color='inverse' icon='Up' size={7} weight='heavy' forSvgUsage />
           </g>}
         {label &&
-          <g transform={`translate(0,${bothDirectionMark ? 45 : 30}) rotate(${dmCoordinate.labelRotate})`}>
+          <g transform={`translate(0,${showSmallDirectionMark ? 45 : 30}) rotate(${dmCoordinate.labelRotate})`}>
             <LabelText textAnchor='middle' dominantBaseline='middle' styling={styling} fontSize={`${14}px`} x={0} y={0} showIndex={revealSetIndex || handleFinderActive}>
               {label}
             </LabelText>

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -103,9 +103,9 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
   const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling = 'primary', moveEndCB = () => { }, showSmallDirectionMark = false, overrideShowMoveHandle = true } = props;
   const { handleFinderActive, revealSetIndex, showMoveHandle, setIndexOffset, showDirectionMark} = options;
 
-  const a = x1 - x2;
-  const b = y1 - y2;
-  const distance = Math.sqrt( a*a + b*b );
+  // const a = x1 - x2;
+  // const b = y1 - y2;
+  // const distance = Math.sqrt( a*a + b*b );
   //this distance 60 doesn't work now...
   const hideGrabHandle = !showMoveHandle || !overrideShowMoveHandle;
 

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -93,13 +93,13 @@ interface ILineUnitProps {
   moveEndCB?: () => void;
   label?: string;
   styling?: string;
-  doubleDirectionMark: boolean;
+  bothDirectionMark: boolean;
 }
 
 
 
 const LineUnit : React.FC<ILineUnitProps> = (props) => {
-  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling='primary', moveEndCB=()=>{}, doubleDirectionMark } = props;
+  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling='primary', moveEndCB=()=>{}, bothDirectionMark } = props;
   const { handleFinderActive, revealSetIndex, showMoveHandle, setIndexOffset, showDirectionMark} = options;
 
   const a = x1 - x2;
@@ -171,13 +171,13 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
           <DMCircle r={12} cx={6} cy={7} />
           <Icon color='inverse' icon='Up' size={12} weight='heavy' forSvgUsage />
         </g>
-        {doubleDirectionMark &&
+        {bothDirectionMark &&
           <g transform='translate(5,25) rotate(-180) scale(0.8)'>
             <DMCircle r={8} cx={3.5} cy={4.5} />
             <Icon color='inverse' icon='Up' size={7} weight='heavy' forSvgUsage />
           </g>}
         {label &&
-          <g transform={`translate(0,${doubleDirectionMark ? 45 : 30}) rotate(${dmCoordinate.labelRotate})`}>
+          <g transform={`translate(0,${bothDirectionMark ? 45 : 30}) rotate(${dmCoordinate.labelRotate})`}>
             <LabelText textAnchor='middle' dominantBaseline='middle' styling={styling} fontSize={`${14}px`} x={0} y={0} showIndex={revealSetIndex || handleFinderActive}>
               {label}
             </LabelText>

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -94,19 +94,20 @@ interface ILineUnitProps {
   label?: string;
   styling?: string;
   bothDirectionMark: boolean;
+  hideMoveHandle?: boolean;
 }
 
 
 
 const LineUnit : React.FC<ILineUnitProps> = (props) => {
-  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling='primary', moveEndCB=()=>{}, bothDirectionMark } = props;
+  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling = 'primary', moveEndCB = () => { }, bothDirectionMark, hideMoveHandle = true } = props;
   const { handleFinderActive, revealSetIndex, showMoveHandle, setIndexOffset, showDirectionMark} = options;
 
   const a = x1 - x2;
   const b = y1 - y2;
   const distance = Math.sqrt( a*a + b*b );
   //this distance 60 doesn't work now...
-  const hideGrabHandle = showMoveHandle === false || (showMoveHandle !== true && distance < 60);
+  const hideGrabHandle = hideMoveHandle ? (showMoveHandle === false || (showMoveHandle !== true && distance < 60)) : !hideMoveHandle;
 
 
   /** --- Toucher Events Section --- */

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -19,6 +19,7 @@ export interface IPointSet {
   showOrientation?: boolean;
   styling?: string;
   areaName?: string;
+  hidePointHandle?: boolean;
 }
 
 export interface IMinMax {

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -20,7 +20,8 @@ export interface IPointSet {
   styling?: string;
   areaName?: string;
   showPointHandle?: boolean;
-  showBothDirectionMark?: boolean;
+  showSmallDirectionMark?: boolean;
+  showMoveHandle?: boolean;
 }
 
 export interface IMinMax {

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -20,6 +20,7 @@ export interface IPointSet {
   styling?: string;
   areaName?: string;
   hidePointHandle?: boolean;
+  showDoubleDirectionMark?: boolean;
 }
 
 export interface IMinMax {

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -19,8 +19,8 @@ export interface IPointSet {
   showOrientation?: boolean;
   styling?: string;
   areaName?: string;
-  hidePointHandle?: boolean;
-  showDoubleDirectionMark?: boolean;
+  showPointHandle?: boolean;
+  showBothDirectionMark?: boolean;
 }
 
 export interface IMinMax {


### PR DESCRIPTION
### Description

This PR has enhancement in Line UI for the Direction Arrow feature (Feature required for Traffic Counter Project)
- Add Up and Down direction arrow on the same line
- Option to control the show and hide point handle of a specific line
- Fix the alignment issue for the line label to show it on center

Zeplin design:https://zpl.io/r1y9qOD
![Camera - Configuration](https://user-images.githubusercontent.com/91055033/174583074-70fbf00c-6024-4620-a6b4-d33af2f8c1fc.png)


 ### Considerations on Implementation
The implementation is done for **LineUI** component only. Once the changes are approved then we will make similar changes for **LineUIVideo** and **LineUIRTC** components.

 ### Reviewing/Testing steps
Follow the steps given:
https://github.com/future-standard/scorer-ui-kit/tree/feature/line-ui-arrow-icon#readme

When the project runs, Open http://localhost:3000/scorer-ui-kit#/line in the browser you will see

Hide PointHandler Add  "showPointHandle: false" in State Data
Show Both Directions Mark  Add "showBothDirectionMark: true" in  State Data

![localhost_3000_scorer-ui-kit(1440)](https://user-images.githubusercontent.com/91055033/174583537-9b1a059a-c44d-49d0-9845-d2c471f63e02.png)
