### PR TITLE
Percentage Slider -> Added prop to handle ValueTitle show/hide behaviour

### DIFF
--- a/src/Form/atoms/SliderInput.tsx
+++ b/src/Form/atoms/SliderInput.tsx
@@ -224,6 +224,7 @@ interface ISliderOwnProps {
   value?: number
   thumbColor?: IFeedbackColor
   onlyMarkSelect?: boolean
+  showValueTitle?: boolean
   inputCallback?: (value: number) => void
   onChangeCallback?: (value: number) => void
 }

--- a/src/Form/atoms/SliderInput.tsx
+++ b/src/Form/atoms/SliderInput.tsx
@@ -224,7 +224,7 @@ interface ISliderOwnProps {
   value?: number
   thumbColor?: IFeedbackColor
   onlyMarkSelect?: boolean
-  showValueTitle?: boolean
+  showValue?: boolean
   inputCallback?: (value: number) => void
   onChangeCallback?: (value: number) => void
 }

--- a/src/Form/molecules/PercentageSlider.tsx
+++ b/src/Form/molecules/PercentageSlider.tsx
@@ -49,6 +49,7 @@ interface IPercentageSliderProps {
   marks?: ISliderMark[]
   defaultValue?: number
   value?: number
+  showValueTitle?: boolean
   inputCallback?: (value: number) => void
   updateThumbColor?:  (value: number) => IFeedbackColor
   updateTitle?: (value: number) => string
@@ -63,6 +64,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
     inputCallback,
     updateThumbColor,
     updateTitle,
+    showValueTitle,
     ...props
   }
   ) => {
@@ -82,7 +84,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
           htmlFor='percentage-slider'
           labelText={updateTitle ? updateTitle(selectedValue) : getTitleLevel(selectedValue)}
         />
-        <ValueTitle htmlFor='percentage-slider' labelText={`${selectedValue}%`} />
+        {showValueTitle && <ValueTitle htmlFor='percentage-slider' labelText={`${selectedValue}%`} />}
       </Headers>
       <SliderInput
         {...props}
@@ -90,6 +92,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
         max={100}
         min={0}
         defaultValue={defaultValue}
+        showValueTitle={showValueTitle}
         onChangeCallback={handleSelectedValue}
         thumbColor={
             updateThumbColor

--- a/src/Form/molecules/PercentageSlider.tsx
+++ b/src/Form/molecules/PercentageSlider.tsx
@@ -49,7 +49,7 @@ interface IPercentageSliderProps {
   marks?: ISliderMark[]
   defaultValue?: number
   value?: number
-  showValueTitle?: boolean
+  showValue?: boolean
   inputCallback?: (value: number) => void
   updateThumbColor?:  (value: number) => IFeedbackColor
   updateTitle?: (value: number) => string
@@ -64,7 +64,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
     inputCallback,
     updateThumbColor,
     updateTitle,
-    showValueTitle,
+    showValue,
     ...props
   }
   ) => {
@@ -84,7 +84,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
           htmlFor='percentage-slider'
           labelText={updateTitle ? updateTitle(selectedValue) : getTitleLevel(selectedValue)}
         />
-        {showValueTitle && <ValueTitle htmlFor='percentage-slider' labelText={`${selectedValue}%`} />}
+        {showValue && <ValueTitle htmlFor='percentage-slider' labelText={`${selectedValue}%`} />}
       </Headers>
       <SliderInput
         {...props}
@@ -92,7 +92,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
         max={100}
         min={0}
         defaultValue={defaultValue}
-        showValueTitle={showValueTitle}
+        showValue={showValue}
         onChangeCallback={handleSelectedValue}
         thumbColor={
             updateThumbColor

--- a/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
+++ b/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
@@ -48,7 +48,7 @@ export const _PercentageSlider = () => {
   const customTitle = boolean("Custom Title function",false);
   const showValue = action('Input Callback');
   const marks = object('Marks', exampleMarks);
-  const showValueTitle = boolean("Value title visible", false);
+  const showValueTitle = boolean("Show Value Title", false);
 
   // const step = number('Step', 1); // still fixing step option
   const handleUpdate = (value: number) => {

--- a/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
+++ b/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
@@ -48,6 +48,7 @@ export const _PercentageSlider = () => {
   const customTitle = boolean("Custom Title function",false);
   const showValue = action('Input Callback');
   const marks = object('Marks', exampleMarks);
+  const showValueTitle = boolean("Value title visible", false);
 
   // const step = number('Step', 1); // still fixing step option
   const handleUpdate = (value: number) => {
@@ -90,6 +91,7 @@ export const _PercentageSlider = () => {
           title={title}
           updateThumbColor={customThumb ? otherColorHandler : undefined }
           updateTitle={customTitle ? otherTitlesHandler : undefined}
+          showValueTitle={showValueTitle}
         />
     </Container>
   )

--- a/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
+++ b/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
@@ -48,7 +48,7 @@ export const _PercentageSlider = () => {
   const customTitle = boolean("Custom Title function",false);
   const showValue = action('Input Callback');
   const marks = object('Marks', exampleMarks);
-  const showValueTitle = boolean("Show Value Title", false);
+  const showTitle = boolean("Show Value", true);
 
   // const step = number('Step', 1); // still fixing step option
   const handleUpdate = (value: number) => {
@@ -91,7 +91,7 @@ export const _PercentageSlider = () => {
           title={title}
           updateThumbColor={customThumb ? otherColorHandler : undefined }
           updateTitle={customTitle ? otherTitlesHandler : undefined}
-          showValueTitle={showValueTitle}
+          showValue={showTitle}
         />
     </Container>
   )


### PR DESCRIPTION
**Description**
This PR has following enhancement in the **PercentageSlider** component:

1. In our current component, we have Value title label showing at the top of the slider bar, as showing in the below attached snapshot.
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/bb5b69bc-f35c-4c1e-8a34-9f246b4cc4fd)

2. There is a chances to make it's visibility show/hide based on the Boolean value passed by an user.

3. Hence, I have added a boolean prop named **showValueTitle** which will handle visibility of an element based on the value provided.

4. If true then label will be shown else it will be hidden.
