### PR TITLE
Fix/on menu toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -41867,7 +41867,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^2.0.0",

--- a/packages/ui-lib/src/Global/organisms/MainMenu.tsx
+++ b/packages/ui-lib/src/Global/organisms/MainMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import ReactDom from 'react-dom';
 import styled, { css } from 'styled-components';
 
@@ -104,7 +104,7 @@ const ContainerInner = styled.div`
 `;
 
 
-const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true, canAlwaysPin = false, onMenuToggle}) => {
+const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, keepOpenText = "Keep Open", autoHideText = "Auto-Hide", supportUrl, defaultMenuOpen = true, canAlwaysPin = false, onMenuToggle= ()=>{}}) => {
 
   const { menuState, setMenuOpen, setMenuClose, togglePinned } = useMenu(defaultMenuOpen, canAlwaysPin);
 
@@ -117,26 +117,22 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
   const autoMenuOpen = useCallback((e: any) => {
     if (e.pointerType === 'touch') { return; }
     setMenuOpen();
-    if(onMenuToggle) {
-      onMenuToggle(true);
-    }
-  }, [onMenuToggle, setMenuOpen]);
+
+  }, [setMenuOpen]);
 
   const autoMenuClose = useCallback(() => {
     // TODO: Move the focused back to the active view so it re-opens on current context.
     setMenuClose();
-    if(onMenuToggle) {
-      onMenuToggle(false);
-    }
-  }, [onMenuToggle, setMenuClose]);
+  }, [setMenuClose]);
 
   const toggleMenuPin = useCallback((e: any) => {
     if (e.pointerType === 'touch') { return; }
     togglePinned();
-    if(onMenuToggle) {
-      onMenuToggle(true);
-    }
-  }, [onMenuToggle, togglePinned]);
+  }, [togglePinned]);
+
+  useEffect(() => {
+    onMenuToggle(menuState.isMenuOpen);
+  },[menuState.isMenuOpen, onMenuToggle]);
 
   /** Manage which context is open. */
   /** Submenu sends -1 because context only is for the parent

--- a/packages/ui-lib/src/Global/templates/GlobalUI.tsx
+++ b/packages/ui-lib/src/Global/templates/GlobalUI.tsx
@@ -45,14 +45,16 @@ const GlobalUI: React.FC<INavigation> = ({
             logoText,
             supportUrl,
             defaultMenuOpen,
-            canAlwaysPin}
+            canAlwaysPin,
+            onMenuToggle,
+          }
           }
         />
         <MainContainer>
           <TopBar
             {...{...props}}
           />
-          <ContentArea {...{maxWidth, paddingOverride, onMenuToggle}}>
+          <ContentArea {...{maxWidth, paddingOverride}}>
             {children}
           </ContentArea>
         </MainContainer>
@@ -67,7 +69,6 @@ const GlobalUI: React.FC<INavigation> = ({
             logoMark,
             supportUrl,
             defaultMenuOpen,
-            onMenuToggle,
             ...props
             }
           }


### PR DESCRIPTION
- Fix bug where menu was always treated as open when pin open was toggled 
- refactor `onMenuToggle` callback to just watch state instead of being triggered manually
- Fix bug where `onMenuToggle` callback was being passed to wrong components
- fix bug where `onMenuToggle` callback wasn't being passed to main menu component