### PR TITLE
Add dynamic icon for date filter in result

### DIFF
--- a/src/Filters/organisms/FilterBar.tsx
+++ b/src/Filters/organisms/FilterBar.tsx
@@ -207,7 +207,7 @@ const createLabelResults = (
       const newLabel: IFilterLabel = {
         filterId: foundPicker.id,
         item: foundPicker.selected,
-        icon: 'Date',
+        icon: datePicker.buttonIcon,
         filterName: datePicker.name,
         type: foundPicker.type
       };


### PR DESCRIPTION
**Description**
This PR is for date picker filter icon.

Adding multiple date pickers to a filter results in the same icons being displayed in the result.
To distinguish this icon in the showing results, include support for the filter's button icon.

**Related Bugherd Requirement links**
[Requirement](https://www.bugherd.com/projects/216134/tasks/133)

**Considerations on Implementation**
Tested this work in TCC project.

![image](https://user-images.githubusercontent.com/75060979/210755545-60b50426-4e98-45a8-af6f-31d631f362ba.png)
