### PR TITLE
Feature/Line UI enhancements

### DIFF
--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -23,6 +23,7 @@ const Line: React.FC<{}> = () => {
   const [options, setOptions] = useState<LineUIOptions>({
     showSetIndex: true,
     pointIndexOffset: 1,
+    showPointHandle: true,
     showPointLabel: true,
     setIndexOffset: 1,
     showMoveHandle: true,
@@ -73,6 +74,7 @@ const Line: React.FC<{}> = () => {
               y: 389
             }
         ],
+        showPointHandle: true,
         showSmallDirectionMark: true,
         readOnly: false,
         styling: 'primary'
@@ -133,14 +135,20 @@ const Line: React.FC<{}> = () => {
   }, [state]);
 
   const selectLine = useCallback((lineId: number) => {
-    state.forEach((_, index) => {
-      dispatch({
-        type: 'UPDATE_SET_OPTIONS',
-        index,
-        data: {
-          showPointHandle: lineId === index,
-        }
-      });
+    const deselectLineIndex = state.findIndex((item) => item.showPointHandle);
+    dispatch({
+      type: 'UPDATE_SET_OPTIONS',
+      index: deselectLineIndex,
+      data: {
+        showPointHandle: false,
+      }
+    });
+    dispatch({
+      type: 'UPDATE_SET_OPTIONS',
+      index: lineId,
+      data: {
+        showPointHandle: true,
+      }
     });
   }, [state]);
 

--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -141,6 +141,7 @@ const Line: React.FC<{}> = () => {
       index: deselectLineIndex,
       data: {
         showPointHandle: false,
+        showMoveHandle: false
       }
     });
     dispatch({
@@ -148,6 +149,7 @@ const Line: React.FC<{}> = () => {
       index: lineId,
       data: {
         showPointHandle: true,
+        showMoveHandle: true
       }
     });
   }, [state]);

--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -132,6 +132,18 @@ const Line: React.FC<{}> = () => {
     });
   }, [state]);
 
+  const selectLine = useCallback((lineId: number) => {
+    state.forEach((_, index) => {
+      dispatch({
+        type: 'UPDATE_SET_OPTIONS',
+        index,
+        data: {
+          showPointHandle: lineId === index,
+        }
+      });
+    });
+  }, [state]);
+
   const toggleOptions = useCallback((option: keyof LineUIOptions) => () => {
     setOptions({...options, [option]: !options[option]});
   }, [options]);
@@ -191,7 +203,7 @@ const Line: React.FC<{}> = () => {
       <Content padBottom={false}>
         {error && <div>{error}</div>}
         <LineSetContext.Provider value={{ state, dispatch }}>
-          <LineUI options={options} src="https://i.picsum.photos/id/1026/4621/3070.jpg?hmac=OJ880cIneqAKIwHbYgkRZxQcuMgFZ4IZKJasZ5c5Wcw" />
+          <LineUI options={options} onLineClick={selectLine} src="https://i.picsum.photos/id/1026/4621/3070.jpg?hmac=OJ880cIneqAKIwHbYgkRZxQcuMgFZ4IZKJasZ5c5Wcw" />
         </LineSetContext.Provider>
       </Content>
     </Layout>

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -26,6 +26,7 @@ interface ILineSetProps {
   lineData: IPointSet,
   options: IDragLineUISharedOptions,
   onLineMoveEnd: () => void;
+  onLineClick: (lineSetId: number) => void;
   getCTM: () => DOMMatrix | null;
 }
 
@@ -50,7 +51,7 @@ const AreaLabel : React.FC<AreaLabelProps> = ( { lineSetData, unit } ) => {
   return <AreaLabelText fontSize={`${unit * 14}px`} styling={lineSetData.styling || 'primary'} x={midpoint.x - (4 * Textlen * unit)} y={midpoint.y + (6 * unit)}>{lineSetData.areaName}</AreaLabelText>;
 };
 
-const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lineSetId, options , onLineMoveEnd}) => {
+const LineSet: React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lineSetId, options, onLineMoveEnd, onLineClick }) => {
   // console.log("Unit " + lineSetId + ", reporting in...")
 
   const {state, dispatch} = useContext(LineSetContext);
@@ -228,6 +229,7 @@ const LineSet : React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, lin
       unit={unit}
       label={name}
       styling={styling}
+      lineClickCallback={onLineClick}
       lineMoveCallback={lineDragUpdate}
       lineMoveStartCallback={lineDragStart}
       showSmallDirectionMark={lineSetData.showSmallDirectionMark}

--- a/src/LineUI/LineUI.tsx
+++ b/src/LineUI/LineUI.tsx
@@ -66,6 +66,7 @@ interface LineUIProps {
   src: string;
   onSizeChange?: (size: { h: number; w: number }) => void;
   onLineMoveEnd?: () => void;
+  onLineClick?: (lineSetId: number) => void;
   options?: LineUIOptions;
   showDirectionMark?: boolean;
 }
@@ -73,6 +74,7 @@ const LineUI: React.FC<LineUIProps> = ({
   src,
   onSizeChange = () => { },
   onLineMoveEnd = () => { },
+  onLineClick = () => { },
   options: {
     showHandleFinder,
     showSetIndex,
@@ -193,7 +195,7 @@ const LineUI: React.FC<LineUIProps> = ({
         (loaded && boundaries) ?
           <Frame ref={frame} viewBox={`0 0 ${imgSize.w} ${imgSize.h} `} version='1.1' xmlns='http://www.w3.org/2000/svg' onPointerDown={handlePositionTipShow} onPointerUp={handlePositionTipHide} onPointerLeave={handlePositionTipHide} transculent={handleFinder}>
             {state.map((lineSet, index) => (
-              <LineSet key={index} onLineMoveEnd={onLineMoveEnd} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
+              <LineSet key={index} onLineMoveEnd={onLineMoveEnd} onLineClick={onLineClick} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
             ))}
           </Frame>
           :

--- a/src/LineUI/LineUIRTC.tsx
+++ b/src/LineUI/LineUIRTC.tsx
@@ -67,6 +67,7 @@ interface LineUIProps {
   ws: string;
   onSizeChange?: (size: {h: number; w: number}) => void;
   onLineMoveEnd?: ()=> void;
+  onLineClick?: ()=> void;
   onLoaded?: (metadata: {height: number; width: number; }) => void;
   options?: LineUIOptions;
   videoOptions?: LineUIVideoOptions;
@@ -75,6 +76,7 @@ const LineUI : React.FC<LineUIProps> = ({
   ws,
   onSizeChange = ()=>{},
   onLineMoveEnd = ()=>{},
+  onLineClick = ()=>{},
   onLoaded = ()=>{},
   videoOptions,
   options: {
@@ -192,7 +194,7 @@ const LineUI : React.FC<LineUIProps> = ({
         loaded &&
           <Frame ref={frame} viewBox={`0 0 ${videoSize.w} ${videoSize.h} `} version='1.1' xmlns='http://www.w3.org/2000/svg' onPointerDown={handlePositionTipShow} onPointerUp={handlePositionTipHide} onPointerLeave={handlePositionTipHide} transcalent={handleFinder}>
             {state.map((lineSet, index) => (
-              <LineSet key={index} onLineMoveEnd={onLineMoveEnd} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
+              <LineSet key={index} onLineMoveEnd={onLineMoveEnd} onLineClick={onLineClick} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
               ))}
           </Frame>
       }

--- a/src/LineUI/LineUIVideo.tsx
+++ b/src/LineUI/LineUIVideo.tsx
@@ -66,6 +66,7 @@ interface LineUIProps {
   src: string;
   onSizeChange?: (size: {h: number; w: number}) => void;
   onLineMoveEnd?: ()=> void;
+  onLineClick?: ()=> void;
   onLoaded?: (metadata: {height: number; width: number; }) => void;
   options?: LineUIOptions;
   videoOptions: LineUIVideoOptions;
@@ -74,6 +75,7 @@ const LineUIVideo : React.FC<LineUIProps> = ({
   src,
   onSizeChange = ()=>{},
   onLineMoveEnd = ()=>{},
+  onLineClick = ()=>{},
   onLoaded = ()=>{},
   videoOptions: {
     loop = false,
@@ -196,7 +198,7 @@ const LineUIVideo : React.FC<LineUIProps> = ({
         loaded &&
           <Frame ref={frame} viewBox={`0 0 ${videoSize.w} ${videoSize.h} `} version='1.1' xmlns='http://www.w3.org/2000/svg' onPointerDown={handlePositionTipShow} onPointerUp={handlePositionTipHide} onPointerLeave={handlePositionTipHide} transcalent={handleFinder}>
             {state.map((lineSet, index) => (
-              <LineSet key={index} onLineMoveEnd={onLineMoveEnd} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
+              <LineSet key={index} onLineMoveEnd={onLineMoveEnd} onLineClick={onLineClick} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
               ))}
           </Frame>
       }

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -181,7 +181,7 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
           </g>}
         {label &&
           <g transform={`translate(0,${showSmallDirectionMark ? 45 : 30}) rotate(${dmCoordinate.labelRotate})`}>
-            <LabelText textAnchor='middle' dominantBaseline='middle' styling={styling} fontSize={`${14}px`} x={0} y={0} showIndex={revealSetIndex || handleFinderActive}>
+            <LabelText textAnchor={showSmallDirectionMark ? dmCoordinate.labelRotate < 0 ? 'end' : 'start' : 'middle'} dominantBaseline='middle' styling={styling} fontSize={`${14}px`} x={0} y={0} showIndex={revealSetIndex || handleFinderActive}>
               {label}
             </LabelText>
           </g>}

--- a/src/LineUI/LineUnit.tsx
+++ b/src/LineUI/LineUnit.tsx
@@ -5,7 +5,6 @@ import Icon from '../Icons/Icon';
 
 
 const ContrastLine = styled.line<{styling: string}>`
-  pointer-events: none;
   stroke: ${({theme, styling}) => theme.custom.lines[styling].contrastLine.stroke};
   mix-blend-mode: multiply;
 `;
@@ -88,6 +87,7 @@ interface ILineUnitProps {
   x2: number,
   y2: number,
   unit: number,
+  lineClickCallback: (lineSetId: number) => void,
   lineMoveCallback: any,
   lineMoveStartCallback: any,
   moveEndCB?: () => void;
@@ -100,7 +100,7 @@ interface ILineUnitProps {
 
 
 const LineUnit : React.FC<ILineUnitProps> = (props) => {
-  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling = 'primary', moveEndCB = () => { }, showSmallDirectionMark = false, overrideShowMoveHandle = true } = props;
+  const { x1, y1, x2, y2, unit, lineMoveCallback, lineMoveStartCallback, options, lineSetId, label, styling = 'primary', moveEndCB = () => { }, lineClickCallback = () => { }, showSmallDirectionMark = false, overrideShowMoveHandle = true } = props;
   const { handleFinderActive, revealSetIndex, showMoveHandle, setIndexOffset, showDirectionMark} = options;
 
   // const a = x1 - x2;
@@ -191,7 +191,7 @@ const LineUnit : React.FC<ILineUnitProps> = (props) => {
 
   return (
     <g>
-      <ContrastLine styling={styling} strokeLinecap='round' x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth={4 * unit} />
+      <ContrastLine onClick={() => lineClickCallback(lineSetId)} styling={styling} strokeLinecap='round' x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth={4 * unit} />
       <HighlightLine styling={styling} x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth={2 * unit} />
 
       <GrabHandleGroup styling={styling} showIndex={handleFinderActive && revealSetIndex} originalRadius={8 * unit}>


### PR DESCRIPTION
### Description

This PR has updates for `LineUI` to provide support for customer requests. 
- Lines should be selectable on clicking them.
- Provide fix for overlapping of Line-label and `small-direction-arrow`
- Links of Bugherd issues
  - [Selectable Lines](https://www.bugherd.com/projects/289019/tasks/159)
  - [Overlapping issue](https://www.bugherd.com/projects/289019/tasks/157)


 ### Considerations on Implementation
- For Selectable lines, Function binding is required with an parameter to `onLineClick` prop of LineUI which will be called when lines got clicked and `lineSetID` will be provided. We can use this **ID** to toggle `readOnly` and `showHandle` option of Lines
- For Overlapping issue, I kept previous implementation of line-label same, fix will only occur when we have `small-direction-arrow`.

 ### Reviewing/Testing steps

- To test it just run the example pages and goto line page. And click on any line and that line will be selected.
- To test overlapping issue with `small-direction-arrow` just rename the line will large text from the options in left menu and rotate the line in all direction and check if label and `small-direction-arrow` overlap or not.