### PR TITLE
Fix/Table thumbnail modal min-height issue

### DIFF
--- a/src/Tables/atoms/TableRowThumbnail.tsx
+++ b/src/Tables/atoms/TableRowThumbnail.tsx
@@ -104,7 +104,7 @@ const TableRowThumbnail: React.FC<IProps> = ({ hoverZoom = true, image='', media
   const handleModal = useCallback(async () => {
 
     if ( mediaUrl && mediaType ) {
-      createMediaModal({ src: mediaUrl, mediaType });
+      createMediaModal({ src: mediaUrl, mediaType, minHeight: '240px' });
     }
   }, [createMediaModal, mediaType, mediaUrl]);
 

--- a/src/hooks/useMediaModal.tsx
+++ b/src/hooks/useMediaModal.tsx
@@ -62,7 +62,7 @@ export const useMediaModal = () => {
       dismissCallback,
       retryLoading = false,
       retryLimit=5,
-      minHeight='240px',
+      minHeight='300px',
       minWidth='300px',
     } = mediaModal;
 

--- a/src/hooks/useMediaModal.tsx
+++ b/src/hooks/useMediaModal.tsx
@@ -62,7 +62,7 @@ export const useMediaModal = () => {
       dismissCallback,
       retryLoading = false,
       retryLimit=5,
-      minHeight='300px',
+      minHeight='240px',
       minWidth='300px',
     } = mediaModal;
 


### PR DESCRIPTION
### Description

- In Tables, modal for row thumbnail has `min-height: 300` which is more than a QVGA(320 x 240) image due to which an extra space were seen in the bottom. This issue was reported by customer in below bugherd link.
- [Modal Extra space issue](https://www.bugherd.com/projects/289019/tasks/196) please check its attached thumbnail snapshot.

### Considerations and Implementation
- I just reduced the `min-height` to `240px`.
- To verify and implement this, I used a QVGA image.

### Screenshots

- **White space in height of QVGA image popup**

![spaceIssue](https://user-images.githubusercontent.com/95204740/191952443-76a0cb57-aba4-48f3-bb22-0a70a0b6a921.png)

- **Fix**

![spaceFix](https://user-images.githubusercontent.com/95204740/191952526-8799ec69-d7dd-4eae-86d0-5392f310f574.png)
