### PR TITLE
On click over NoImage thumbnail, media modal should not open issue re…

### DIFF
--- a/src/Tables/atoms/TableRowThumbnail.tsx
+++ b/src/Tables/atoms/TableRowThumbnail.tsx
@@ -7,7 +7,7 @@ import { NoImage } from '../../svg';
 
 type VideoAspects = '4:3' | '16:9';
 
-const Container = styled.div<{ hoverZoom?: boolean, aspect?: VideoAspects, mediaUrl?: string}>`
+const Container = styled.div<{ hoverZoom?: boolean, aspect?: VideoAspects, mediaUrl?: string, showImage?: boolean}>`
   position: relative;
   height: inherit;
   background: grey;
@@ -34,7 +34,7 @@ const Container = styled.div<{ hoverZoom?: boolean, aspect?: VideoAspects, media
   `}
 
   &:hover {
-    ${({ mediaUrl }) => mediaUrl && css`
+    ${({ mediaUrl, showImage }) => mediaUrl && showImage && css`
       cursor: pointer;
     `};
 
@@ -117,7 +117,7 @@ const TableRowThumbnail: React.FC<IProps> = ({ hoverZoom = true, image='', media
 
   const handleModal = useCallback(async () => {
 
-    if ( mediaUrl && mediaType ) {
+    if ( mediaUrl && mediaType && showImage ) {
       createMediaModal({ src: mediaUrl, mediaType, minHeight: '240px', closeText });
     }
   }, [closeText, createMediaModal, mediaType, mediaUrl]);
@@ -183,7 +183,7 @@ const TableRowThumbnail: React.FC<IProps> = ({ hoverZoom = true, image='', media
   },[image]);
   
   return (
-    <Container {...{ hoverZoom, mediaUrl }} aspect='16:9' onClick={handleModal}>
+    <Container {...{ hoverZoom, mediaUrl, showImage }} aspect='16:9' onClick={handleModal}>
       {showImage ? 
         <ImageWrapper ref={imgRef} src={imgSrc} onError={retryImage} onLoad={onLoad} /> :
         <NoImageWrapper><NoImage /></NoImageWrapper>}


### PR DESCRIPTION
**Description**
This PR has following bugfix in the TableRowThumbnail component:

If there is no image url or broken image url or distorted image url, then in all these cases, the thumbnail in the table showing No image as shown in below attached screenshot, else showing the exact image.
![image](https://user-images.githubusercontent.com/118800413/226252759-a1f13bcc-6229-428a-bdd1-9d5328e01d78.png)

In case of No image thumbnail, somewhere onHover pointer was showing so somewhere not, same for some No image thumbnail, media modal was getting open as shown in below attached screenshot so somewhere not.
![image](https://user-images.githubusercontent.com/118800413/226252878-be4c1fbf-4ed4-4b08-84c4-0e62afe0b217.png)

**Requirement**
Ideally if it is showing No image thumbnail, then pointer event should not be there on hovering over it and also a media modal should not get open.

**Considerations on Implementation**
1. Added showImage boolean state(use to check if the coming image is exists or not and consist boolean value based on the image url) to the onHover css to manage pointer event.
2. Added showImage boolean state to the handleModal function based on which a media modal will get open

**Note**- While using this component, user should not handle condition for "No Image" scenario as it is already handle in the component itself, no need to check if image exists or not 