### PR TITLE
Update missing htmlfor, name, id missing in examples

### DIFF
--- a/example/src/pages/LinePage.tsx
+++ b/example/src/pages/LinePage.tsx
@@ -213,35 +213,35 @@ const Line: React.FC<{}> = () => {
         </SidebarBox>
         <SidebarBox>
           <Label labelText='Show Point Handle' htmlFor='showPointHandle' >
-            <input type='checkbox' name='showPointHandle' checked={options.showPointHandle} onChange={toggleOptions('showPointHandle')}/>
+            <input id='showPointHandle' type='checkbox' name='showPointHandle' checked={options.showPointHandle} onChange={toggleOptions('showPointHandle')}/>
           </Label>
           <Label labelText='Show Move Handle' htmlFor='showMoveHandle' >
-            <input type='checkbox' name='showMoveHandle' checked={options.showMoveHandle} onChange={toggleOptions('showMoveHandle')}/>
+            <input id='showMoveHandle' type='checkbox' name='showMoveHandle' checked={options.showMoveHandle} onChange={toggleOptions('showMoveHandle')}/>
           </Label>
           <Label labelText='Show Point' htmlFor='showPoint' >
-            <input type='checkbox' name='showPoint' checked={options.showPoint} onChange={toggleOptions('showPoint')}/>
+            <input id='showPoint' type='checkbox' name='showPoint' checked={options.showPoint} onChange={toggleOptions('showPoint')}/>
           </Label>
           <Label labelText='Show Direction Mark' htmlFor='showDirectionMark' >
-            <input type='checkbox' name='showDirectionMark' checked={options.showDirectionMark} onChange={toggleOptions('showDirectionMark')}/>
+            <input id='showDirectionMark' type='checkbox' name='showDirectionMark' checked={options.showDirectionMark} onChange={toggleOptions('showDirectionMark')}/>
           </Label>
           <Label labelText='Show Label Shadow' htmlFor='showLabelShadow' >
-            <input type='checkbox' name='showLabelShadow' checked={options.showLabelShadow} onChange={toggleOptions('showLabelShadow')}/>
+            <input id='showLabelShadow' type='checkbox' name='showLabelShadow' checked={options.showLabelShadow} onChange={toggleOptions('showLabelShadow')}/>
           </Label>
         </SidebarBox>
         <SidebarBox>
           { options.showDirectionMark ?
             <>
-              <TextField label='Rename UP Line' fieldState='default' name='renameLine1' value={state[0]?.name ||''} onChange={(e) => renamePointLine(0, e)} />
-              <TextField label='Rename DOWN Line' fieldState='default' name='renameLine2' value={state[1]?.name ||''} onChange={(e) => renamePointLine(1, e)} />
+              <TextField id='renameLine1' label='Rename UP Line' fieldState='default' name='renameLine1' value={state[0]?.name ||''} onChange={(e) => renamePointLine(0, e)} />
+              <TextField id='renameLine2' label='Rename DOWN Line' fieldState='default' name='renameLine2' value={state[1]?.name ||''} onChange={(e) => renamePointLine(1, e)} />
             </>
             :
-            <TextField label='Rename Line' fieldState='default' name='rename' value={state[0]?.name ||''} onChange={renameLine}/>
+            <TextField id='rename' label='Rename Line' fieldState='default' name='rename' value={state[0]?.name ||''} onChange={renameLine}/>
           }
           <Label labelText='Boundary Offset' htmlFor='boundaryOffset' >
-            <Input type='number' name='boundaryOffset' min={0} value={options.boundaryOffset} onChange={updateBoudaryOffset}/>
+            <Input id='boundaryOffset' type='number' name='boundaryOffset' min={0} value={options.boundaryOffset} onChange={updateBoudaryOffset}/>
           </Label>
-          <TextField label='Area Fill Color' fieldState='default' name='fillColor' value={state[0]?.areaFillColor ||''} onChange={(e) => changeFillColor(0, e)}/>
-          <TextField label='Area Tranparency Level' fieldState='default' name='transparencyLevel' value={state[0]?.areaTransparencyLevel ||''} onChange={(e) => changeTranparencyLevel(0, e)}/>
+          <TextField id='fillColor' label='Area Fill Color' fieldState='default' name='fillColor' value={state[0]?.areaFillColor ||''} onChange={(e) => changeFillColor(0, e)}/>
+          <TextField id='transparencyLevel' label='Area Tranparency Level' fieldState='default' name='transparencyLevel' value={state[0]?.areaTransparencyLevel ||''} onChange={(e) => changeTranparencyLevel(0, e)}/>
         </SidebarBox>
         <SidebarBox>
           <Button design="secondary" onClick={toggleReadOnly()} >Toggle Read Only</Button>

--- a/example/src/pages/Login.tsx
+++ b/example/src/pages/Login.tsx
@@ -90,7 +90,7 @@ const ForgotLink = styled(Link)`
 
 const ForgotLinkWrapper = styled.div`
     text-align: center;
-    margin: 10px auto; 
+    margin: 10px auto;
 `;
 
 const CopyRightStyle = css`
@@ -188,7 +188,7 @@ export const LogoContainer = styled.div`
   position: relative;
   justify-content: center;
   overflow: hidden;
-  
+
   ${({theme}) => css`
     @media ${theme.deviceMediaQuery.large} {
       height: auto;
@@ -289,6 +289,7 @@ const Login: React.FC<OwnProps> = ({
             onChange={onFieldChange('username')}
             value={form.username}
             name='username'
+            id='username'
           />
 
           <PasswordField
@@ -298,6 +299,7 @@ const Login: React.FC<OwnProps> = ({
             onChange={onFieldChange('password')}
             value={form.password}
             name='password'
+            id='password'
           />
           {alert && <AlertBar type={alert.type} message={alert.message} />}
 

--- a/example/src/pages/TabsPage.tsx
+++ b/example/src/pages/TabsPage.tsx
@@ -34,16 +34,16 @@ const TabsPage: React.FC = () => {
         <Divider />
         <TabContent tabId='tab1'>
           <Tab1Container>
-            <Label htmlFor='' labelText='Content of tab 1' />
-            <TextField fieldState='default' required label='Full Name' name='fullname' />
-            <TextField fieldState='default' required label='Department' name='department' />
+            <Label htmlFor='fullname' labelText='Content of tab 1' />
+            <TextField fieldState='default' required label='Full Name' name='fullname' id='fullname' />
+            <TextField fieldState='default' required label='Department' name='department' id='department'/>
             <Button design='primary' size='small'> Save </Button>
           </Tab1Container>
         </TabContent>
         <TabContent tabId='tab2'>
           <Tab2Container>
-            <Label htmlFor='' labelText='Content of tab 2' />
-            <Label htmlFor='' labelText='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sit amet erat et sapien pulvinar efficitur. Quisque tristique massa at auctor rhoncus. Ut venenatis sem id gravida volutpat. Phasellus faucibus accumsan sapien, id pellentesque dolor consectetur quis. Duis non rhoncus nunc. Suspendisse et rhoncus tortor.' /> 
+            <Label htmlFor='content2' labelText='Content of tab 2'/>
+            <Label htmlFor='lorem' labelText='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sit amet erat et sapien pulvinar efficitur. Quisque tristique massa at auctor rhoncus. Ut venenatis sem id gravida volutpat. Phasellus faucibus accumsan sapien, id pellentesque dolor consectetur quis. Duis non rhoncus nunc. Suspendisse et rhoncus tortor.' />
             <Button design='primary' size='small'> OK </Button>
           </Tab2Container>
         </TabContent>

--- a/storybook/src/stories/Alerts/Modals/LoginModalExample.tsx
+++ b/storybook/src/stories/Alerts/Modals/LoginModalExample.tsx
@@ -49,7 +49,7 @@ const LoginModalExample : React.FC = () => {
     }, [form]);
 
   const { setModalOpen } = useModal();
-  
+
   // Fake login for the example
   const onLogin = useCallback((params: { username: string; password: string })  => {
     if(params.username === 'user' && params.password === 'fakepass123') {
@@ -96,13 +96,13 @@ const LoginModalExample : React.FC = () => {
 
     return true;
   };
-  
+
   const handleModalSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement | HTMLButtonElement>) => {
     e.preventDefault();
 
     // Validate inputs and show errors
     const areInputsValid = validateFields(form);
-  
+
     // if inputs are not valid return to allow user to correct before submiting
     if(!areInputsValid) { return; }
 
@@ -128,6 +128,7 @@ const LoginModalExample : React.FC = () => {
       onChange={onFieldChange('username')}
       value={form.username}
       name='username'
+      id='username'
     />
     <PasswordField
       fieldState='default'
@@ -136,6 +137,7 @@ const LoginModalExample : React.FC = () => {
       onChange={onFieldChange('password')}
       value={form.password}
       name='password'
+      id='password'
     />
     {alert && <AlertBar type={alert.type} message={alert.message} />}
     <Box flex='1'>

--- a/storybook/src/stories/Form/Input/Input.stories.tsx
+++ b/storybook/src/stories/Form/Input/Input.stories.tsx
@@ -21,6 +21,6 @@ export const TextInput = () => {
   const inputPlaceholder = text("Placeholder", "Placeholder...");
   const inputState = select("State", { Default: "default",  Disabled: 'disabled', Required: 'required',  Valid: 'valid',  Invalid: 'invalid', Processing: 'processing' }, "default");
 
-  return <Container><TextField name={inputName} label={inputLabel} placeholder={inputPlaceholder} fieldState={inputState} feedbackMessage={inputFeedback} /></Container>;
-
+  return <Container>
+    <TextField id={inputName} name={inputName} label={inputLabel} placeholder={inputPlaceholder} fieldState={inputState} feedbackMessage={inputFeedback} /></Container>;
 };

--- a/storybook/src/stories/Form/Input/SmallInput.stories.tsx
+++ b/storybook/src/stories/Form/Input/SmallInput.stories.tsx
@@ -24,6 +24,7 @@ export const _SmallInput = () => {
 
   return <Container>
     <SmallInput
+      id = {inputName}
       type={inputType}
       unit={inputUnit}
       name={inputName}

--- a/storybook/src/stories/Form/Input/TextAreaField.stories.tsx
+++ b/storybook/src/stories/Form/Input/TextAreaField.stories.tsx
@@ -30,6 +30,7 @@ export const _TextAreaField = () => {
 
     return <Container>
       <TextAreaField
+        id={fieldName}
         name={fieldName}
         label={fieldLabel}
         placeholder = {fieldPlaceholder}


### PR DESCRIPTION
### Description

There was a problem on a project that showed warnings in chrome, when reported it was mention that the same error was in our code. The solution was to update the missing parameters of id and htmlfor in labels. 

This PR corrects this problem in the examples to avoid the warnings and avoid confusion.

### Before
Two occurrences are shown because missing id on small input and one that is always present from Storybook code
   
<img width="1272" alt="Screenshot 2024-03-06 at 11 37 18" src="https://github.com/future-standard/scorer-ui-kit/assets/10409078/9dea1d70-8f56-4dbd-8501-fd4af2978c88">


### After
After the update there is stilll the Storybook code shown but not in the small input
<img width="1076" alt="Screenshot 2024-03-06 at 11 34 54" src="https://github.com/future-standard/scorer-ui-kit/assets/10409078/2f73e78b-2ca1-48ae-b66d-1b5cc090774c">


### Description

Testing just check the components in Example and Storybook