### PR TITLE
Percentage slider -> Aligned min/max dividers

### DIFF
--- a/src/Form/atoms/SliderInput.tsx
+++ b/src/Form/atoms/SliderInput.tsx
@@ -61,7 +61,7 @@ const Mark = styled.span<{leftValue: number}>`
   background-color: hsl(205, 77%, 64%);
 `;
 
-const MarkLabel = styled.span<{leftValue: number; alignment?: IMartAlignment; isCenterAlignedEndNum: boolean}>`
+const MarkLabel = styled.span<{leftValue: number; alignment?: IMartAlignment; isCenterAlignedEndNum?: boolean}>`
   position: absolute;
   top: -24px;
   font-size: 10px;
@@ -188,7 +188,7 @@ const getMarkAlignment = (value: number, min: number, max: number) : IMartAlignm
   return 'center';
 };
 
-const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag: string, isCenterAlignedEndNum: boolean) => {
+const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag: string, isCenterAlignedEndNum?: boolean) => {
 
   const listOptions : JSX.Element[] = [];
   const marksElements = markList.map(({value, label}, index) => {
@@ -243,7 +243,7 @@ interface ISliderOwnProps {
   showValue?: boolean
   inputCallback?: (value: number) => void
   onChangeCallback?: (value: number) => void
-  isCenterAlignedEndNum: boolean
+  isCenterAlignedEndNum?: boolean
 }
 
 export type ISlider = ISliderOwnProps & InputHTMLAttributes<HTMLInputElement>;

--- a/src/Form/atoms/SliderInput.tsx
+++ b/src/Form/atoms/SliderInput.tsx
@@ -61,7 +61,7 @@ const Mark = styled.span<{leftValue: number}>`
   background-color: hsl(205, 77%, 64%);
 `;
 
-const MarkLabel = styled.span<{leftValue: number; alignment?: IMartAlignment; isCenterAlignedEndNum?: boolean}>`
+const MarkLabel = styled.span<{leftValue: number; alignment?: IMartAlignment; isCenterAlignedEndNum?: boolean; isFromSliderStory?: boolean}>`
   position: absolute;
   top: -24px;
   font-size: 10px;
@@ -69,7 +69,7 @@ const MarkLabel = styled.span<{leftValue: number; alignment?: IMartAlignment; is
   line-height: normal;
   text-align: center;
   color: hsla(195, 10%, 52%, 0.72);
-  left: ${({ leftValue, isCenterAlignedEndNum }) => {
+  left: ${({ leftValue, isCenterAlignedEndNum, isFromSliderStory }) => {
     if (isCenterAlignedEndNum) {
       let baseValue;
       switch (leftValue) {
@@ -77,7 +77,7 @@ const MarkLabel = styled.span<{leftValue: number; alignment?: IMartAlignment; is
           baseValue = 2;
           break;
         case 100:
-          baseValue = 22;
+          baseValue = isFromSliderStory ? 15 : 22;
           break;
         default:
           baseValue = 7;
@@ -188,7 +188,7 @@ const getMarkAlignment = (value: number, min: number, max: number) : IMartAlignm
   return 'center';
 };
 
-const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag: string, isCenterAlignedEndNum?: boolean) => {
+const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag: string, isCenterAlignedEndNum?: boolean, isFromSliderStory?: boolean) => {
 
   const listOptions : JSX.Element[] = [];
   const marksElements = markList.map(({value, label}, index) => {
@@ -206,6 +206,7 @@ const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag:
           leftValue={left}
           alignment={getMarkAlignment(value, min, max)}
           isCenterAlignedEndNum={isCenterAlignedEndNum}
+          isFromSliderStory={isFromSliderStory}
         >
           {label}
         </MarkLabel>
@@ -244,6 +245,7 @@ interface ISliderOwnProps {
   inputCallback?: (value: number) => void
   onChangeCallback?: (value: number) => void
   isCenterAlignedEndNum?: boolean
+  isFromSliderStory?: boolean
 }
 
 export type ISlider = ISliderOwnProps & InputHTMLAttributes<HTMLInputElement>;
@@ -261,6 +263,7 @@ const SliderInput : React.FC<ISlider> = ({
   inputCallback = () => {},
   onChangeCallback = () => {},
   isCenterAlignedEndNum,
+  isFromSliderStory,
   ...props
 }) => {
 
@@ -334,7 +337,7 @@ const SliderInput : React.FC<ISlider> = ({
     <SliderWrapper disabled={disabled}>
       <Rail />
       <ThumbWrapper>
-        {marks && renderMarks(marks, minValid, maxValid, `sliderList-${minValid}-${maxValid}`, isCenterAlignedEndNum)}
+        {marks && renderMarks(marks, minValid, maxValid, `sliderList-${minValid}-${maxValid}`, isCenterAlignedEndNum, isFromSliderStory)}
         {isGhostActive && onlyMarkSelect
           ? (
             <GhostThumb

--- a/src/Form/atoms/SliderInput.tsx
+++ b/src/Form/atoms/SliderInput.tsx
@@ -64,7 +64,7 @@ const Mark = styled.span<{leftValue: number}>`
 const MarkLabel = styled.span<{leftValue: number, alignment?: IMartAlignment,}>`
   position: absolute;
   top: -24px;
-  left: ${({leftValue}) => `calc(${leftValue}% + 7px)`};
+  left: ${({ leftValue }) => `calc(${leftValue}% + ${leftValue === 0 ? 2 : leftValue === 100 ? 22 : 7}px)`};
 
   font-size: 10px;
   font-style: italic;

--- a/src/Form/atoms/SliderInput.tsx
+++ b/src/Form/atoms/SliderInput.tsx
@@ -61,17 +61,32 @@ const Mark = styled.span<{leftValue: number}>`
   background-color: hsl(205, 77%, 64%);
 `;
 
-const MarkLabel = styled.span<{leftValue: number, alignment?: IMartAlignment,}>`
+const MarkLabel = styled.span<{leftValue: number; alignment?: IMartAlignment; isCenterAlignedEndNum: boolean}>`
   position: absolute;
   top: -24px;
-  left: ${({ leftValue }) => `calc(${leftValue}% + ${leftValue === 0 ? 2 : leftValue === 100 ? 22 : 7}px)`};
-
   font-size: 10px;
   font-style: italic;
   line-height: normal;
   text-align: center;
   color: hsla(195, 10%, 52%, 0.72);
-
+  left: ${({ leftValue, isCenterAlignedEndNum }) => {
+    if (isCenterAlignedEndNum) {
+      let baseValue;
+      switch (leftValue) {
+        case 0:
+          baseValue = 2;
+          break;
+        case 100:
+          baseValue = 22;
+          break;
+        default:
+          baseValue = 7;
+      }
+      return `calc(${leftValue}% + ${baseValue}px)`;
+    } else {
+      return `calc(${leftValue}% + 7px)`;
+    }
+  }};
   ${({alignment}) => (alignment === 'center') && css`transform: translateX(-50%);;`}
   ${({alignment}) => (alignment === 'right') && css`transform: translateX(5%);`}
   ${({alignment}) => (alignment === 'left') && css`transform: translateX(-95%);`}
@@ -173,7 +188,7 @@ const getMarkAlignment = (value: number, min: number, max: number) : IMartAlignm
   return 'center';
 };
 
-const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag: string) => {
+const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag: string, isCenterAlignedEndNum: boolean) => {
 
   const listOptions : JSX.Element[] = [];
   const marksElements = markList.map(({value, label}, index) => {
@@ -190,6 +205,7 @@ const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag:
         <MarkLabel
           leftValue={left}
           alignment={getMarkAlignment(value, min, max)}
+          isCenterAlignedEndNum={isCenterAlignedEndNum}
         >
           {label}
         </MarkLabel>
@@ -227,6 +243,7 @@ interface ISliderOwnProps {
   showValue?: boolean
   inputCallback?: (value: number) => void
   onChangeCallback?: (value: number) => void
+  isCenterAlignedEndNum: boolean
 }
 
 export type ISlider = ISliderOwnProps & InputHTMLAttributes<HTMLInputElement>;
@@ -243,6 +260,7 @@ const SliderInput : React.FC<ISlider> = ({
   onlyMarkSelect = false,
   inputCallback = () => {},
   onChangeCallback = () => {},
+  isCenterAlignedEndNum,
   ...props
 }) => {
 
@@ -316,7 +334,7 @@ const SliderInput : React.FC<ISlider> = ({
     <SliderWrapper disabled={disabled}>
       <Rail />
       <ThumbWrapper>
-        {marks && renderMarks(marks, minValid, maxValid, `sliderList-${minValid}-${maxValid}`)}
+        {marks && renderMarks(marks, minValid, maxValid, `sliderList-${minValid}-${maxValid}`, isCenterAlignedEndNum)}
         {isGhostActive && onlyMarkSelect
           ? (
             <GhostThumb

--- a/src/Form/atoms/SliderInput.tsx
+++ b/src/Form/atoms/SliderInput.tsx
@@ -61,7 +61,7 @@ const Mark = styled.span<{leftValue: number}>`
   background-color: hsl(205, 77%, 64%);
 `;
 
-const MarkLabel = styled.span<{leftValue: number, alignment?: IMarkAlignment,}>`
+const MarkLabel = styled.span<{leftValue: number, alignment?: IMarkAlignment}>`
   position: absolute;
   top: -24px;
   left: ${({leftValue}) => `calc(${leftValue}% + 7px)`};
@@ -244,7 +244,7 @@ const SliderInput : React.FC<ISlider> = ({
   onlyMarkSelect = false,
   inputCallback = () => {},
   onChangeCallback = () => {},
-  allMarkCentered,
+  allMarkCentered = false,
   ...props
 }) => {
 

--- a/src/Form/atoms/SliderInput.tsx
+++ b/src/Form/atoms/SliderInput.tsx
@@ -61,32 +61,17 @@ const Mark = styled.span<{leftValue: number}>`
   background-color: hsl(205, 77%, 64%);
 `;
 
-const MarkLabel = styled.span<{leftValue: number; alignment?: IMartAlignment; isCenterAlignedEndNum?: boolean; isFromSliderStory?: boolean}>`
+const MarkLabel = styled.span<{leftValue: number, alignment?: IMarkAlignment,}>`
   position: absolute;
   top: -24px;
+  left: ${({leftValue}) => `calc(${leftValue}% + 7px)`};
+
   font-size: 10px;
   font-style: italic;
   line-height: normal;
   text-align: center;
   color: hsla(195, 10%, 52%, 0.72);
-  left: ${({ leftValue, isCenterAlignedEndNum, isFromSliderStory }) => {
-    if (isCenterAlignedEndNum) {
-      let baseValue;
-      switch (leftValue) {
-        case 0:
-          baseValue = 2;
-          break;
-        case 100:
-          baseValue = isFromSliderStory ? 15 : 22;
-          break;
-        default:
-          baseValue = 7;
-      }
-      return `calc(${leftValue}% + ${baseValue}px)`;
-    } else {
-      return `calc(${leftValue}% + 7px)`;
-    }
-  }};
+
   ${({alignment}) => (alignment === 'center') && css`transform: translateX(-50%);;`}
   ${({alignment}) => (alignment === 'right') && css`transform: translateX(5%);`}
   ${({alignment}) => (alignment === 'left') && css`transform: translateX(-95%);`}
@@ -176,7 +161,7 @@ const  valueToPercent = (value: number, min: number, max: number) : number => {
 // };
 
 
-const getMarkAlignment = (value: number, min: number, max: number) : IMartAlignment => {
+const getMarkAlignment = (value: number, min: number, max: number) : IMarkAlignment => {
   if(value === min) {
     return 'right';
   }
@@ -188,7 +173,7 @@ const getMarkAlignment = (value: number, min: number, max: number) : IMartAlignm
   return 'center';
 };
 
-const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag: string, isCenterAlignedEndNum?: boolean, isFromSliderStory?: boolean) => {
+const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag: string, allMarkCentered?: boolean) => {
 
   const listOptions : JSX.Element[] = [];
   const marksElements = markList.map(({value, label}, index) => {
@@ -204,9 +189,7 @@ const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag:
         />
         <MarkLabel
           leftValue={left}
-          alignment={getMarkAlignment(value, min, max)}
-          isCenterAlignedEndNum={isCenterAlignedEndNum}
-          isFromSliderStory={isFromSliderStory}
+          alignment={allMarkCentered ? 'center' : getMarkAlignment(value, min, max)}
         >
           {label}
         </MarkLabel>
@@ -225,7 +208,7 @@ const renderMarks = (markList: ISliderMark[], min: number, max: number, listTag:
 
 };
 
-export type IMartAlignment = 'left' | 'center' | 'right';
+export type IMarkAlignment = 'left' | 'center' | 'right';
 
 export interface ISliderMark {
   value: number
@@ -244,8 +227,7 @@ interface ISliderOwnProps {
   showValue?: boolean
   inputCallback?: (value: number) => void
   onChangeCallback?: (value: number) => void
-  isCenterAlignedEndNum?: boolean
-  isFromSliderStory?: boolean
+  allMarkCentered?: boolean
 }
 
 export type ISlider = ISliderOwnProps & InputHTMLAttributes<HTMLInputElement>;
@@ -262,8 +244,7 @@ const SliderInput : React.FC<ISlider> = ({
   onlyMarkSelect = false,
   inputCallback = () => {},
   onChangeCallback = () => {},
-  isCenterAlignedEndNum,
-  isFromSliderStory,
+  allMarkCentered,
   ...props
 }) => {
 
@@ -337,7 +318,7 @@ const SliderInput : React.FC<ISlider> = ({
     <SliderWrapper disabled={disabled}>
       <Rail />
       <ThumbWrapper>
-        {marks && renderMarks(marks, minValid, maxValid, `sliderList-${minValid}-${maxValid}`, isCenterAlignedEndNum, isFromSliderStory)}
+        {marks && renderMarks(marks, minValid, maxValid, `sliderList-${minValid}-${maxValid}`, allMarkCentered)}
         {isGhostActive && onlyMarkSelect
           ? (
             <GhostThumb

--- a/src/Form/molecules/PercentageSlider.tsx
+++ b/src/Form/molecules/PercentageSlider.tsx
@@ -53,6 +53,7 @@ interface IPercentageSliderProps {
   inputCallback?: (value: number) => void
   updateThumbColor?:  (value: number) => IFeedbackColor
   updateTitle?: (value: number) => string
+  isCenterAlignedEndNum: boolean
 }
 
 type IPercentageSlider = IPercentageSliderProps & InputHTMLAttributes<HTMLInputElement>;
@@ -65,6 +66,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
     updateThumbColor,
     updateTitle,
     showValue,
+    isCenterAlignedEndNum,
     ...props
   }
   ) => {
@@ -99,6 +101,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
             ? updateThumbColor(selectedValue)
             : getThumbColor(selectedValue)
           }
+        isCenterAlignedEndNum={isCenterAlignedEndNum}
       />
     </Container>
   );

--- a/src/Form/molecules/PercentageSlider.tsx
+++ b/src/Form/molecules/PercentageSlider.tsx
@@ -53,7 +53,7 @@ interface IPercentageSliderProps {
   inputCallback?: (value: number) => void
   updateThumbColor?:  (value: number) => IFeedbackColor
   updateTitle?: (value: number) => string
-  isCenterAlignedEndNum: boolean
+  isCenterAlignedEndNum?: boolean
 }
 
 type IPercentageSlider = IPercentageSliderProps & InputHTMLAttributes<HTMLInputElement>;

--- a/src/Form/molecules/PercentageSlider.tsx
+++ b/src/Form/molecules/PercentageSlider.tsx
@@ -53,7 +53,7 @@ interface IPercentageSliderProps {
   inputCallback?: (value: number) => void
   updateThumbColor?:  (value: number) => IFeedbackColor
   updateTitle?: (value: number) => string
-  isCenterAlignedEndNum?: boolean
+  allMarkCentered?: boolean
 }
 
 type IPercentageSlider = IPercentageSliderProps & InputHTMLAttributes<HTMLInputElement>;
@@ -66,7 +66,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
     updateThumbColor,
     updateTitle,
     showValue,
-    isCenterAlignedEndNum,
+    allMarkCentered,
     ...props
   }
   ) => {
@@ -101,7 +101,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
             ? updateThumbColor(selectedValue)
             : getThumbColor(selectedValue)
           }
-        isCenterAlignedEndNum={isCenterAlignedEndNum}
+        allMarkCentered={allMarkCentered}
       />
     </Container>
   );

--- a/src/Form/molecules/PercentageSlider.tsx
+++ b/src/Form/molecules/PercentageSlider.tsx
@@ -6,13 +6,17 @@ import Label from '../atoms/Label';
 
 
 const Container = styled.div``;
-const Headers = styled.div`
+const Headers = styled.div<{allMarkCentered?:boolean}>`
   font-size: 14px;
   color: hsl(207, 5%, 57%);
   display: flex;
   justify-content: space-between;
   margin-bottom: 20px;
-  padding: 0 6px;
+  ${({allMarkCentered}) => allMarkCentered ?
+      `padding: 0;`
+    :
+      `padding: 0 6px;`
+  };
 `;
 
 const ValueTitle = styled(Label)`
@@ -81,7 +85,7 @@ const PercentageSlider: React.FC<IPercentageSlider> = (
 
   return(
     <Container>
-      <Headers>
+      <Headers allMarkCentered={allMarkCentered}>
         <Label
           htmlFor='percentage-slider'
           labelText={updateTitle ? updateTitle(selectedValue) : getTitleLevel(selectedValue)}

--- a/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
+++ b/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
@@ -39,7 +39,7 @@ const exampleMarks : ISliderMark[] = [
     label:'100%',
   },
 ];
-  
+
 export const _PercentageSlider = () => {
   const title = text('Title', 'Duration');
   const disabled = boolean('Disabled', false);
@@ -49,7 +49,7 @@ export const _PercentageSlider = () => {
   const showValue = action('Input Callback');
   const marks = object('Marks', exampleMarks);
   const showTitle = boolean("Show Value", true);
-  const isCenterAlignedEndNum = boolean('Center aligned end numbers', false);
+  const allMarkCentered = boolean('Center aligned end numbers', false);
 
   // const step = number('Step', 1); // still fixing step option
   const handleUpdate = (value: number) => {
@@ -61,11 +61,11 @@ export const _PercentageSlider = () => {
     if(value <= 20) {
       return 'neutral';
     }
-  
+
     if((value > 20) && (value <= 80)) {
       return 'info';
     }
-  
+
     return 'error';
   }
 
@@ -73,11 +73,11 @@ export const _PercentageSlider = () => {
     if(value <= 20) {
       return 'Small sound';
     }
-  
+
     if((value > 20) && (value <= 80)) {
       return 'Normal sound';
     }
-  
+
     return 'Dangerous sound';
   }
 
@@ -93,7 +93,7 @@ export const _PercentageSlider = () => {
           updateThumbColor={customThumb ? otherColorHandler : undefined }
           updateTitle={customTitle ? otherTitlesHandler : undefined}
           showValue={showTitle}
-          isCenterAlignedEndNum={isCenterAlignedEndNum}
+          allMarkCentered={allMarkCentered}
         />
     </Container>
   )

--- a/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
+++ b/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
@@ -49,7 +49,7 @@ export const _PercentageSlider = () => {
   const showValue = action('Input Callback');
   const marks = object('Marks', exampleMarks);
   const showTitle = boolean("Show Value", true);
-  const allMarkCentered = boolean('Center aligned end numbers', false);
+  const allMarkCentered = boolean('Center all mark values', false);
 
   // const step = number('Step', 1); // still fixing step option
   const handleUpdate = (value: number) => {

--- a/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
+++ b/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
@@ -49,6 +49,7 @@ export const _PercentageSlider = () => {
   const showValue = action('Input Callback');
   const marks = object('Marks', exampleMarks);
   const showTitle = boolean("Show Value", true);
+  const isCenterAlignedEndNum = boolean('Center aligned end numbers', false);
 
   // const step = number('Step', 1); // still fixing step option
   const handleUpdate = (value: number) => {
@@ -92,6 +93,7 @@ export const _PercentageSlider = () => {
           updateThumbColor={customThumb ? otherColorHandler : undefined }
           updateTitle={customTitle ? otherTitlesHandler : undefined}
           showValue={showTitle}
+          isCenterAlignedEndNum={isCenterAlignedEndNum}
         />
     </Container>
   )

--- a/storybook/src/stories/Form/Input/SliderInput.stories.tsx
+++ b/storybook/src/stories/Form/Input/SliderInput.stories.tsx
@@ -60,6 +60,7 @@ export const _SliderInput = () => {
   const defaultValue = number('Default value', 6)
   const showValue = action('Input Callback');
   const marks = object('Marks', exampleMarks);
+  const isCenterAlignedEndNum = boolean('Center aligned end numbers', false);
   // const step = number('Step', 1); // still fixing step option
 
   const handleUpdate = (value: number) => {
@@ -77,6 +78,7 @@ export const _SliderInput = () => {
           inputCallback={handleUpdate}
           marks={marks}
           defaultValue={defaultValue}
+          isCenterAlignedEndNum={isCenterAlignedEndNum}
         />
     </Container>
   )

--- a/storybook/src/stories/Form/Input/SliderInput.stories.tsx
+++ b/storybook/src/stories/Form/Input/SliderInput.stories.tsx
@@ -51,7 +51,7 @@ const exampleMarks : ISliderMark[] = [
     label:'8H',
   },
 ];
-  
+
 
 export const _SliderInput = () => {
   const disabled = boolean('Disabled', false);
@@ -60,7 +60,7 @@ export const _SliderInput = () => {
   const defaultValue = number('Default value', 6)
   const showValue = action('Input Callback');
   const marks = object('Marks', exampleMarks);
-  const isCenterAlignedEndNum = boolean('Center aligned end numbers', false);
+  const allMarkCentered = boolean('Center aligned end numbers', false);
   // const step = number('Step', 1); // still fixing step option
 
   const handleUpdate = (value: number) => {
@@ -78,8 +78,7 @@ export const _SliderInput = () => {
           inputCallback={handleUpdate}
           marks={marks}
           defaultValue={defaultValue}
-          isCenterAlignedEndNum={isCenterAlignedEndNum}
-          isFromSliderStory={isCenterAlignedEndNum}
+          allMarkCentered={allMarkCentered}
         />
     </Container>
   )

--- a/storybook/src/stories/Form/Input/SliderInput.stories.tsx
+++ b/storybook/src/stories/Form/Input/SliderInput.stories.tsx
@@ -79,6 +79,7 @@ export const _SliderInput = () => {
           marks={marks}
           defaultValue={defaultValue}
           isCenterAlignedEndNum={isCenterAlignedEndNum}
+          isFromSliderStory={isCenterAlignedEndNum}
         />
     </Container>
   )


### PR DESCRIPTION
**Description**
This PR has following enhancement in the PercentageSlider component:

- In our current component, it was noticed in the demo by @h2suzuki san that the alignment of the min (0%) and max(100%) values are not proper as shown in below attached snapshot,
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/c86f4e1a-9586-422c-b8a2-35902dde876e)

- So, I have aligned  min (0%) and max(100%) values as shown in the below attached snapshot,
![image](https://github.com/future-standard/scorer-ui-kit/assets/118800413/c01ec055-2a45-4461-acb4-3fa2b4d58a10)
