### PR TITLE
ICustomDrawer -> modified interface type of counter to accept string or number 

### DIFF
--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -67,7 +67,7 @@ export interface IMenuTop {
     customComponent: ReactElement
     icon: string
     status?: IStatusDot
-    counter?: number | string
+    counter?: number
     width?: string
     maxCounter?: number
   }

--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -69,6 +69,7 @@ export interface IMenuTop {
     status?: IStatusDot
     counter?: number | string
     width?: string
+    maxCounter?: number
   }
 
 

--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -67,7 +67,7 @@ export interface IMenuTop {
     customComponent: ReactElement
     icon: string
     status?: IStatusDot
-    counter?: number
+    counter?: number | string
     width?: string
   }
 

--- a/src/Icons/StatusIcon.tsx
+++ b/src/Icons/StatusIcon.tsx
@@ -12,7 +12,7 @@ const StatusCounter = styled.div<{ color?: IStatusDot }>`
   position: absolute;
   left: 14px;;
   top: -12px;
-  border-radius: 50%;
+  border-radius: 4px;
   height: 14px;
   min-width: 14px;
   padding: 2px;
@@ -45,14 +45,15 @@ interface IStatusIcon {
   icon: string
   status?: IStatusDot
   counter?: number
+  maxCounter: number
 }
 
-const StatusIcon: React.FC<IStatusIcon> = ({icon, status, counter}) => {
+const StatusIcon: React.FC<IStatusIcon> = ({icon, status, counter, maxCounter = 999}) => {
   return (
     <Container>
       {status && (counter === undefined)
         ? <StatusDot color={status} />
-        :  (counter === undefined) ? null : <StatusCounter color={status}>{counter}</StatusCounter>}
+        :  (counter === undefined) ? null : <StatusCounter color={status}>{counter > maxCounter ? `${maxCounter}+` : counter}</StatusCounter>}
       <Icon icon={icon} size={18} color='dimmed' />
     </Container>
   );

--- a/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -368,7 +368,6 @@ const customDrawer: ICustomDrawer = {
   icon: 'Add',
   status: 'danger',
   counter: 1001,
-  // maxCounter: 1000,
   width: '280px;'
 }
 

--- a/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -367,7 +367,8 @@ const customDrawer: ICustomDrawer = {
   customComponent: MyCustomDrawer,
   icon: 'Add',
   status: 'danger',
-  // counter: 5,
+  counter: 1001,
+  // maxCounter: 1000,
   width: '280px;'
 }
 

--- a/storybook/src/stories/Misc/StatusIcon.stories.tsx
+++ b/storybook/src/stories/Misc/StatusIcon.stories.tsx
@@ -22,10 +22,11 @@ export const _Status_Icon = () => {
   const counter = number('Counter', 5);
   const status = select("Status", { Caution: 'caution', Danger: 'danger', Good: 'good', Neutral:'neutral', Highlight:'highlight'}, 'danger');
   const undefineCounter = boolean('Show empty counter', false);
+  const maxCounter = number('MaxCounter', 999);
 
   return (
     <Container>
-      <StatusIcon {...{icon, status}} counter={undefineCounter ? undefined : counter}/>
+      <StatusIcon {...{icon, status}} counter={undefineCounter ? undefined : counter} maxCounter={maxCounter}/>
     </Container>
   );
 }


### PR DESCRIPTION
### Description
This PR consist a following change in the ICustomDrawer interface-

1. In TopBar component, when the user showing a count of the notifications there might be possibility that count length gets increase to 4 or more as shown in below attached snap-
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/2217cab0-26bc-4330-a08e-b825a4ee9b5c)

2. In order to get rid of such behaviour, we decided that if count exceeds **999** then we can show it as **999+** , as shown in below attached snap-
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/14b7dca3-fc2a-4bbf-9748-c5a48c417c69)

3. To achieve above, we need to concatenate a number with **+** sign, which will return a string 
4. But as **counter** in **ICustomDrawer** accepts number only it throws an error
5. Hence, we modified type of **counter** in **ICustomDrawer** as below:
**counter?: number | string**

Kindly go through below BH requirement link in order to get better clarity 

[BH Requirement](https://www.bugherd.com/projects/263632/tasks/325)
