### PR TITLE
Add Callback and invocation for menu open close value - V2.

### DIFF
--- a/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -509,16 +509,21 @@ export const _GlobalUI = () => {
     languageToggle();
   }
 
+  const getToggleValue = (isMenuOpen: boolean) => {
+    console.log(isMenuOpen);
+  };
+
   return (
     <Container>
       <GlobalUI
         content={menuConfig}
         home={menuHomeLink}
         defaultMenuOpen={defaultMenuOpen}
+        onMenuToggle={getToggleValue}
         {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory, customDrawer, canAlwaysPin }}
         {...{
           loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, logoutText, searchPlaceholder, hasCurrentUser, currentUserText, accountOptionText,
-          hasLanguage, selectedLanguageText, hasSwitchTheme, isLightMode, switchThemeText, selectedThemeText, onThemeToggle, onLanguageToggle,
+          hasLanguage, selectedLanguageText, hasSwitchTheme, isLightMode, switchThemeText, selectedThemeText, onThemeToggle, onLanguageToggle
         }}
       >
         <ComponentLinks />

--- a/packages/ui-lib/src/Global/index.ts
+++ b/packages/ui-lib/src/Global/index.ts
@@ -53,6 +53,7 @@ export interface IMenuTop {
     autoHideText? :string
     defaultMenuOpen?: boolean
     canAlwaysPin?: boolean
+    onMenuToggle?: (isMenuOpen: boolean) => void
   }
 
   export interface ICustomDrawer {

--- a/packages/ui-lib/src/Global/organisms/MainMenu.tsx
+++ b/packages/ui-lib/src/Global/organisms/MainMenu.tsx
@@ -104,7 +104,7 @@ const ContainerInner = styled.div`
 `;
 
 
-const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true, canAlwaysPin = false }) => {
+const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true, canAlwaysPin = false, onMenuToggle}) => {
 
   const { menuState, setMenuOpen, setMenuClose, togglePinned } = useMenu(defaultMenuOpen, canAlwaysPin);
 
@@ -117,17 +117,26 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
   const autoMenuOpen = useCallback((e: any) => {
     if (e.pointerType === 'touch') { return; }
     setMenuOpen();
-  }, [setMenuOpen]);
+    if(onMenuToggle) {
+      onMenuToggle(true);
+    }
+  }, [onMenuToggle, setMenuOpen]);
 
   const autoMenuClose = useCallback(() => {
     // TODO: Move the focused back to the active view so it re-opens on current context.
     setMenuClose();
-  }, [setMenuClose]);
+    if(onMenuToggle) {
+      onMenuToggle(false);
+    }
+  }, [onMenuToggle, setMenuClose]);
 
   const toggleMenuPin = useCallback((e: any) => {
     if (e.pointerType === 'touch') { return; }
     togglePinned();
-  }, [togglePinned]);
+    if(onMenuToggle) {
+      onMenuToggle(true);
+    }
+  }, [onMenuToggle, togglePinned]);
 
   /** Manage which context is open. */
   /** Submenu sends -1 because context only is for the parent

--- a/packages/ui-lib/src/Global/templates/GlobalUI.tsx
+++ b/packages/ui-lib/src/Global/templates/GlobalUI.tsx
@@ -9,7 +9,8 @@ import useBreakpoints from '../../hooks/useBreakpoints';
 
 interface OwnProps {
   maxWidth?: string,
-  paddingOverride?: string
+  paddingOverride?: string,
+  onMenuToggle?: (isMenuOpen: boolean) =>  void
 }
 
 type INavigation = OwnProps & IMenu & ITopBar;
@@ -26,6 +27,7 @@ const GlobalUI: React.FC<INavigation> = ({
   paddingOverride,
   maxWidth,
   children,
+  onMenuToggle,
   ...props
 }) => {
 
@@ -50,7 +52,7 @@ const GlobalUI: React.FC<INavigation> = ({
           <TopBar
             {...{...props}}
           />
-          <ContentArea {...{maxWidth, paddingOverride}}>
+          <ContentArea {...{maxWidth, paddingOverride, onMenuToggle}}>
             {children}
           </ContentArea>
         </MainContainer>
@@ -65,6 +67,7 @@ const GlobalUI: React.FC<INavigation> = ({
             logoMark,
             supportUrl,
             defaultMenuOpen,
+            onMenuToggle,
             ...props
             }
           }


### PR DESCRIPTION
### Description

This PR has code for getting value true or false wether menu is open or closed. 
Here onMenuToggle callback is used to pass value to parent component. If menu is closed it will pass false other wise true,  

This feature is required in Platform renovation project to make organisation switch which is placed on top bar making its position abosulte near side menu. Problem arrived when user open menu or hover on menu the switch hide behind the menu. to overcome this problem code need callback to get menu open/closed value.

Here are some screenshots of the expected result.

**1. When menu is open its passed **true** value**

![image](https://github.com/future-standard/scorer-ui-kit/assets/75060979/e471fa9a-5228-4f81-ae92-6f4a225f9e83)

**2. When Menu is closed its passed false value**

![image](https://github.com/future-standard/scorer-ui-kit/assets/75060979/6103eaa7-0abb-4b43-9c9d-658821bd7388)
