### PR TITLE
Left sidebar >> Menu name should not be hidden in 1368X768 and 1024X720 resolutions

### DIFF
--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -66,7 +66,7 @@ const NavigationContainer = styled.div`
   }
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none; /* Firefox */
-  max-height: 400px;
+  max-height: 500px;
 
   &::after {
     background: linear-gradient(rgba(246, 247, 249, 0) 1%, #F6F7F9 120%) center bottom;

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -49,12 +49,12 @@ const SVGObjectText = styled.object`
 const GradientContainer = styled.div`
   &::after {
     content: '';
-    background: radial-gradient(farthest-side at 50% 100%,rgba(246, 247, 249, 0) 1%, #F6F7F9 120%) center bottom; //Shodow bottom
+    background: linear-gradient(to bottom, transparent, #e5e5e5); //Shodow bottom
     height: 10px;
     display: block;
     position: absolute;
     margin-top: -10px;
-    width: 300px;
+    width: 100%;
   }
 `;
 

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -194,21 +194,21 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
               <LogoType>{logoText ? <SVGObjectText type='image/svg+xml' data={logoText} /> : <SvgLogoText />}</LogoType>
             </Logo>
             <GradientContainer>
-            <NavigationContainer>
-              {content.items.map((item, key) => {
-              return (
-                <NavigationItem
-                  topLevelPath={getTopLevelPath(location.pathname)}
-                  key={key}
-                  contextKey={key}
-                  menuOpen={menuState.isMenuOpen}
-                  submenuOpen={key === focusedContext && menuState.isMenuOpen}
-                  onClickCallback={setFocusedContextCb}
-                  {...{ item, loading, focusedContext, readyCallback }}
-                />
-              );
-              })}
-            </NavigationContainer>
+              <NavigationContainer>
+                {content.items.map((item, key) => {
+                return (
+                  <NavigationItem
+                    topLevelPath={getTopLevelPath(location.pathname)}
+                    key={key}
+                    contextKey={key}
+                    menuOpen={menuState.isMenuOpen}
+                    submenuOpen={key === focusedContext && menuState.isMenuOpen}
+                    onClickCallback={setFocusedContextCb}
+                    {...{ item, loading, focusedContext, readyCallback }}
+                  />
+                );
+                })}
+              </NavigationContainer>
             </GradientContainer>
             
             <MenuFooter>

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -66,7 +66,7 @@ const NavigationContainer = styled.div`
   }
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none; /* Firefox */
-  max-height: 500px;
+  max-height: 550px;
 
   &::after {
     background: linear-gradient(rgba(246, 247, 249, 0) 1%, #F6F7F9 120%) center bottom;
@@ -90,7 +90,7 @@ const MenuFooter = styled.div`
 `;
 
 const FooterItemContainer = styled.div`
-  min-height: 50px;
+  min-height: 30px;
 `;
 
 const PushContainer = styled.div<{ isPinned: boolean; }>`

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -46,7 +46,16 @@ const SVGObjectText = styled.object`
   max-width: 180px;
 `;
 
-const NavigationContainer = styled.div``;
+const NavigationContainer = styled.div`
+  max-height: 300px;
+  min-height: 200px;
+  overflow-y: scroll;
+  ::-webkit-scrollbar {  /* Hide scrollbar for Chrome, Safari and Opera */
+    display: none;
+  }
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+`;
 
 const MenuFooter = styled.div`
   ${({ theme }) => theme && css`

--- a/src/Global/organisms/MainMenu.tsx
+++ b/src/Global/organisms/MainMenu.tsx
@@ -46,15 +46,37 @@ const SVGObjectText = styled.object`
   max-width: 180px;
 `;
 
+const GradientContainer = styled.div`
+  &::after {
+    content: '';
+    background: radial-gradient(farthest-side at 50% 100%,rgba(246, 247, 249, 0) 1%, #F6F7F9 120%) center bottom; //Shodow bottom
+    height: 10px;
+    display: block;
+    position: absolute;
+    margin-top: -10px;
+    width: 300px;
+  }
+`;
+
 const NavigationContainer = styled.div`
-  max-height: 300px;
   min-height: 200px;
-  overflow-y: scroll;
+  overflow-y: auto;
   ::-webkit-scrollbar {  /* Hide scrollbar for Chrome, Safari and Opera */
     display: none;
   }
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none; /* Firefox */
+  max-height: 400px;
+
+  &::after {
+    background: linear-gradient(rgba(246, 247, 249, 0) 1%, #F6F7F9 120%) center bottom;
+    content: '';
+    background: white;
+    display: block;
+    position: sticky;
+    height: 10px;
+    z-index: 1;
+  }
 `;
 
 const MenuFooter = styled.div`
@@ -68,7 +90,7 @@ const MenuFooter = styled.div`
 `;
 
 const FooterItemContainer = styled.div`
-  min-height: 70px;
+  min-height: 50px;
 `;
 
 const PushContainer = styled.div<{ isPinned: boolean; }>`
@@ -111,7 +133,6 @@ const ContainerInner = styled.div`
   flex-direction: column;
   height: 100%;
 `;
-
 
 const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true, canAlwaysPin = false }) => {
 
@@ -172,7 +193,7 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
               <LogoMark>{logoMark ? <SVGObject type='image/svg+xml' data={logoMark} /> : <SvgLogoMark />}</LogoMark>
               <LogoType>{logoText ? <SVGObjectText type='image/svg+xml' data={logoText} /> : <SvgLogoText />}</LogoType>
             </Logo>
-
+            <GradientContainer>
             <NavigationContainer>
               {content.items.map((item, key) => {
               return (
@@ -188,7 +209,8 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
               );
               })}
             </NavigationContainer>
-
+            </GradientContainer>
+            
             <MenuFooter>
 
               {supportUrl && (


### PR DESCRIPTION
### Description

This PR has following change in the Left sidebar menu of the Global Ui component:

 - When the menu options exceeded, "Keep Open/Auto-Hide" footer text hides for some screen resolutions as shown in below attached screenshot
 
![image](https://user-images.githubusercontent.com/118800413/226816854-b6cbf21d-df91-4a9e-956f-7c3be7d62af2.png)

 - When Sub menus of the menu options exceeded then the sub menus are also hides as shown in attached screen shot
 
![image](https://user-images.githubusercontent.com/118800413/226817084-ce344849-9538-45af-84e4-477ec27be841.png)

- As there is no vertical scroll bar a user cannot scroll down and see the hidden options or menus or footer 


 ### Considerations on Implementation

- Added a vertical scroll bar to the menu options with min and max height by keeping a position of logo & text and Footer text fixed
- Also a scroll bar is hidden in all the browser as its visibility on ui does not seems correct.

Here is the screencast of the expected result.
https://www.awesomescreenshot.com/video/15820748?key=3e8aaf86b3e648da83a8b0924d1f2efe

As per the user readability, if there are more items then those items get hides and user cannot understand whether there is more menu or not, as shown in above screencast, hence to improve this we have added a linear-gradient at the bottom to show there are more items to scroll, please refer below screencast:
https://www.awesomescreenshot.com/video/16031733?key=ed935505a7338a8a74111b4f7b9f9e75

As there was more space showing between the Menu container and footer container, I have increased max-height of the Navigation container & decreased height of the Footer item container, as shown in below attached screenshot:
![image](https://user-images.githubusercontent.com/118800413/228748381-2ea6440c-afc6-4219-995e-3515bdd516b9.png)
