### PR TITLE
DatePicker - 2 digit time format in the hours input field

### DIFF
--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -123,14 +123,14 @@ const DateTimeBlock : React.FC<IProps> = ({
   const convertMinutes = (date?.getMinutes()).toString();
   const [displayHours, setDisplayHours] = useState<string>(getFormattedTime(convertHours));
   const [displayMinutes, setDisplayMinutes] = useState<string>(getFormattedTime(convertMinutes));
-  const [isKeyboardEvent, setIsKeyboardEvent] = useState(false);
+  const [isNonArrowKey, setIsNonArrowKey] = useState(false);
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
     const key = event.key;
     if (key === "ArrowUp" || key === "ArrowDown") {
-      setIsKeyboardEvent(false);
+      setIsNonArrowKey(false);
     } else {
-      setIsKeyboardEvent(true);
+      setIsNonArrowKey(true);
     }
   },[]);
 
@@ -139,7 +139,7 @@ const DateTimeBlock : React.FC<IProps> = ({
     if (!hourRegex.test(value)) {
       return;
     }
-    isKeyboardEvent ? setDisplayHours(value) : setDisplayHours(value.padStart(2, '0'));
+    isNonArrowKey ? setDisplayHours(value) : setDisplayHours(value.padStart(2, '0'));
     setDateCallback(
       min([
         endOfDay(date),
@@ -151,8 +151,8 @@ const DateTimeBlock : React.FC<IProps> = ({
         })
       ])
     );
-    setIsKeyboardEvent(false);
-  }, [date, displayMinutes, setDateCallback, isKeyboardEvent]);
+    setIsNonArrowKey(false);
+  }, [date, displayMinutes, setDateCallback, isNonArrowKey]);
 
   const setDateMinutes = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
     const minuteRegex = /^[0-5]{0,1}[0-9]{0,1}$/;

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -125,20 +125,23 @@ const DateTimeBlock : React.FC<IProps> = ({
   const [displayMinutes, setDisplayMinutes] = useState<string>(getFormattedTime(convertMinutes));
 
   const setDateHours = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
-    let newVal = '0';
-    if(value.length === 1){
+    let newVal;
+    if(Number(value) > 24){
+      const minuteRegex = /^-?\d{1,2}$|^$/;
+      if (!minuteRegex.test(value)) {
+        return;
+      }
+      newVal = '24';
+    } else if(Number(value) < 0){
+      newVal = '00';
+    } else if(value.length === 1){
       if(value === '0'){
-        newVal = ('0');
+        newVal = ('00');
       } else {
         newVal = ('0' + value).slice(-2) ;
       }
     } else {
       newVal = value.slice(-2);
-    }
-    if(Number(newVal) > 24){
-      newVal = '24';
-    } else if(Number(newVal) < 0){
-      newVal = '0';
     }
     setDisplayHours(newVal);
     setDateCallback(
@@ -189,6 +192,14 @@ const DateTimeBlock : React.FC<IProps> = ({
     }
   }, []);
 
+  const onKeyDownChange = useCallback((event) => {
+    if(event.key==='.' || event.key==='e' || event.key==='-'){
+      event.preventDefault();
+    } else if (event.key==='Backspace'){
+      event.target.name === 'hours' ? setDisplayHours('') : setDisplayMinutes('');
+    }
+  },[]);
+
   return (
     <Container hide={!hasDate && !hasTime}>
       <Label>{title}</Label>
@@ -210,7 +221,7 @@ const DateTimeBlock : React.FC<IProps> = ({
             <Icon icon='Time' color='dimmed' size={14} weight='light' />
           </IconWrap>
           <InputWrap>
-            <InputValue onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} onChange={setDateHours} autoComplete='off' />
+            <InputValue onKeyDown={(e) => onKeyDownChange(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} onChange={setDateHours} autoComplete='off' />
             <TimeColon>:</TimeColon>
             <InputValue onBlur={()=>onBlurInputs(displayMinutes, 'mins')} {...{allowManualTimeChange}} name='minutes' type='number' value={displayMinutes} onChange={setDateMinutes} autoComplete='off' />
           </InputWrap>

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -123,38 +123,61 @@ const DateTimeBlock : React.FC<IProps> = ({
   const convertMinutes = (date?.getMinutes()).toString();
   const [displayHours, setDisplayHours] = useState<string>(getFormattedTime(convertHours));
   const [displayMinutes, setDisplayMinutes] = useState<string>(getFormattedTime(convertMinutes));
+  const [isKeyboardEvent, setIsKeyboardEvent] = useState(false);
 
-  const setDateHours = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
-    let newVal;
-    if(Number(value) > 24){
-      const hourRegex = /^-?\d{1,2}$|^$/;
-      if (!hourRegex.test(value)) {
-        return;
-      }
-      newVal = '24';
-    } else if(Number(value) < 0){
-      newVal = '00';
-    } else if(value.length === 1){
-      if(value === '0'){
-        newVal = '00';
-      } else {
-        newVal = ('0' + value).slice(-2) ;
-      }
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    let value = event.currentTarget.value;
+    const key = event.key;
+    // const hourRegex  = /^[0-1]{0,1}[1-9]{0,1}$|(^2[0-3])$/;
+    // if (!hourRegex.test(value)) {
+    //   return;
+    // }
+    if (key === "ArrowUp") {
+      setIsKeyboardEvent(false);
+      // event.preventDefault();
+      // let hours = parseInt(value);
+      // setDisplayHours((hours + 1).toString().padStart(2, '0'));
+    } else if (key === "ArrowDown") {
+      setIsKeyboardEvent(false);
+      // event.preventDefault();
+      // let hours = parseInt(value);
+      // setDisplayHours((hours - 1).toString().padStart(2, '0'));
     } else {
-      newVal = value.slice(-2);
+      console.log('else');
+      setIsKeyboardEvent(true);
     }
-    setDisplayHours(newVal);
     setDateCallback(
       min([
         endOfDay(date),
         set(date, {
-          hours: Number(newVal),
+          hours: Number(value),
           minutes: Number(displayMinutes),
           seconds: 0,
           milliseconds: 0
         })
       ])
     );
+  },[]);
+
+  const setDateHours = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
+    console.log('2', isKeyboardEvent);
+    const hourRegex  = /^[0-1]{0,1}[0-9]{0,1}$|(^2[0-4])$/;
+    if (!hourRegex.test(value)) {
+      return;
+    }
+    isKeyboardEvent ? setDisplayHours(value) : setDisplayHours(value.padStart(2, '0'));
+    setDateCallback(
+      min([
+        endOfDay(date),
+        set(date, {
+          hours: Number(value),
+          minutes: Number(displayMinutes),
+          seconds: 0,
+          milliseconds: 0
+        })
+      ])
+    );
+    setIsKeyboardEvent(false);
   }, [date, displayMinutes, setDateCallback]);
 
   const setDateMinutes = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
@@ -192,14 +215,6 @@ const DateTimeBlock : React.FC<IProps> = ({
     }
   }, []);
 
-  const onKeyDownChange = useCallback((event) => {
-    if(event.key==='.' || event.key==='e' || event.key==='-'){
-      event.preventDefault();
-    } else if (event.key==='Backspace'){
-      event.target.name === 'hours' ? setDisplayHours('') : setDisplayMinutes('');
-    }
-  },[]);
-
   return (
     <Container hide={!hasDate && !hasTime}>
       <Label>{title}</Label>
@@ -221,7 +236,7 @@ const DateTimeBlock : React.FC<IProps> = ({
             <Icon icon='Time' color='dimmed' size={14} weight='light' />
           </IconWrap>
           <InputWrap>
-            <InputValue onKeyDown={(e) => onKeyDownChange(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} onChange={setDateHours} autoComplete='off' />
+            <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} autoComplete='off' onChange={(e) => setDateHours(e)}/>
             <TimeColon>:</TimeColon>
             <InputValue onBlur={()=>onBlurInputs(displayMinutes, 'mins')} {...{allowManualTimeChange}} name='minutes' type='number' value={displayMinutes} onChange={setDateMinutes} autoComplete='off' />
           </InputWrap>

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -136,7 +136,7 @@ const DateTimeBlock : React.FC<IProps> = ({
       newVal = '00';
     } else if(value.length === 1){
       if(value === '0'){
-        newVal = ('00');
+        newVal = '00';
       } else {
         newVal = ('0' + value).slice(-2) ;
       }

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -126,41 +126,15 @@ const DateTimeBlock : React.FC<IProps> = ({
   const [isKeyboardEvent, setIsKeyboardEvent] = useState(false);
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
-    let value = event.currentTarget.value;
     const key = event.key;
-    // const hourRegex  = /^[0-1]{0,1}[1-9]{0,1}$|(^2[0-3])$/;
-    // if (!hourRegex.test(value)) {
-    //   return;
-    // }
-    if (key === "ArrowUp") {
+    if (key === "ArrowUp" || key === "ArrowDown") {
       setIsKeyboardEvent(false);
-      // event.preventDefault();
-      // let hours = parseInt(value);
-      // setDisplayHours((hours + 1).toString().padStart(2, '0'));
-    } else if (key === "ArrowDown") {
-      setIsKeyboardEvent(false);
-      // event.preventDefault();
-      // let hours = parseInt(value);
-      // setDisplayHours((hours - 1).toString().padStart(2, '0'));
     } else {
-      console.log('else');
       setIsKeyboardEvent(true);
     }
-    setDateCallback(
-      min([
-        endOfDay(date),
-        set(date, {
-          hours: Number(value),
-          minutes: Number(displayMinutes),
-          seconds: 0,
-          milliseconds: 0
-        })
-      ])
-    );
-  },[date, displayMinutes, setDateCallback]);
+  },[]);
 
   const setDateHours = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
-    console.log('2', isKeyboardEvent);
     const hourRegex  = /^[0-1]{0,1}[0-9]{0,1}$|(^2[0-4])$/;
     if (!hourRegex.test(value)) {
       return;
@@ -236,7 +210,7 @@ const DateTimeBlock : React.FC<IProps> = ({
             <Icon icon='Time' color='dimmed' size={14} weight='light' />
           </IconWrap>
           <InputWrap>
-            <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} autoComplete='off' onChange={(e) => setDateHours(e)} />
+            <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} autoComplete='off' onChange={setDateHours} />
             <TimeColon>:</TimeColon>
             <InputValue onBlur={()=>onBlurInputs(displayMinutes, 'mins')} {...{allowManualTimeChange}} name='minutes' type='number' value={displayMinutes} onChange={setDateMinutes} autoComplete='off' />
           </InputWrap>

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -157,7 +157,7 @@ const DateTimeBlock : React.FC<IProps> = ({
         })
       ])
     );
-  },[]);
+  },[date, displayMinutes, setDateCallback]);
 
   const setDateHours = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
     console.log('2', isKeyboardEvent);
@@ -178,7 +178,7 @@ const DateTimeBlock : React.FC<IProps> = ({
       ])
     );
     setIsKeyboardEvent(false);
-  }, [date, displayMinutes, setDateCallback]);
+  }, [date, displayMinutes, setDateCallback, isKeyboardEvent]);
 
   const setDateMinutes = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
     const minuteRegex = /^[0-5]{0,1}[0-9]{0,1}$/;
@@ -236,7 +236,7 @@ const DateTimeBlock : React.FC<IProps> = ({
             <Icon icon='Time' color='dimmed' size={14} weight='light' />
           </IconWrap>
           <InputWrap>
-            <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} autoComplete='off' onChange={(e) => setDateHours(e)}/>
+            <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} autoComplete='off' onChange={(e) => setDateHours(e)} />
             <TimeColon>:</TimeColon>
             <InputValue onBlur={()=>onBlurInputs(displayMinutes, 'mins')} {...{allowManualTimeChange}} name='minutes' type='number' value={displayMinutes} onChange={setDateMinutes} autoComplete='off' />
           </InputWrap>

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -125,16 +125,27 @@ const DateTimeBlock : React.FC<IProps> = ({
   const [displayMinutes, setDisplayMinutes] = useState<string>(getFormattedTime(convertMinutes));
 
   const setDateHours = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
-    const hourRegex  = /^[0-1]{0,1}[0-9]{0,1}$|(^2[0-4])$/;
-    if (!hourRegex.test(value)) {
-      return;
+    let newVal = '0';
+    if(value.length === 1){
+      if(value === '0'){
+        newVal = ('0' + '');
+      } else {
+        newVal = ('0' + value).slice(-2) ;
+      }
+    } else {
+      newVal = value.slice(-2);
     }
-    setDisplayHours(value);
+    if(Number(newVal) > 24){
+      newVal = '24';
+    } else if(Number(newVal) < 0){
+      newVal = '0';
+    }
+    setDisplayHours(newVal);
     setDateCallback(
       min([
         endOfDay(date),
         set(date, {
-          hours: Number(value),
+          hours: Number(newVal),
           minutes: Number(displayMinutes),
           seconds: 0,
           milliseconds: 0

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -127,8 +127,8 @@ const DateTimeBlock : React.FC<IProps> = ({
   const setDateHours = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
     let newVal;
     if(Number(value) > 24){
-      const minuteRegex = /^-?\d{1,2}$|^$/;
-      if (!minuteRegex.test(value)) {
+      const hourRegex = /^-?\d{1,2}$|^$/;
+      if (!hourRegex.test(value)) {
         return;
       }
       newVal = '24';

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -128,7 +128,7 @@ const DateTimeBlock : React.FC<IProps> = ({
     let newVal = '0';
     if(value.length === 1){
       if(value === '0'){
-        newVal = ('0' + '');
+        newVal = ('0');
       } else {
         newVal = ('0' + value).slice(-2) ;
       }

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -210,7 +210,7 @@ const DateTimeBlock : React.FC<IProps> = ({
             <Icon icon='Time' color='dimmed' size={14} weight='light' />
           </IconWrap>
           <InputWrap>
-            <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} autoComplete='off' onChange={setDateHours} />
+            <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} onChange={setDateHours} autoComplete='off' />
             <TimeColon>:</TimeColon>
             <InputValue onBlur={()=>onBlurInputs(displayMinutes, 'mins')} {...{allowManualTimeChange}} name='minutes' type='number' value={displayMinutes} onChange={setDateMinutes} autoComplete='off' />
           </InputWrap>

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -135,16 +135,25 @@ const DateTimeBlock : React.FC<IProps> = ({
   },[]);
 
   const setDateHours = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
-    const hourRegex  = /^[0-1]{0,1}[0-9]{0,1}$|(^2[0-4])$/;
-    if (!hourRegex.test(value)) {
+    const parsedValue = Number(value);
+    let rolledValue;
+    if (parsedValue === 24) {
+      rolledValue = '00';
+    } else if (parsedValue === -1) {
+      rolledValue = '23';
+    } else {
+      rolledValue = value;
+    }
+    const hourRegex  = /^[0-1]{0,1}[0-9]{0,1}$|(^2[0-3])$/;
+    if (!hourRegex.test(rolledValue)) {
       return;
     }
-    isNonArrowKey ? setDisplayHours(value) : setDisplayHours(value.padStart(2, '0'));
+    isNonArrowKey ? setDisplayHours(rolledValue) : setDisplayHours(rolledValue.padStart(2, '0'));
     setDateCallback(
       min([
         endOfDay(date),
         set(date, {
-          hours: Number(value),
+          hours: Number(rolledValue),
           minutes: Number(displayMinutes),
           seconds: 0,
           milliseconds: 0
@@ -155,23 +164,33 @@ const DateTimeBlock : React.FC<IProps> = ({
   }, [date, displayMinutes, setDateCallback, isNonArrowKey]);
 
   const setDateMinutes = useCallback(({target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
+    const parsedValue = Number(value);
+    let rolledValue;
+    if (parsedValue === 60) {
+      rolledValue = '00';
+    } else if (parsedValue === -1) {
+      rolledValue = '59';
+    } else {
+      rolledValue = value;
+    }
     const minuteRegex = /^[0-5]{0,1}[0-9]{0,1}$/;
-    if (!minuteRegex.test(value)) {
+    if (!minuteRegex.test(rolledValue)) {
       return;
     }
-    setDisplayMinutes(value);
+    isNonArrowKey ? setDisplayMinutes(rolledValue) : setDisplayMinutes(rolledValue.padStart(2, '0'));
     setDateCallback(
       min([
         endOfDay(date),
         set(date, {
           hours: displayHours === '24' ? 23 : Number(displayHours),
-          minutes: Number(value) % 60,
+          minutes: Number(rolledValue) % 60,
           seconds: 0,
           milliseconds: 0
         })
       ])
     );
-  }, [date, displayHours, setDateCallback]);
+    setIsNonArrowKey(false);
+  }, [date, displayHours, setDateCallback, isNonArrowKey]);
 
   useEffect(()=>{
     if(allowAfterMidnight && isEqual(date, endOfDay(date))){
@@ -212,7 +231,7 @@ const DateTimeBlock : React.FC<IProps> = ({
           <InputWrap>
             <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayHours, 'hours')} {...{allowManualTimeChange}} name='hours' type='number' value={displayHours} onChange={setDateHours} autoComplete='off' />
             <TimeColon>:</TimeColon>
-            <InputValue onBlur={()=>onBlurInputs(displayMinutes, 'mins')} {...{allowManualTimeChange}} name='minutes' type='number' value={displayMinutes} onChange={setDateMinutes} autoComplete='off' />
+            <InputValue onKeyDown={(e) => handleKeyDown(e)} onBlur={()=>onBlurInputs(displayMinutes, 'mins')} {...{allowManualTimeChange}} name='minutes' type='number' value={displayMinutes} onChange={setDateMinutes} autoComplete='off' />
           </InputWrap>
         </Item>
       )}

--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -194,8 +194,8 @@ const DateTimeBlock : React.FC<IProps> = ({
 
   useEffect(()=>{
     if(allowAfterMidnight && isEqual(date, endOfDay(date))){
-      setDisplayHours('24');
-      setDisplayMinutes('00');
+      setDisplayHours('23');
+      setDisplayMinutes('59');
     }
   },[date, allowAfterMidnight]);
 

--- a/src/Filters/molecules/DatePicker.tsx
+++ b/src/Filters/molecules/DatePicker.tsx
@@ -360,7 +360,9 @@ const DatePicker: React.FC<IDatePicker> = ({
   const updateStartDate = useCallback((start: Date) => {
     const { end } = selectedRange ? selectedRange : TODAY_INTERVAL;
     if((isAfter(add(start, { minutes: 1 }), end))){
-      setAllowManualTimeChange(true);
+      if(dateMode === 'interval' || timeMode === 'interval'){
+        setAllowManualTimeChange(true); 
+      }
     } else {
       setAllowManualTimeChange(false);
     }

--- a/src/Filters/molecules/DatePicker.tsx
+++ b/src/Filters/molecules/DatePicker.tsx
@@ -367,7 +367,7 @@ const DatePicker: React.FC<IDatePicker> = ({
       setAllowManualTimeChange(false);
     }
     setSelectedRange({ start, end });
-  }, [selectedRange]);
+  }, [selectedRange, dateMode, timeMode]);
 
   const updateEndDate = useCallback((end: Date) => {
     const { start } = selectedRange ? selectedRange : TODAY_INTERVAL;


### PR DESCRIPTION
### Description

This PR has following change in the Hour input of DatePicker component:

- While pressing UP arrow(incrementing) of the input field from 0 to 9, it shows a single digit value, ex- 0, 1, 2, 3, 4, 5, 6, 7, 8, 9  shown in below attached screenshot:

![image](https://user-images.githubusercontent.com/118800413/226535490-a725c13b-0738-4c41-b33a-e2c6c98a2412.png)

- While pressing UP arrow(incrementing) of the input field from 10 to 24 it shows 2 digit value
- Similarly while pressing DOWN arrow(decrementing) of the input field from 9 to 0 it shows single digit value
- Expected result is, for the single digit value from 0 to 9 it must show 2 digit representation such as 00, 01, 02, 03, 04, 05, 06, 07, 08, 09
- Also while entering value manually, if I enter 1 then it should show 01 and if i enter 11 then it must show 11.
- decimal values and exponential constant were allowing, which must be restricted

**Additional Requirement** 
- I have also implemented a rollover of the hours field value.
- Example: When the user increments the value from 23, it should roll over to 00. Similarly, when the user decrements the value from 00, it should roll over to 23.

**Considerations on Implementation**

- To achieve 2 digit time format, I'm padding 0 with the entered value as given below:
**setDisplayHours(value.padStart(2, '0'))** 

But I have handled this 0 padding conditionally, If I won't handle this conditionally then a user won't be able to delete entered value manually and enter a new value from keyboard because it will pad 00 if backspace hit occurs, and it will again raise below issue.
[BH](https://www.bugherd.com/projects/216134/tasks/132)

- We want 0 padding only when **UP/DOWN keyboard keys** or **UP/DOWN ui input box arrow** hit occurs, any keyboard entries other than **UP/DOWN keyboard keys** hit occurs then it should not pad 0.

- To make this happen, I used below state
const [isNonArrowKey, setIsNonArrowKey] = useState(false);

- Making isNonArrowKey = true only when **KeyboardEvent** occurs and **event.key** is not equal to"ArrowUp" or "ArrowDown"

- So based on isNonArrowKey state we padding 0 to the value as shown below:
**isNonArrowKey ? setDisplayHours(value) : setDisplayHours(value.padStart(2, '0'));**

 
**Here are some screenshots of the expected result.**

![image](https://user-images.githubusercontent.com/118800413/226535753-02ee724d-b06b-453a-aba4-8bffdb568d2a.png)

**Kindly go through attached Screencast for better clarity of implementation**

https://github.com/future-standard/scorer-ui-kit/assets/118800413/807ca74e-a5ae-4571-8e8f-faa8475649f1

**Important Note** -> 
I'm merging the changes of below PR in this PR only as there are some common functions or logic we are using in both PR.
https://github.com/future-standard/scorer-ui-kit/pull/404