### PR TITLE
Bump for v1.7.30 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "1.7.29",
+  "version": "1.7.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "1.7.29",
+  "version": "1.7.30",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
### Description
Bump for release 1.7.30

Fixes

- Datepicker: 23-24 hours fix with rolling minutes to the next or previous hour when required.
- HTMLfor missing examples
