### PR TITLE
FilterDropdown -> verticle scrollbar styling changed

### DIFF
--- a/src/Filters/molecules/FilterDropdown.tsx
+++ b/src/Filters/molecules/FilterDropdown.tsx
@@ -40,19 +40,6 @@ const OptionList = styled.div<{moreItem?: boolean}>`
   position: relative;
   overflow-y: auto;
   margin-right: 2px;
-  
-  /* Firefox supports the scrollbar-width property */
-  scrollbar-width: thin;
-
-  /* Customize the scrollbar width for Chrome and Safari */
-  ::-webkit-scrollbar {
-    width: 2px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    background: #44444499;
-  }
 
   ${StyledFilterOption} {
     height: 35px;


### PR DESCRIPTION
**Description**
This PR has following bugfix in the FilterDropdown component:

- The virtical scrollbar for this dropdown list is too narrow.  So it is very difficult to operate on it. Refer screenshot attached below
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/d4e250d6-a305-42f6-a080-d5ecac8debcf)

[BH Requirement](https://www.bugherd.com/projects/263632/tasks/461)

**Considerations on Implementation**

- Removed below styling applied on the scrollbar-
**/* Firefox supports the scrollbar-width property */
  scrollbar-width: thin;

  /* Customize the scrollbar width for Chrome and Safari */
  ::-webkit-scrollbar {
    width: 2px;
  }

  ::-webkit-scrollbar-thumb {
    border-radius: 10px;
    background: #44444499;
  }**


Here is screenshot of the expected result.
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/f4e414d1-d3d0-4cf4-86d4-2d9d8ce87503)