### PR TITLE
Update FilterResults to transform midnight input into next day

### DIFF
--- a/src/Filters/atoms/DateTimeBlock.tsx
+++ b/src/Filters/atoms/DateTimeBlock.tsx
@@ -79,7 +79,7 @@ const Input = styled.input<{ readOnly? : boolean, allowManualTimeChange?:boolean
 const TimeColon = styled.div`
   flex: 0 0 20px;
   text-align: center;
-`;  
+`;
 
 const InputWrap = styled.div`
   display: flex;

--- a/src/Filters/molecules/FiltersResults.tsx
+++ b/src/Filters/molecules/FiltersResults.tsx
@@ -5,7 +5,7 @@ import { resetButtonStyles } from '../../common/index';
 import Icon, { IconWrapper } from '../../Icons/Icon';
 import { isFilterItem } from '../FilterTypes';
 import { DateInterval, isDateInterval } from './DatePicker';
-import { format } from 'date-fns';
+import { format, add, startOfDay } from 'date-fns';
 
 const Container = styled.div`
   display: flex;
@@ -65,6 +65,20 @@ const FilterLabelsGroup = styled.div`
   margin-left: 10px;
 `;
 
+/**
+ * Date from Datepicker, since it does not support seconds input, we assumed that 23:59:59 value is showing 24:00 in display
+ * Here is not changing the value that the developer receives, just displaying 00:00 of the next Day
+ */
+
+const validWithMidnight = (endDate: Date, resultsDateFormat: string) =>  {
+
+  if (endDate.getHours() === 23 && endDate.getSeconds() > 0) {
+  return format( add(startOfDay(endDate), {days:1}), resultsDateFormat);
+  }
+
+  return format(endDate, resultsDateFormat);
+};
+
 const validateDateFormat = (resultsDateFormat: string): boolean => {
   let isFormatValid = false;
 
@@ -91,6 +105,8 @@ const renderLabel = (item: IFilterItem | DateInterval | Date, resultsDateFormat:
   let textLabel: string = "";
   const isDateFormatValid = validateDateFormat(resultsDateFormat);
 
+  console.log('date received', resultsDateFormat, item);
+
   if (filterName && isFilterItem(item)) {
     textLabel = `${filterName}: ${item.text}`;
   } else if (filterName && item instanceof Date) {
@@ -99,7 +115,7 @@ const renderLabel = (item: IFilterItem | DateInterval | Date, resultsDateFormat:
       : `${filterName}: ${item.toDateString()}`;
   } else if (filterName && isDateInterval(item)) {
     textLabel = isDateFormatValid
-      ? `${filterName}: ${format(item.start, resultsDateFormat)} - ${format(item.end, resultsDateFormat)}`
+      ? `${filterName}: ${format(item.start, resultsDateFormat)} - ${validWithMidnight(item.end, resultsDateFormat)}`
       : `${filterName}: ${item.start.toDateString()} - ${item.end.toDateString()}`;
   } else if (!filterName && isFilterItem(item)) {
     textLabel = item.text;
@@ -109,9 +125,11 @@ const renderLabel = (item: IFilterItem | DateInterval | Date, resultsDateFormat:
       : item.toDateString();
   } else if (!filterName && isDateInterval(item)) {
     textLabel = isDateFormatValid
-      ? `${format(item.start, resultsDateFormat)} - ${format(item.end, resultsDateFormat)}`
+      ? `${format(item.start, resultsDateFormat)} - ${validWithMidnight(item.end, resultsDateFormat)}`
       : `${item.start.toDateString()} - ${item.end.toDateString()}`;
   }
+
+  console.log('Inputs results', textLabel);
 
   return <FilterLabelText hasIcon={!!icon}>{textLabel}</FilterLabelText>;
 };

--- a/src/Filters/molecules/FiltersResults.tsx
+++ b/src/Filters/molecules/FiltersResults.tsx
@@ -105,8 +105,6 @@ const renderLabel = (item: IFilterItem | DateInterval | Date, resultsDateFormat:
   let textLabel: string = "";
   const isDateFormatValid = validateDateFormat(resultsDateFormat);
 
-  console.log('date received', resultsDateFormat, item);
-
   if (filterName && isFilterItem(item)) {
     textLabel = `${filterName}: ${item.text}`;
   } else if (filterName && item instanceof Date) {
@@ -128,8 +126,6 @@ const renderLabel = (item: IFilterItem | DateInterval | Date, resultsDateFormat:
       ? `${format(item.start, resultsDateFormat)} - ${validWithMidnight(item.end, resultsDateFormat)}`
       : `${item.start.toDateString()} - ${item.end.toDateString()}`;
   }
-
-  console.log('Inputs results', textLabel);
 
   return <FilterLabelText hasIcon={!!icon}>{textLabel}</FilterLabelText>;
 };

--- a/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
+++ b/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
@@ -121,7 +121,7 @@ export const _FilterBar = () => {
   const singleFilter = boolean('Single Filter', false);
   const hasShowMore = boolean('Has Show More', true);
   // valid formats - https://date-fns.org/v2.25.0/docs/format
-  const resultsDateFormat = text('Results date format', 'yyyy-MM-dd');
+  const resultsDateFormat = text('Results date format', 'yyyy-MM-dd HH:mm');
 
   // Sent to checkbox in TableRow via Table component.
   const selectCallback = useCallback((checked: boolean, id?: string | number) => {
@@ -203,7 +203,6 @@ export const _FilterBar = () => {
     {
       id: 'datePickerForRuntime',
       dateMode: 'interval',
-      timeMode: 'off',
       buttonText: language === 'english' ? 'Date Range' : '日付範囲',
       buttonIcon: 'DateTime',
       dateTimeTextUpper: language === 'english' ? 'From' : 'から',


### PR DESCRIPTION
### Description
This PR is an update request of the Issue 
https://github.com/future-standard/scorer-ui-kit/issues/439

Right now midnight is not correctly reflected in the text of filter results input

24:00 is shown as 23:59 the request is to show the next day at 00:00


 ### Considerations on Implementation
The format sent by the user might influence the output but that is related to date-fns and should be handled by the Developer using UI Kit

yyyy-MM-dd HH:MM will show 2024-03-14 00:03 - 2024-03-15 00:03

yyyy-MM-dd HH:mm while using minutes lowercase will show 2024-03-14 00:01 - 2024-03-15 00:00

Out of the scope of this PR is to fix the DatePicker wrong Dates related to 24 hours 

Currently when the user updates the date to 24:00 the value is received as 23:00 by the developer.

This will be fix in a different PR.


<img width="869" alt="Screenshot 2024-03-14 at 14 02 41" src="https://github.com/future-standard/scorer-ui-kit/assets/10409078/6cbe9c37-2aec-497d-ab72-ea838c52a4ef">

 ### Reviewing/Testing steps

Run storybook in local

On FilterBar story select in the second clock 24:00 of any Date.


### Video
This is the happy path but like I mentioned before error in the callback are present when the user updates to 24 hours manually

https://drive.google.com/file/d/1Cs3JiClLQh_yoREZLWyaWwj76dcazPBi/view?usp=drive_link
