### PR TITLE
FilterDropDown -> Graded last filter option was not selectable

### DIFF
--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -97,6 +97,7 @@ const Gradient = styled.div`
   height: 25px;
   background-image: linear-gradient(to bottom, rgba(246, 247, 249, 0) 1%, #F6F7F9 120%);
   width: 100%;
+  pointer-events: none;
 `;
 
 const isValueSelected = (item: IFilterItem, selected: IFilterValue) => {


### PR DESCRIPTION
**Description**

This PR has following fix in the FilterDropDown component:

- With respect to the below referenced PR, when we fixed last item cropped issue for the FilterDropdown component, we added a gradient css property to make last item faded which was achieved by below css :
**const Gradient = styled.div`
  position: absolute;
  right: 0px;
  bottom: 9px;
  height: 25px;
  background-image: linear-gradient(to bottom, rgba(246, 247, 249, 0) 1%, #F6F7F9 120%);
  width: 100%;
`;**

- Due to above property on last item which consist **position: absolute;**, user was not able to select the last item.
- To fix above issue, I have added one css property called **pointer-events: none;** 
- Now, a user can select the last graded option from the list

[Reference](https://github.com/future-standard/scorer-ui-kit/pull/396)

**Implemented Ui Snapshot**
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/9c7eacd1-cec3-4493-85dd-0041d756dcd8)
