### PR TITLE
Filter: Fix filter last item crop issue

### DIFF
--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -90,12 +90,12 @@ const EmptyResultText = styled.div`
   font-size: 12px;
 `;
 
-const Gradient = styled.div<{hasSearchOption: boolean}>`
+const Gradient = styled.div`
   position: absolute;
   right: 0px;
-  top: ${({ hasSearchOption }) => hasSearchOption ? '223px' : '149px'};
+  bottom: 9px;
   height: 25px;
-  background-image: linear-gradient(to bottom, rgba(246, 247, 249, 0) 1%, #F6F7F9 81%);
+  background-image: linear-gradient(to bottom, rgba(246, 247, 249, 0) 1%, #F6F7F9 120%);
   width: 100%;
 `;
 
@@ -358,7 +358,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
 
                     : <EmptyResultText>{emptyResultText}</EmptyResultText>}
                 </OptionList>
-                {list.length > 5 && <Gradient hasSearchOption={hasOptionsFilter ? true : false} />}
+                {list.length > 5 && <Gradient />}
               </ResultsContainer>)}
         </InnerBox>
       </FilterDropHandler>

--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -35,7 +35,7 @@ const StyledFilterOption = styled(FilterOption)`
 `;
 
 const OptionList = styled.div`
-  max-height: 162px;
+  max-height: 170px;
   min-height: 40px;
   overflow-y: scroll;
   ::-webkit-scrollbar {  /* Hide scrollbar for Chrome, Safari and Opera */

--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -95,7 +95,7 @@ const Gradient = styled.div<{hasSearchOption: boolean}>`
   right: 0px;
   top: ${({ hasSearchOption }) => hasSearchOption ? '223px' : '149px'};
   height: 25px;
-  background-image: linear-gradient(to top,hsl(200deg 23% 97%),hsl(0deg 0% 0% / 0%));
+  background-image: linear-gradient(to bottom, rgba(246, 247, 249, 0) 1%, #F6F7F9 81%);
   width: 100%;
 `;
 

--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -35,8 +35,9 @@ const StyledFilterOption = styled(FilterOption)`
 `;
 
 const OptionList = styled.div`
-  max-height: 170px;
+  max-height: 162px;
   min-height: 40px;
+  position: relative;
   overflow-y: scroll;
   ::-webkit-scrollbar {  /* Hide scrollbar for Chrome, Safari and Opera */
     display: none;
@@ -87,6 +88,15 @@ const EmptyResultText = styled.div`
   display: flex;
   align-items: center;
   font-size: 12px;
+`;
+
+const Gradient = styled.div<{hasSearchOption: boolean}>`
+  position: absolute;
+  right: 0px;
+  top: ${({ hasSearchOption }) => hasSearchOption ? '223px' : '149px'};
+  height: 25px;
+  background-image: linear-gradient(to top,hsl(200deg 23% 97%),hsl(0deg 0% 0% / 0%));
+  width: 100%;
 `;
 
 const isValueSelected = (item: IFilterItem, selected: IFilterValue) => {
@@ -348,6 +358,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
 
                     : <EmptyResultText>{emptyResultText}</EmptyResultText>}
                 </OptionList>
+                {list.length > 5 && <Gradient hasSearchOption={hasOptionsFilter ? true : false}/>}
               </ResultsContainer>)}
         </InnerBox>
       </FilterDropHandler>

--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -358,7 +358,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
 
                     : <EmptyResultText>{emptyResultText}</EmptyResultText>}
                 </OptionList>
-                {list.length > 5 && <Gradient hasSearchOption={hasOptionsFilter ? true : false}/>}
+                {list.length > 5 && <Gradient hasSearchOption={hasOptionsFilter ? true : false} />}
               </ResultsContainer>)}
         </InnerBox>
       </FilterDropHandler>


### PR DESCRIPTION
### Description
This PR consist a following bugfix:
All the filter dropdowns in the scorer-ui-kit, were having maximum 5 displayed options, among which last item was getting cropped as shown in below attached screenshot

**snapshot of ui having bug:**
![image](https://user-images.githubusercontent.com/118800413/215712910-1813c125-b1d2-4d50-880f-45fa67015582.png)
![image](https://user-images.githubusercontent.com/118800413/221839670-f90d6029-5f26-4af1-8704-4b50cb333043.png)

So, as a fix of this bug, instead of increasing a max-height of OptionList from 162px to 170px, as per the suggested comment in the PR I have added a linear-gradient property to the option list if the options in the list are greater than 5 which looks proper as shown in below attached screenshot

**Here are some screenshots of the expected result.**
![image](https://user-images.githubusercontent.com/118800413/222108690-46dcf7a4-c714-42e0-a637-9755da6c8bcd.png)
![image](https://user-images.githubusercontent.com/118800413/222108797-90129bd5-7679-4618-a86d-0a8936a60488.png)
![image](https://user-images.githubusercontent.com/118800413/222108882-8eef1645-8544-4d5d-8cc3-cb4619ccc6f6.png)
![image](https://user-images.githubusercontent.com/118800413/222108949-ebb28f09-cc14-4bc5-a773-af6f9087c453.png)
![image](https://user-images.githubusercontent.com/118800413/222109023-448a2be3-f1fc-469f-bea5-fa871c99a83d.png)



 ### Reviewing/ Testing Steps
 You can review this feature in this page
 https://future-standard.github.io/scorer-ui-kit/storybook/?path=/story/filters-molecules--filter-dropdown
