### PR TITLE
warning issue handled for maxCounter in case of undefined

### DIFF
--- a/src/Icons/StatusIcon.tsx
+++ b/src/Icons/StatusIcon.tsx
@@ -45,7 +45,7 @@ interface IStatusIcon {
   icon: string
   status?: IStatusDot
   counter?: number
-  maxCounter: number
+  maxCounter?: number
 }
 
 const StatusIcon: React.FC<IStatusIcon> = ({icon, status, counter, maxCounter = 999}) => {


### PR DESCRIPTION
### Description

 This PR consist following bugfix-
 
 While building scorer-ui-kit, we came across an issue shown in attached snap below-
**Type 'number | undefined' is not assignable to type 'number'.**
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/92b04d0a-5a74-4bff-a361-20bce1a60a43)..
