### PR TITLE
Copy Icon in userDrawerMeta component handled conditionally

### DIFF
--- a/src/Global/atoms/UserDrawerMeta.tsx
+++ b/src/Global/atoms/UserDrawerMeta.tsx
@@ -81,8 +81,15 @@ const TitleBox = styled.div`
   align-items: center;
 `;
 
-const IconBox = styled.div`
+const IconBox = styled.div<{hasHoverCopyIcon?: boolean}>`
   padding: 1px 5px 0 0;
+  ${({ hasHoverCopyIcon }) => hasHoverCopyIcon && css`
+    opacity: 0;
+    ${Container}:hover & {
+      opacity: 1;
+      cursor: pointer;
+    }
+  `}
 `;
 
 const CopyTextBox = styled.pre`
@@ -121,7 +128,7 @@ interface IShowCopyIcon {
 
 
 const UserDrawerMeta : React.FC<IProps> = ({item, onUserDrawerMetaClick, copySuccessMessage, includeCopyTitle}) => {
-  const { icon, title, subTitle, notes, hasCopyIcon } = item;
+  const { icon, title, subTitle, notes, hasCopyIcon, hasHoverCopyIcon } = item;
   const { copyToClipboard } = useCopyToClipboard();
   const [ showCopyText, setShowCopyText ] = useState<boolean>(false);
   const [onHoverColorValue, setOnHoverColorValue] = useState<'mono' | 'dimmed' | 'subtle' | 'inverse' | 'primary' | 'danger'>('dimmed');
@@ -164,7 +171,7 @@ const UserDrawerMeta : React.FC<IProps> = ({item, onUserDrawerMetaClick, copySuc
                     {copySuccessMessage !== '' ? copySuccessMessage : 'Copied!'}
                   </CopyTextBox>}
                 {(hasCopyIcon) ?
-                  <IconBox onClick={() => onClickCopyText(title , subTitle, notes)} onMouseEnter={onHoverMetaInfo} onMouseLeave={onLeaveMeatInfo}>
+                  <IconBox onClick={() => onClickCopyText(title , subTitle, notes)} onMouseEnter={onHoverMetaInfo} onMouseLeave={onLeaveMeatInfo} hasHoverCopyIcon={hasHoverCopyIcon}>
                     <Icon icon='Copy' size={12} color={onHoverColorValue} />
                   </IconBox>:
                   null}

--- a/src/Global/atoms/UserDrawerMeta.tsx
+++ b/src/Global/atoms/UserDrawerMeta.tsx
@@ -81,15 +81,13 @@ const TitleBox = styled.div`
   align-items: center;
 `;
 
-const IconBox = styled.div<{hasHoverCopyIcon?: boolean}>`
+const IconBox = styled.div`
   padding: 1px 5px 0 0;
-  ${({ hasHoverCopyIcon }) => hasHoverCopyIcon && css`
-    opacity: 0;
-    ${Container}:hover & {
-      opacity: 1;
-      cursor: pointer;
-    }
-  `}
+  opacity: 0;
+  ${Container}:hover & {
+    opacity: 1;
+    cursor: pointer;
+  }
 `;
 
 const CopyTextBox = styled.pre`
@@ -128,7 +126,7 @@ interface IShowCopyIcon {
 
 
 const UserDrawerMeta : React.FC<IProps> = ({item, onUserDrawerMetaClick, copySuccessMessage, includeCopyTitle}) => {
-  const { icon, title, subTitle, notes, hasCopyIcon, hasHoverCopyIcon } = item;
+  const { icon, title, subTitle, notes, hasCopyIcon } = item;
   const { copyToClipboard } = useCopyToClipboard();
   const [ showCopyText, setShowCopyText ] = useState<boolean>(false);
   const [onHoverColorValue, setOnHoverColorValue] = useState<'mono' | 'dimmed' | 'subtle' | 'inverse' | 'primary' | 'danger'>('dimmed');
@@ -171,7 +169,7 @@ const UserDrawerMeta : React.FC<IProps> = ({item, onUserDrawerMetaClick, copySuc
                     {copySuccessMessage !== '' ? copySuccessMessage : 'Copied!'}
                   </CopyTextBox>}
                 {(hasCopyIcon) ?
-                  <IconBox onClick={() => onClickCopyText(title , subTitle, notes)} onMouseEnter={onHoverMetaInfo} onMouseLeave={onLeaveMeatInfo} hasHoverCopyIcon={hasHoverCopyIcon}>
+                  <IconBox onClick={() => onClickCopyText(title , subTitle, notes)} onMouseEnter={onHoverMetaInfo} onMouseLeave={onLeaveMeatInfo}>
                     <Icon icon='Copy' size={12} color={onHoverColorValue} />
                   </IconBox>:
                   null}

--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -41,7 +41,8 @@ export interface IMenuTop {
     icon?: string,
     subTitle?: string,
     notes?: string,
-    hasCopyIcon?: boolean
+    hasCopyIcon?: boolean,
+    hasHoverCopyIcon?: boolean
   }
 
   export interface IMenuItemSubmenu {

--- a/src/Global/index.ts
+++ b/src/Global/index.ts
@@ -41,8 +41,7 @@ export interface IMenuTop {
     icon?: string,
     subTitle?: string,
     notes?: string,
-    hasCopyIcon?: boolean,
-    hasHoverCopyIcon?: boolean
+    hasCopyIcon?: boolean
   }
 
   export interface IMenuItemSubmenu {

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -133,16 +133,14 @@ export const _TopBar = () => {
       title: 'Device ID:',
       subTitle: 'DEB-NUC8i7BE-G6BE935008VH',
       notes: '',
-      hasCopyIcon:true,
-      hasHoverCopyIcon: false
+      hasCopyIcon:true
     },
     {
       icon: 'Information',
       title: 'GPU machine with 4 GPU',
       subTitle: 'Building B',
       notes: `This is a GPU machine having 30 camera support`,
-      hasCopyIcon:true,
-      hasHoverCopyIcon: true
+      hasCopyIcon:true
     },
     {
       icon: 'Success',

--- a/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/storybook/src/stories/Global/TopBar.stories.tsx
@@ -103,7 +103,7 @@ export const _TopBar = () => {
   const searchPlaceholder = text("Search Placeholder", "Search area names, etc.")
   const currentUserText = text("Current User Text", "Current User");
   const logoutText = text("Logout Text", "Logout");
-  const hasUserDrawerMeta = boolean("Has User Drawer Meta", false);
+  const hasUserDrawerMeta = boolean("Has User Drawer Meta", true);
   const copySuccessMessage= text("Tooltip Text", "Copied");
   const includeCopyTitle = boolean("Include Title Copy", true);
   const hasUserDrawerFooter = boolean("Has User Drawer Footer", false);
@@ -133,14 +133,16 @@ export const _TopBar = () => {
       title: 'Device ID:',
       subTitle: 'DEB-NUC8i7BE-G6BE935008VH',
       notes: '',
-      hasCopyIcon:true
+      hasCopyIcon:true,
+      hasHoverCopyIcon: false
     },
     {
       icon: 'Information',
       title: 'GPU machine with 4 GPU',
       subTitle: 'Building B',
       notes: `This is a GPU machine having 30 camera support`,
-      hasCopyIcon:true
+      hasCopyIcon:true,
+      hasHoverCopyIcon: true
     },
     {
       icon: 'Success',


### PR DESCRIPTION
**Description**
This PR has following enhancement in the **UserDrawerMeta** component:

1. Copy Icon showing inside **UserDrawerMeta** component in the **TopBar** ui-kit's component is present based on value of the prop **hasCopyIcon**. If **hasCopyIcon** is true then Copy Icon will be present in the component, other it will be hidden.
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/e2b2e03c-0e48-4c1c-876d-24e52ea7416e)

2. Based on below BH requierment, it was required to show that copy icon only when user hover over the **UserDrawerMeta**, to achieve this, we have added one more prop named **hasHoverCopyIcon**.

3. When value of **hasHoverCopyIcon** is true then the copy icon will be visible only when user hover over the **UserDrawerMeta**. If it is false, then the copy icon will be visible always irrespective of onHover event.

[BH Requirement](https://www.bugherd.com/projects/289019/tasks/278)

**Here is screencast of the expected result.**


https://github.com/future-standard/scorer-ui-kit/assets/118800413/64db1f40-c329-4533-b279-895e2ad464bc


