### PR TITLE
Add icon prop to Notification Component

### DIFF
--- a/src/Alerts/atom/Notification.tsx
+++ b/src/Alerts/atom/Notification.tsx
@@ -116,13 +116,14 @@ const MainMessage = styled.div`
 export type INotificationProps = {
   type: AlertType;
   message: string;
+  icon?: string;
   actionTextButton?: string;
   onTextButtonClick?: () => void;
   closeCallback?: () => void;
   isPinned?: boolean;
 }
 
-const Notification : React.FC<INotificationProps> = ({type ='info', message, isPinned = false, actionTextButton, closeCallback, onTextButtonClick}) => {
+const Notification : React.FC<INotificationProps> = ({type ='info', message, icon = '', isPinned = false, actionTextButton, closeCallback, onTextButtonClick}) => {
   const [dismiss, setDismiss] = useState(false);
   const [slideUp, setSlideUp] = useState(false);
   const [textClicked, setTextClicked] = useState(false);
@@ -175,7 +176,7 @@ const Notification : React.FC<INotificationProps> = ({type ='info', message, isP
   return( (message && !dismiss)
   ? ReactDom.createPortal(
     <Container type={type} isClosing={slideUp} onAnimationEnd={animationEnded}>
-      <Icon icon={IconNames[type]} color='inverse' />
+      <Icon icon={!icon ? IconNames[type] : icon} color='inverse' />
       <MainMessage>{message}</MainMessage>
       {actionTextButton
         ? <TextButton onClick={() => handleTextClick()}>{actionTextButton} </TextButton>

--- a/src/context/NotificationContext.tsx
+++ b/src/context/NotificationContext.tsx
@@ -41,6 +41,10 @@ const NotificationProvider: React.FC = ({ children }) => {
       type: newNotification.type,
     };
 
+    if (newNotification.icon) {
+      validNotification.icon = newNotification.icon;
+    }
+
     if (newNotification.actionTextButton) {
       validNotification.actionTextButton = newNotification.actionTextButton;
     }

--- a/storybook/src/stories/Alerts/Notification.stories.tsx
+++ b/storybook/src/stories/Alerts/Notification.stories.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { text, boolean, select } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
+import { IconSVGs } from '@future-standard/icons';
 
 import {
   useNotification,
@@ -44,12 +45,25 @@ const NotificationExample: React.FC<INotificationProps> = (notiSettings) => {
   )
 }
 
+const generateIconList = () => {
+  let iconList : {[key: string]: string}= {};
+
+
+  for(const key in IconSVGs){
+    iconList[key] = key;
+  }
+
+  return iconList;
+};
+
   // Provider should be at main Index level, it's here just for the story example
 export const _Notification = () => {
 
   const isPin = boolean('Is Pinned', false);
   const type = select("Type", { Error: 'error', Warning: 'warning', Info: 'info', Success: 'success', Neutral: 'neutral' }, 'info');
   const msg = text('Message', 'This is a message example');
+  const iconList = {'': '', ...generateIconList()};
+  const icon = select("Icon", iconList, Object.keys(iconList)[0]);
   const actionText = text('Action Text Button', '');
   const onTextBtnClick = action('Action was clicked');
   const closeCall = action('The message was closed by the user');
@@ -65,6 +79,7 @@ export const _Notification = () => {
         <NotificationExample
           type={type}
           message={msg}
+          icon={icon}
           closeCallback={closeCall}
           actionTextButton={actionText}
           onTextButtonClick={handleActionTextCall}


### PR DESCRIPTION
### Description

 - In `Notification` there is no option(prop) available to change that notification type "icon" on left and there is an requirement in the design.


### Implementation

- Added a prop: `icon` which can be used to change the type-icon.
- _Note: If `icon` prop is not specified then the component will follow default behavior that is the icon shown will depend on the type of notification._

### Screenshots

- **When icon is not specified**

![image](https://user-images.githubusercontent.com/95204740/180416432-aa335c30-4e36-4222-aeec-6754bac06c92.png)

- **When icon is specified**

![image](https://user-images.githubusercontent.com/95204740/180416607-88cc5d55-a428-4e15-b0ee-c1e6a68ef77e.png)
