### PR TITLE
WebRtc -> onClick  Line Selection and on hover border shadow

### DIFF
--- a/example/src/pages/LineRTCPage.tsx
+++ b/example/src/pages/LineRTCPage.tsx
@@ -62,6 +62,8 @@ const Line: React.FC<{}> = () => {
             y: 531
           }
         ],
+        showPointHandle: true,
+        showMoveHandle: true,
         readOnly: false,
         styling: "primary"
       },
@@ -77,8 +79,10 @@ const Line: React.FC<{}> = () => {
             y: 283
           }
         ],
-        "readOnly": false,
-        "styling": "secondary"
+        showPointHandle: false,
+        showMoveHandle: false,
+        readOnly: false,
+        styling: "secondary"
       },
       {
         name: "Yikes!",
@@ -92,8 +96,36 @@ const Line: React.FC<{}> = () => {
             y: 1000
           }
         ],
+        showPointHandle: false,
+        showMoveHandle: false,
         readOnly: false,
         styling: "danger"
+      },
+      {
+        name: 'Shape 1',
+        areaName: 'Traffic Area',
+        points: [
+          {
+            x: 502,
+            y: 453
+          },
+          {
+            x: 1067,
+            y: 581
+          },
+          {
+            x: 776,
+            y: 982
+          },
+          {
+            x: 376,
+            y: 782
+          }
+        ],
+        readOnly: false,
+        styling: 'secondary',
+        areaFillColor: '#0B0B0B',
+        areaTransparencyLevel: 40
       }
     ];
 
@@ -140,6 +172,26 @@ const Line: React.FC<{}> = () => {
     createMediaModal({ mediaType: 'video', src: `ws://${wsURL}/`, dismissCallback: handleModalClose })
   }, [createMediaModal, handleModalClose, wsURL])
 
+  const selectLine = useCallback((lineId: number) => {
+    const deselectLineIndex = state.findIndex((item) => item.showPointHandle);
+    dispatch({
+      type: 'UPDATE_SET_OPTIONS',
+      index: deselectLineIndex,
+      data: {
+        showPointHandle: false,
+        showMoveHandle: false
+      }
+    });
+    dispatch({
+      type: 'UPDATE_SET_OPTIONS',
+      index: lineId,
+      data: {
+        showPointHandle: true,
+        showMoveHandle: true
+      }
+    });
+  }, [state]);
+
   return (
     <Layout >
       <Sidebar>
@@ -167,7 +219,7 @@ const Line: React.FC<{}> = () => {
         {
           wsURL && <>
             <LineSetContext.Provider value={{ state, dispatch }}>
-              <LineUIRTC ws={`ws://${wsURL}/`} {...{videoOptions, options}}/>
+              <LineUIRTC ws={`ws://${wsURL}/`} {...{videoOptions, options}} onLineClick={selectLine} />
             </LineSetContext.Provider>
             <ButtonWrapper>
               <Button onClick={handleMediaModal}>Open Video Modal</Button>

--- a/src/LineUI/LineUIRTC.tsx
+++ b/src/LineUI/LineUIRTC.tsx
@@ -67,10 +67,12 @@ interface LineUIProps {
   ws: string;
   onSizeChange?: (size: {h: number; w: number}) => void;
   onLineMoveEnd?: ()=> void;
-  onLineClick?: ()=> void;
+  onLineClick?: (lineSetId: number) => void;
   onLoaded?: (metadata: {height: number; width: number; }) => void;
   options?: LineUIOptions;
   videoOptions?: LineUIVideoOptions;
+  lineClickSensingBorder?: string;
+  hasClickSensingBorder?: boolean;
 }
 const LineUI : React.FC<LineUIProps> = ({
   ws,
@@ -78,6 +80,8 @@ const LineUI : React.FC<LineUIProps> = ({
   onLineMoveEnd = ()=>{},
   onLineClick = ()=>{},
   onLoaded = ()=>{},
+  lineClickSensingBorder = '65',
+  hasClickSensingBorder = true,
   videoOptions,
   options: {
     showHandleFinder,
@@ -196,7 +200,7 @@ const LineUI : React.FC<LineUIProps> = ({
         loaded &&
           <Frame ref={frame} viewBox={`0 0 ${videoSize.w} ${videoSize.h} `} version='1.1' xmlns='http://www.w3.org/2000/svg' onPointerDown={handlePositionTipShow} onPointerUp={handlePositionTipHide} onPointerLeave={handlePositionTipHide} transcalent={handleFinder}>
             {state.map((lineSet, index) => (
-              <LineSet key={index} onLineMoveEnd={onLineMoveEnd} onLineClick={onLineClick} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
+              <LineSet key={index} hasClickSensingBorder={hasClickSensingBorder} lineClickSensingBorder={lineClickSensingBorder} onLineMoveEnd={onLineMoveEnd} onLineClick={onLineClick} lineSetId={index} lineData={lineSet} getCTM={calculateCTM} boundaries={boundaries} unit={unit} size={30} options={options} />
               ))}
           </Frame>
       }


### PR DESCRIPTION
**Description**
This PR has following bugfixes in the LineUIRTC component:


1. On hovering over a line in LineUIRTC, a line doesn't show any click sensing border effect so a user can understand that, this is a line he is pointing to.

2. When selecting a line in LineUIRTC, by mouse click, it is difficult to select line by clicking exactly on line and also moving a line to different places.

**Considerations on Implementation**

1. Added a prop lineClickSensingBorder to give width to transparent border and default width of border is 65px, and
   hasClickSensingBorder = true.
2. For selecting line, I have added on click functionality for arrows of line as well as name of line. Also I have added a showPointHandle & showMoveHandle prop to the lineset.

Here is screencast of the expected result.

https://github.com/future-standard/scorer-ui-kit/assets/118800413/bbe04113-886c-4072-b69a-d81307dcaba7
