### PR TITLE
Bugfix/linevideo

### DIFF
--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -62,6 +62,26 @@ const Line: React.FC<{}> = () => {
             y: 1393
           }
         ],
+        showPointHandle: true,
+        showSmallDirectionMark: true,
+        readOnly: false,
+        styling: 'primary'
+      },
+      {
+        name: 'Line 2',
+        points: [
+          {
+            x: 568,
+            y: 1097
+          },
+          {
+            x: 1649,
+            y: 1193
+          }
+        ],
+        showPointHandle: false,
+        showMoveHandle: false,
+        readOnly: false,
         styling: 'primary'
       },
       {
@@ -168,6 +188,26 @@ const Line: React.FC<{}> = () => {
     createMediaModal({ mediaType: 'video', src: '/scorer-ui-kit/traffic.mp4', dismissCallback: handleModalClose })
   }, [createMediaModal, handleModalClose])
 
+  const selectLine = useCallback((lineId: number) => {
+    const deselectLineIndex = state.findIndex((item) => item.showPointHandle);
+    dispatch({
+      type: 'UPDATE_SET_OPTIONS',
+      index: deselectLineIndex,
+      data: {
+        showPointHandle: false,
+        showMoveHandle: false
+      }
+    });
+    dispatch({
+      type: 'UPDATE_SET_OPTIONS',
+      index: lineId,
+      data: {
+        showPointHandle: true,
+        showMoveHandle: true
+      }
+    });
+  }, [state]);
+
   return (
     <Layout >
       <Sidebar>
@@ -194,7 +234,7 @@ const Line: React.FC<{}> = () => {
       <Content padBottom={false}>
         {error && <div>{error}</div>}
         <LineSetContext.Provider value={{ state, dispatch }}>
-          <LineUIVideo options={options} videoOptions={videoOptions} src='/scorer-ui-kit/traffic.mp4' />
+          <LineUIVideo options={options} onLineClick={selectLine} videoOptions={videoOptions} src='/scorer-ui-kit/traffic.mp4' />
         </LineSetContext.Provider>
         <ButtonWrapper>
           <Button onClick={handleMediaModal}>Open Video Modal</Button>

--- a/src/LineUI/LineUIVideo.tsx
+++ b/src/LineUI/LineUIVideo.tsx
@@ -70,6 +70,8 @@ interface LineUIProps {
   onLoaded?: (metadata: {height: number; width: number; }) => void;
   options?: LineUIOptions;
   videoOptions: LineUIVideoOptions;
+  lineClickSensingBorder?: string;
+  hasClickSensingBorder?: boolean;
 }
 const LineUIVideo : React.FC<LineUIProps> = ({
   src,
@@ -77,6 +79,8 @@ const LineUIVideo : React.FC<LineUIProps> = ({
   onLineMoveEnd = ()=>{},
   onLineClick = ()=>{},
   onLoaded = ()=>{},
+  lineClickSensingBorder = '65',
+  hasClickSensingBorder = true,
   videoOptions: {
     loop = false,
     autoPlay = false,
@@ -198,7 +202,7 @@ const LineUIVideo : React.FC<LineUIProps> = ({
         loaded &&
           <Frame ref={frame} viewBox={`0 0 ${videoSize.w} ${videoSize.h} `} version='1.1' xmlns='http://www.w3.org/2000/svg' onPointerDown={handlePositionTipShow} onPointerUp={handlePositionTipHide} onPointerLeave={handlePositionTipHide} transcalent={handleFinder}>
             {state.map((lineSet, index) => (
-              <LineSet key={index} onLineMoveEnd={onLineMoveEnd} onLineClick={onLineClick} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
+              <LineSet key={index} hasClickSensingBorder={hasClickSensingBorder} lineClickSensingBorder={lineClickSensingBorder} onLineMoveEnd={onLineMoveEnd} onLineClick={onLineClick} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
               ))}
           </Frame>
       }

--- a/src/LineUI/LineUIVideo.tsx
+++ b/src/LineUI/LineUIVideo.tsx
@@ -66,7 +66,7 @@ interface LineUIProps {
   src: string;
   onSizeChange?: (size: {h: number; w: number}) => void;
   onLineMoveEnd?: ()=> void;
-  onLineClick?: ()=> void;
+  onLineClick?: (lineSetId: number) => void;
   onLoaded?: (metadata: {height: number; width: number; }) => void;
   options?: LineUIOptions;
   videoOptions: LineUIVideoOptions;


### PR DESCRIPTION
**Description**
This PR has following bugfixes in the LineUiVedio component: 
1.  On hovering over a line on LineVideoUI, a line doesn't show any click sensing border effect so a user can understand that, this is a line he is  pointing to.
2.  When selecting a line video UI by mouse click, it is difficult to select line by clicking exactly on line and also moving a line to different places.


**This PR is an extension of the below below PR:**
[Extension](https://github.com/future-standard/scorer-ui-kit/pull/386)

**Considerations on Implementation**
1. Added a prop lineClickSensingBorder to give width to transparent border and default width of border is 65px, and
  hasClickSensingBorder = true.
2. For selecting line, I have added on click functionality for arrows of line as well as name of line. Also I have added a showPointHandle & showMoveHandle prop to the lineset.

**Here is screencast of the expected result.**
https://www.awesomescreenshot.com/video/15453653?key=358139460ad5a592777162e3565d5b04
