### PR TITLE
LineUiVideo -> Added color and opacity attribute to fill color in the shapes

### DIFF
--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -32,7 +32,9 @@ const Line: React.FC<{}> = () => {
       y: 1535
     },
     boundaryOffset: 0,
-    showDirectionMark: true
+    showDirectionMark: true,
+    areaFillColor: '',
+    areaTransparencyLevel: 0
   });
 
   const fetchLine = useCallback(async () => {
@@ -134,6 +136,26 @@ const Line: React.FC<{}> = () => {
     });
   }, []);
 
+  const changeFillColor = useCallback( (lineIndex: number, {target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch({
+      type: 'UPDATE_FILL_COLOR',
+      index: lineIndex,
+      data: {
+        areaFillColor: value
+      }
+    });
+  }, []);
+
+  const changeTranparencyLevel = useCallback( (lineIndex: number, {target: {value}}: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch({
+      type: 'UPDATE_TRANSPARENCY_LEVEL',
+      index: lineIndex,
+      data: {
+        areaTransparencyLevel: parseInt(value)
+      }
+    });
+  }, []);
+
   const toggleReadOnly = useCallback((index=0) => () => {
     dispatch({
       type: 'UPDATE_SET_OPTIONS',
@@ -214,6 +236,8 @@ const Line: React.FC<{}> = () => {
           <Label labelText='Boundary Offset' htmlFor='boundaryOffset' >
             <Input type='number' name='boundaryOffset' min={0} value={options.boundaryOffset} onChange={updateBoudaryOffset}/>
           </Label>
+          <TextField label='Area Fill Color' fieldState='default' name='fillColor' value={state[0]?.areaFillColor ||''} onChange={(e) => changeFillColor(0, e)}/>
+          <TextField label='Area Tranparency Level' fieldState='default' name='transparencyLevel' value={state[0]?.areaTransparencyLevel ||''} onChange={(e) => changeTranparencyLevel(0, e)}/>
         </SidebarBox>
         <SidebarBox>
           <Button design="secondary" onClick={toggleReadOnly()} >Toggle Read Only</Button>

--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -65,19 +65,29 @@ const Line: React.FC<{}> = () => {
     const state: IPointSet[] = [{
         name: 'UP',
         points: [
-            {
-              x: 343,
-              y: 281
-            },
-            {
-              x: 898,
-              y: 389
-            }
+          {
+            x: 1048,
+            y: 456
+          },
+          {
+            x: 1613,
+            y: 584
+          },
+          {
+            x: 1322,
+            y: 985
+          },
+          {
+            x: 922,
+            y: 785
+          }
         ],
         showPointHandle: true,
         showSmallDirectionMark: true,
         readOnly: false,
-        styling: 'primary'
+        styling: 'primary',
+        areaFillColor: 'rgb(0,0,0)',
+        areaTransparencyLevel: 40
       },
       {
         name: 'DOWN',
@@ -213,7 +223,7 @@ const Line: React.FC<{}> = () => {
       <Content padBottom={false}>
         {error && <div>{error}</div>}
         <LineSetContext.Provider value={{ state, dispatch }}>
-          <LineUI options={options} onLineClick={selectLine} src="https://i.picsum.photos/id/1026/4621/3070.jpg?hmac=OJ880cIneqAKIwHbYgkRZxQcuMgFZ4IZKJasZ5c5Wcw" />
+          <LineUI options={options} onLineClick={selectLine} src="https://picsum.photos/id/1026/4621/3070.jpg?hmac=OJ880cIneqAKIwHbYgkRZxQcuMgFZ4IZKJasZ5c5Wcw" />
         </LineSetContext.Provider>
       </Content>
     </Layout>

--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -88,7 +88,7 @@ const Line: React.FC<{}> = () => {
         showSmallDirectionMark: true,
         readOnly: false,
         styling: 'primary',
-        areaFillColor: 'rgb(0,0,0)',
+        areaFillColor: '#0B0B0B',
         areaTransparencyLevel: 40
       },
       {

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -107,8 +107,8 @@ const Line: React.FC<{}> = () => {
         ],
         readOnly: false,
         styling: 'secondary',
-        areaFillColor: 'blue',
-        areaTransparencyLevel: '0.2'
+        areaFillColor: 'rgb(255,255,0)',
+        areaTransparencyLevel: 80
       }
     ];
 

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -106,7 +106,9 @@ const Line: React.FC<{}> = () => {
           }
         ],
         readOnly: false,
-        styling: 'secondary'
+        styling: 'secondary',
+        color: 'blue',
+        opacity: '0.2'
       }
     ];
 

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -107,8 +107,8 @@ const Line: React.FC<{}> = () => {
         ],
         readOnly: false,
         styling: 'secondary',
-        areaFillColor: 'rgb(255,255,0)',
-        areaTransparencyLevel: 80
+        areaFillColor: 'rgb(0,0,0)',
+        areaTransparencyLevel: 40
       }
     ];
 

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -107,7 +107,7 @@ const Line: React.FC<{}> = () => {
         ],
         readOnly: false,
         styling: 'secondary',
-        areaFillColor: 'rgb(0,0,0)',
+        areaFillColor: '#0B0B0B',
         areaTransparencyLevel: 40
       }
     ];

--- a/example/src/pages/LineVideoPage.tsx
+++ b/example/src/pages/LineVideoPage.tsx
@@ -107,8 +107,8 @@ const Line: React.FC<{}> = () => {
         ],
         readOnly: false,
         styling: 'secondary',
-        color: 'blue',
-        opacity: '0.2'
+        areaFillColor: 'blue',
+        areaTransparencyLevel: '0.2'
       }
     ];
 

--- a/src/LineUI/LineReducer.ts
+++ b/src/LineUI/LineReducer.ts
@@ -10,6 +10,8 @@ export type IReducerActions =
   | RemovePointAction
   | UpdateSetOptions
   | RenameSetAction
+  | ChangeFillColorAction
+  | ChangeTranparencyLevelAction
   ;
 
 interface AddSetAction{
@@ -49,6 +51,22 @@ interface AddPointAction {
 interface RemovePointAction {
   type: 'REMOVE_POINT';
   index: number;
+}
+
+interface ChangeFillColorAction {
+  type: 'UPDATE_FILL_COLOR';
+  index: number;
+  data: {
+    areaFillColor: string;
+  };
+}
+
+interface ChangeTranparencyLevelAction {
+  type: 'UPDATE_TRANSPARENCY_LEVEL';
+  index: number;
+  data: {
+    areaTransparencyLevel: number;
+  };
 }
 
 const getMidpoint = (pointA : IVector2, pointB : IVector2) => {
@@ -102,6 +120,16 @@ export default (state : IPointSet[], action: IReducerActions) => {
           })
         );
       return newState;
+    }
+
+    case "UPDATE_FILL_COLOR": {
+      const set = { ...state[action.index], areaFillColor: action.data.areaFillColor};
+      return update(state, {[action.index]: {$set: set}});
+    }
+
+    case "UPDATE_TRANSPARENCY_LEVEL": {
+      const set = { ...state[action.index], areaTransparencyLevel: action.data.areaTransparencyLevel};
+      return update(state, {[action.index]: {$set: set}});
     }
 
     default:

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -6,7 +6,7 @@ import { LineSetContext } from './Contexts';
 import { IPointSet, IDragLineUISharedOptions, IVector2 } from '.';
 import styled from 'styled-components';
 
-const SelectedArea = styled.polygon<{ color: string; opacity: string }>`
+const FilledPolygon = styled.polygon<{ color: string; opacity: string }>`
   fill: ${({ color }) => color };
   opacity: ${({ opacity }) => opacity };
 `;
@@ -246,11 +246,11 @@ const LineSet: React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, line
     />
   );});
 
-  const check = lineSetData.points.map((point) => `${point.x},${point.y}`).join(" ");
+  const polygonPoints = lineSetData.points.map((point) => `${point.x},${point.y}`).join(" ");
   
   return (
     <g>
-      <SelectedArea points={check} color={lineSetData.color ? lineSetData.color : 'transparent'} opacity={lineSetData.opacity ? lineSetData.opacity : ''} />
+      <FilledPolygon points={polygonPoints} color={lineSetData.areaFillColor ? lineSetData.areaFillColor : 'transparent'} opacity={lineSetData.areaTransparencyLevel ? lineSetData.areaTransparencyLevel : ''} />
       {lines}
       {handles}
       {points}

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -6,7 +6,7 @@ import { LineSetContext } from './Contexts';
 import { IPointSet, IDragLineUISharedOptions, IVector2 } from '.';
 import styled from 'styled-components';
 
-const FilledPolygon = styled.polygon<{ color: string; opacity: string }>`
+const FilledPolygon = styled.polygon<{ color: string; opacity: number }>`
   fill: ${({ color }) => color };
   opacity: ${({ opacity }) => opacity };
 `;
@@ -250,7 +250,7 @@ const LineSet: React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, line
   
   return (
     <g>
-      <FilledPolygon points={polygonPoints} color={lineSetData.areaFillColor ? lineSetData.areaFillColor : 'transparent'} opacity={lineSetData.areaTransparencyLevel ? lineSetData.areaTransparencyLevel : ''} />
+      <FilledPolygon points={polygonPoints} color={lineSetData.areaFillColor ? lineSetData.areaFillColor : 'transparent'} opacity={lineSetData.areaTransparencyLevel ? lineSetData.areaTransparencyLevel / 100 : 0} />
       {lines}
       {handles}
       {points}

--- a/src/LineUI/LineSet.tsx
+++ b/src/LineUI/LineSet.tsx
@@ -6,6 +6,11 @@ import { LineSetContext } from './Contexts';
 import { IPointSet, IDragLineUISharedOptions, IVector2 } from '.';
 import styled from 'styled-components';
 
+const SelectedArea = styled.polygon<{ color: string; opacity: string }>`
+  fill: ${({ color }) => color };
+  opacity: ${({ opacity }) => opacity };
+`;
+
 const Point = styled.circle<{styling: string}>`
   fill: ${({theme, styling}) => theme.custom.lines[styling].point.fill};
 `;
@@ -241,8 +246,11 @@ const LineSet: React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, line
     />
   );});
 
+  const check = lineSetData.points.map((point) => `${point.x},${point.y}`).join(" ");
+  
   return (
     <g>
+      <SelectedArea points={check} color={lineSetData.color ? lineSetData.color : 'transparent'} opacity={lineSetData.opacity ? lineSetData.opacity : ''} />
       {lines}
       {handles}
       {points}

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -22,6 +22,8 @@ export interface IPointSet {
   showPointHandle?: boolean;
   showSmallDirectionMark?: boolean;
   showMoveHandle?: boolean;
+  color?: string;
+  opacity?: string;
 }
 
 export interface IMinMax {

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -22,8 +22,8 @@ export interface IPointSet {
   showPointHandle?: boolean;
   showSmallDirectionMark?: boolean;
   showMoveHandle?: boolean;
-  color?: string;
-  opacity?: string;
+  areaFillColor?: string;
+  areaTransparencyLevel?: string;
 }
 
 export interface IMinMax {

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -71,7 +71,9 @@ export interface LineUIOptions {
   };
 
   boundaryOffset?: number,
-  showDirectionMark?: boolean
+  showDirectionMark?: boolean,
+  areaFillColor?: string;
+  areaTransparencyLevel?: number;
 }
 
 export type  LineUIVideoOptions = VideoHTMLAttributes<HTMLVideoElement>

--- a/src/LineUI/index.ts
+++ b/src/LineUI/index.ts
@@ -23,7 +23,7 @@ export interface IPointSet {
   showSmallDirectionMark?: boolean;
   showMoveHandle?: boolean;
   areaFillColor?: string;
-  areaTransparencyLevel?: string;
+  areaTransparencyLevel?: number;
 }
 
 export interface IMinMax {


### PR DESCRIPTION
### Description

 This PR has following change in the LineUiVideo component:

-  In our recent component we don't have feasibility to fill color in the selected area created by a shape.
- Requirement is we should be able to specify for each shape it's fill color attributes including different transparency level for each independent of other.

[Zeplin Design for the Requirement](https://app.zeplin.io/project/6425995d21e4040182901a6c/screen/642599bf77d65979fe41598d)

![Snapshot of Zeplin Design](https://github.com/future-standard/scorer-ui-kit/assets/118800413/e46a54f4-8cf6-4996-9fba-6964b95019fb)


 ### Considerations on Implementation

- To achieve this we have added an optional color and opacity attribute to the **IPointSet** interface of LineUiVideo component.
- While creating a shape if user will pass color and opacity values in string then the respective shape will get filled with the passed color value with the transparency level given by opacity.
- If user will omit color and opacity then the filled area will be transparent.

Here are some screenshots of the expected result.
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/1795277a-5f31-4dc0-98a2-871c9554d066)

After adding above feature in the LinePage by adding input fields to verify changes, here is the screenshots
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/eb2e5fce-46ba-4b8b-9a9b-2aa8c6ab06d1)
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/4a9fa569-a55f-46dc-9f6d-9a515d950b62)
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/c61ab0d1-29d6-449e-8f3b-a8c4abd73d73)

