### PR TITLE
Feature/user drawer enhancement 2

### DIFF
--- a/src/Global/atoms/UserDrawerMeta.tsx
+++ b/src/Global/atoms/UserDrawerMeta.tsx
@@ -19,7 +19,6 @@ const LabelTitle = styled.div`
   white-space: break-spaces;
   overflow: hidden;
   text-overflow: ellipsis;
-  user-select: none;
   white-space: nowrap;
   opacity: 0.76;
   font-size: 10px;
@@ -28,7 +27,6 @@ const LabelTitle = styled.div`
   color: #575757;
   font-family: ${({ theme }) => theme.fontFamily.ui};
   margin-top: 2px;
-  user-select: all;
 `;
 
 const LabelContent = styled.div`
@@ -40,12 +38,10 @@ const LabelContent = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 4px 0 5px 0;
-  user-select: none;
   white-space: nowrap;
   font-weight: 500;
   letter-spacing: 0.29px;
   color: rgba(87, 87, 87, 0.5);
-  user-select: all;
 `;
 
 const LabelNotes = styled.div`
@@ -56,13 +52,11 @@ const LabelNotes = styled.div`
   text-overflow: ellipsis;
   margin: 5px 0 8px 0;
   max-height: 23px;
-  user-select: none;
   font-size: 10px;
   font-weight: 500;
   letter-spacing: 0.29px;
   color: rgba(87, 87, 87, 0.5);
   font-family: ${({ theme }) => theme.fontFamily.ui};
-  user-select: all;
 `;
 
 const TitleContainer = styled.div`

--- a/src/Global/atoms/UserDrawerMeta.tsx
+++ b/src/Global/atoms/UserDrawerMeta.tsx
@@ -75,16 +75,16 @@ const Container = styled.div`
 interface IProps {
   item: IUserDrawerMeta;
   onUserDrawerMetaClick?:(data:number) => void;
-  dataObjKey: number;
+  userMetaIndex: number;
 }
 
-const UserDrawerMeta : React.FC<IProps> = ({item, onUserDrawerMetaClick = () => { }, dataObjKey}) => {
+const UserDrawerMeta : React.FC<IProps> = ({item, onUserDrawerMetaClick = () => { }, userMetaIndex}) => {
   const { icon, title, subTitle, notes } = item;
 
   return (
     <Fragment>
       {(title !== '' ) &&
-        <Container onClick={()=>onUserDrawerMetaClick(dataObjKey)}>
+        <Container onClick={()=>onUserDrawerMetaClick(userMetaIndex)}>
           <MetaConatiner>
             <TitleContainer>
               <Icon icon={icon as string} size={10} color='dimmed' />

--- a/src/Global/atoms/UserDrawerMeta.tsx
+++ b/src/Global/atoms/UserDrawerMeta.tsx
@@ -74,16 +74,17 @@ const Container = styled.div`
 
 interface IProps {
   item: IUserDrawerMeta;
-  onUserDrawerMetaClick?:() => void;
+  onUserDrawerMetaClick?:(data:number) => void;
+  dataObjKey: number;
 }
 
-const UserDrawerMeta : React.FC<IProps> = ({item, onUserDrawerMetaClick}) => {
+const UserDrawerMeta : React.FC<IProps> = ({item, onUserDrawerMetaClick = () => { }, dataObjKey}) => {
   const { icon, title, subTitle, notes } = item;
 
   return (
     <Fragment>
       {(title !== '' ) &&
-        <Container onClick={onUserDrawerMetaClick}>
+        <Container onClick={()=>onUserDrawerMetaClick(dataObjKey)}>
           <MetaConatiner>
             <TitleContainer>
               <Icon icon={icon as string} size={10} color='dimmed' />

--- a/src/Global/atoms/UserDrawerMeta.tsx
+++ b/src/Global/atoms/UserDrawerMeta.tsx
@@ -28,6 +28,7 @@ const LabelTitle = styled.div`
   color: #575757;
   font-family: ${({ theme }) => theme.fontFamily.ui};
   margin-top: 2px;
+  user-select: all;
 `;
 
 const LabelContent = styled.div`
@@ -44,6 +45,7 @@ const LabelContent = styled.div`
   font-weight: 500;
   letter-spacing: 0.29px;
   color: rgba(87, 87, 87, 0.5);
+  user-select: all;
 `;
 
 const LabelNotes = styled.div`
@@ -60,6 +62,7 @@ const LabelNotes = styled.div`
   letter-spacing: 0.29px;
   color: rgba(87, 87, 87, 0.5);
   font-family: ${({ theme }) => theme.fontFamily.ui};
+  user-select: all;
 `;
 
 const TitleContainer = styled.div`

--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -72,8 +72,8 @@ export interface IMenuTop {
 
 
   export interface IUserDrawerFooter {
-    icon:string,
-    title:string,
+    icon?:string,
+    title?:string,
   }
 
   export interface IUserDrawerMeta {
@@ -105,6 +105,7 @@ export interface IMenuTop {
     userDrawerFooter? : IUserDrawerFooter ,
     userDrawerMeta?: IUserDrawerMeta[];
     hasUserDrawerMeta?: boolean,
+    hasUserDrawerFooter?: boolean,
   }
 
   export interface INotificationItem {

--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -73,7 +73,7 @@ export interface IMenuTop {
 
   export interface IUserDrawerFooter {
     icon?:string,
-    title?:string,
+    title:string,
   }
 
   export interface IUserDrawerMeta {

--- a/src/Global/molecules/TopBar.tsx
+++ b/src/Global/molecules/TopBar.tsx
@@ -160,6 +160,7 @@ const TopBar: React.FC<ITopBar> = ({
   userDrawerMeta,
   onUserDrawerMetaClick = () => { },
   hasUserDrawerMeta,
+  hasUserDrawerFooter,
 }) => {
 
   const [openDrawer, setOpenDrawer] = useState<IDrawerKeys>(null);
@@ -224,6 +225,7 @@ const TopBar: React.FC<ITopBar> = ({
               userDrawerFooter,
               userDrawerMeta,
               hasUserDrawerMeta,
+              hasUserDrawerFooter,
             }}
             />
           </Drawer>

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -158,7 +158,6 @@ const FooterText = styled.div <{ icon?: string }>`
   white-space: nowrap;
   max-width: 136px;
   max-width: ${({ icon }) => icon !== '' ? '136px;' : '164px;'};
-  user-select: all;
 `;
 
 interface IUserMenu extends ITopBar {

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -67,6 +67,19 @@ const IconWrapper = styled.div`
   }
 `;
 
+const IconWrapperFooter = styled.div`
+  width: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  > div {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  padding-right: 20px;
+`;
+
 const LinkMenuItemA = styled(Link) <{ isActive?: boolean }>`
   ${resetButtonStyles};
   display: block;
@@ -114,18 +127,18 @@ const LanguageMenu = styled.button`
   width: 100%;
 `;
 
-const FooterMeta = styled.div`
+const FooterMeta = styled.div <{ icon?: string }>`
   font-family: ${({ theme }) => theme.fontFamily.ui};
   margin-top: auto;
   display: flex;
   flex-direction: row;
-  padding: 10px;
   align-items: center;
   width: 100%;
   font-size: 10px;
   font-weight: 400;
   color: rgba(87, 87, 87, 0.5);
-  display: flex;
+  padding: 10px;
+  padding-left:  ${({ icon }) => icon !== '' ? '31px;' : '21px;'};
 `;
 
 const NavigationContainer = styled.div`
@@ -138,17 +151,14 @@ const NavigationContainer = styled.div`
   `};
 `;
 
-const FooterText = styled.div`
+const FooterText = styled.div <{ icon?: string }>`
   white-space: break-spaces;
   overflow: hidden;
   text-overflow: ellipsis;
   user-select: none;
   white-space: nowrap;
   max-width: 136px;
-`;
-
-const FooterAlignemnt = styled.div`
-  width: 12px;
+  max-width: ${({ icon }) => icon !== '' ? '136px;' : '164px;'};
 `;
 
 interface IUserMenu extends ITopBar {
@@ -253,14 +263,14 @@ const UserMenu: React.FC<IUserMenu> = ({
             </LanguageMenu>
         }
         {(hasUserDrawerFooter) ?
-          <FooterMeta title={title}>
+          <FooterMeta title={title} icon={icon}>
             {icon ?
-              <IconWrapper>
+              <IconWrapperFooter>
                 <Icon icon={icon} size={14} color='dimmed' />
-              </IconWrapper>
+              </IconWrapperFooter>
             :
-              <FooterAlignemnt />}
-            <FooterText>
+              null}
+            <FooterText icon={icon}>
               {title}
             </FooterText>
           </FooterMeta>

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -214,11 +214,11 @@ const UserMenu: React.FC<IUserMenu> = ({
 
         {hasUserDrawerMeta?
           <NavigationContainer>
-            {userDrawerMeta?.map((item:IUserDrawerMeta, index:number) => {
+            {userDrawerMeta?.map((item:IUserDrawerMeta, key:number) => {
             return (
               <UserDetails
                 onUserDrawerMetaClick={onUserDrawerMetaClick}
-                dataObjKey={index}
+                dataObjKey={key}
                 {...{ item }} 
               />
             );

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -158,6 +158,7 @@ const FooterText = styled.div <{ icon?: string }>`
   white-space: nowrap;
   max-width: 136px;
   max-width: ${({ icon }) => icon !== '' ? '136px;' : '164px;'};
+  color: #585858a5;
 `;
 
 interface IUserMenu extends ITopBar {

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -219,7 +219,7 @@ const UserMenu: React.FC<IUserMenu> = ({
               <UserDetails
                 onUserDrawerMetaClick={onUserDrawerMetaClick}
                 key={key}
-                dataObjKey={key}
+                userMetaIndex={key}
                 {...{ item }} 
               />
             );

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -155,7 +155,6 @@ const FooterText = styled.div <{ icon?: string }>`
   white-space: break-spaces;
   overflow: hidden;
   text-overflow: ellipsis;
-  user-select: none;
   white-space: nowrap;
   max-width: 136px;
   max-width: ${({ icon }) => icon !== '' ? '136px;' : '164px;'};

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -259,7 +259,7 @@ const UserMenu: React.FC<IUserMenu> = ({
                 <Icon icon={icon} size={14} color='dimmed' />
               </IconWrapper>
             :
-              <FooterAlignemnt/>}
+              <FooterAlignemnt />}
             <FooterText>
               {title}
             </FooterText>

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -218,6 +218,7 @@ const UserMenu: React.FC<IUserMenu> = ({
             return (
               <UserDetails
                 onUserDrawerMetaClick={onUserDrawerMetaClick}
+                key={key}
                 dataObjKey={key}
                 {...{ item }} 
               />

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -159,6 +159,7 @@ const FooterText = styled.div <{ icon?: string }>`
   white-space: nowrap;
   max-width: 136px;
   max-width: ${({ icon }) => icon !== '' ? '136px;' : '164px;'};
+  user-select: all;
 `;
 
 interface IUserMenu extends ITopBar {

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -144,6 +144,11 @@ const FooterText = styled.div`
   text-overflow: ellipsis;
   user-select: none;
   white-space: nowrap;
+  max-width: 136px;
+`;
+
+const FooterAlignemnt = styled.div`
+  width: 12px;
 `;
 
 interface IUserMenu extends ITopBar {
@@ -168,6 +173,7 @@ const UserMenu: React.FC<IUserMenu> = ({
   onUserDrawerMetaClick = () => { }, 
   userDrawerMeta,
   hasUserDrawerMeta,
+  hasUserDrawerFooter,
 }) => {
 
   const {icon, title} = userDrawerFooter as IUserDrawerFooter;
@@ -246,11 +252,14 @@ const UserMenu: React.FC<IUserMenu> = ({
               Language / 言語
             </LanguageMenu>
         }
-        {(icon || title ) ?
+        {(hasUserDrawerFooter) ?
           <FooterMeta title={title}>
-            <IconWrapper>
-              <Icon icon={icon} size={14} color='dimmed' />
-            </IconWrapper>
+            {icon ?
+              <IconWrapper>
+                <Icon icon={icon} size={14} color='dimmed' />
+              </IconWrapper>
+            :
+              <FooterAlignemnt/>}
             <FooterText>
               {title}
             </FooterText>

--- a/src/Global/molecules/UserMenu.tsx
+++ b/src/Global/molecules/UserMenu.tsx
@@ -214,11 +214,11 @@ const UserMenu: React.FC<IUserMenu> = ({
 
         {hasUserDrawerMeta?
           <NavigationContainer>
-            {userDrawerMeta?.map((item:IUserDrawerMeta, key:number) => {
+            {userDrawerMeta?.map((item:IUserDrawerMeta, index:number) => {
             return (
               <UserDetails
                 onUserDrawerMetaClick={onUserDrawerMetaClick}
-                key={key}
+                dataObjKey={index}
                 {...{ item }} 
               />
             );

--- a/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -523,7 +523,7 @@ export const _GlobalUI = () => {
         defaultMenuOpen={defaultMenuOpen}
         canAlwaysPin={canAlwaysPin}
         userDrawerMeta={userDrawerMetaConfig}
-        {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory, customDrawer }}   
+        {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory, customDrawer }}
         {...{ loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, logoutText, searchPlaceholder, hasLanguage, hasCurrentUser, currentUserText, accountOptionText, userDrawerFooter, hasUserDrawerMeta, hasUserDrawerFooter }}
       >
         <ComponentLinks />

--- a/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -393,6 +393,7 @@ export const _GlobalUI = () => {
   const canAlwaysPin = boolean("Can Always Pin", true);
   const defaultMenuOpen = boolean("Default menu open", false);
   const hasUserDrawerMeta = boolean("Has User Drawer Meta", false);
+  const hasUserDrawerFooter = boolean("Has User Drawer Footer", false);
   const userDrawerFooter = object("User Drawer Footer", {
     icon: 'Information',
     title: 'V12.3.4',
@@ -522,8 +523,8 @@ export const _GlobalUI = () => {
         defaultMenuOpen={defaultMenuOpen}
         canAlwaysPin={canAlwaysPin}
         userDrawerMeta={userDrawerMetaConfig}
-        {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory, customDrawer }}
-        {...{ loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, logoutText, searchPlaceholder, hasLanguage, hasCurrentUser, currentUserText, accountOptionText, userDrawerFooter, hasUserDrawerMeta }}
+        {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory, customDrawer }}   
+        {...{ loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, logoutText, searchPlaceholder, hasLanguage, hasCurrentUser, currentUserText, accountOptionText, userDrawerFooter, hasUserDrawerMeta, hasUserDrawerFooter }}
       >
         <ComponentLinks />
       </GlobalUI>

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -104,6 +104,7 @@ export const _TopBar = () => {
   const currentUserText = text("Current User Text", "Current User");
   const logoutText = text("Logout Text", "Logout");
   const hasUserDrawerMeta = boolean("Has User Drawer Meta", false);
+  const hasUserDrawerFooter = boolean("Has User Drawer Footer", false);
   const userDrawerFooter = object("User Drawer Footer", {
     icon: 'Information',
     title: 'V12.3.4',
@@ -160,6 +161,7 @@ export const _TopBar = () => {
         searchPlaceholder,
         hasLanguage,
         hasUserDrawerMeta,
+        hasUserDrawerFooter,
         hasCurrentUser,
         notificationsHistory,
         currentUserText,


### PR DESCRIPTION
### Description

- While integrating the scorer-ui-kit v1.7.19, we observed that footer attribute is mandatory in TopBar but ideally it should be optional attribute. Footer related changes in ui-kit was merged with this PR (https://github.com/future-standard/scorer-ui-kit/pull/381)
- This PR has an enhancements in User Drawer (Footer) to conditionally show footer information's like version, etc.
-  Removed  `user-select: none` property to select that text of title, subtitle and notes from `UserDrawerMeta.tsx` file and text of footer in `UserMenu.tsx` file.
- Return index by function `onUserDrawerMetaClick`. which will give index of User Drawer Meta object in `UserDetails.tsx` file. Which will help to understand which object we are clicking on UI. So according to that we can use specific object in that function.

- Related Bugherd Requirement links
  - [Requirement](https://www.bugherd.com/projects/289019/tasks/20)
  This changes are required on **Traffic Counter Edge** application.

- Design link
  - [Design](https://app.zeplin.io/project/622084ffc57fbd589f11ef42/screen/6299c853789018ad3a1d6414)

### Considerations on Implementation

- Added a prop `hasUserDrawerFooter` to conditionally show details in drawer footer like application version.

### Screenshots

![Global-Global-UI-⋅-Storybook](https://user-images.githubusercontent.com/87410730/199273912-61f72acc-8e28-45a3-831a-6be2d9f60fa6.png)

![Global-Global-UI-⋅-Storybook](https://user-images.githubusercontent.com/87410730/199962783-dd25201d-e6f6-4950-8d2d-95f48db1d005.png)

