### PR TITLE
Filter dropdown should show vertical scroll if it has more item which are not visible in the list

### DIFF
--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -34,16 +34,11 @@ const StyledFilterOption = styled(FilterOption)`
   letter-spacing: 0.2px;
 `;
 
-const OptionList = styled.div`
+const OptionList = styled.div<{hideVerticleScrollbar: boolean}>`
   max-height: 162px;
   min-height: 40px;
   position: relative;
-  overflow-y: scroll;
-  ::-webkit-scrollbar {  /* Hide scrollbar for Chrome, Safari and Opera */
-    display: none;
-  }
-  -ms-overflow-style: none;  /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
+  overflow-y: ${props => (props.hideVerticleScrollbar ? 'hidden' : 'scroll')};
 
   ${StyledFilterOption} {
     height: 35px;
@@ -339,7 +334,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
             : (
               <ResultsContainer>
                 {hasOptionsFilter && <ResultCounter>{getResultText(searchResultText, visibleList.length, list.length)}</ResultCounter>}
-                <OptionList>
+                <OptionList hideVerticleScrollbar={list.length < 5 || list.length === 5}>
                   {(visibleList.length > 0)
 
                     ? visibleList.map((item: IFilterItem, index) => {


### PR DESCRIPTION

### Description

This PR has following change in the FilterDropdown Ui component:

- As shown in the below attached screenshot, there are more items to scroll down, even though there is slight gradient at the bottom to notify user that there are more items but still it feels that there must be a vertical scroll bar in the FilterDropdown if items are more to scroll down
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/cdfb0d57-46fd-4326-b4c8-5270b27c1777)
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/ebd8ac4d-5191-428c-9be7-241505861ef0)

 ### Considerations on Implementation
- To achieve this, I have added **overflow-y** property in the CSS conditionally as shown below -
**overflow-y: ${props => (props.hideVerticleScrollbar ? 'hidden' : 'scroll')};
<OptionList hideVerticleScrollbar={list.length < 5 || list.length === 5}>**

- In above code, if the items are greater than or equal to 5 then vertical scroll bar should be **hidden** else it should be **scrollable**.

Here are some screenshots of the expected result.
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/2f6f62bf-8ee8-45c1-856a-fcd775540cf1)
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/30a1a884-a48e-4e7b-b47e-df39e96a585f)
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/ead1aa35-4425-4e45-a2b1-339c62c0b3a6)
