### PR TITLE
Icon color selection switched to CSS Variables

### DIFF
--- a/packages/ui-lib/src/Form/atoms/FilterOption.tsx
+++ b/packages/ui-lib/src/Form/atoms/FilterOption.tsx
@@ -47,7 +47,7 @@ const CheckMarkWrapper = styled.div`
       stroke: transparent;
     }
     [fill] {
-      fill: ${({ theme }) => theme.colors.icons.inverse};
+      fill: var(--inverse);
     }
   }
 `;

--- a/packages/ui-lib/src/Form/atoms/IconButton.tsx
+++ b/packages/ui-lib/src/Form/atoms/IconButton.tsx
@@ -3,22 +3,22 @@ import styled from 'styled-components';
 import { resetButtonStyles } from '../../common';
 import Icon, { IconProps, IconWrapper } from '../../Icons/Icon';
 
-const StyledButton = styled.button<{color:ISvgIcons['color']; hoverColor:ISvgIcons['color']}>`
+const StyledButton = styled.button<{color:string; hoverColor:string}>`
   ${resetButtonStyles};
   [stroke]{
-    stroke: ${({theme, color}) => theme.colors.icons[color]};
+    stroke: ${({color}) => color};
   }
   &:hover {
     ${IconWrapper} {
       [stroke]{
-        stroke: ${({theme, hoverColor}) => theme.colors.icons[hoverColor]};
+        stroke: ${({hoverColor}) => hoverColor};
       }
     }
   }
 `;
 
 interface OwnProps {
-  hoverColor?: ISvgIcons['color']
+  hoverColor?: string
 }
 
 export type IconButtonData = OwnProps & IconProps & ButtonHTMLAttributes<HTMLButtonElement>

--- a/packages/ui-lib/src/Form/atoms/IconButton.tsx
+++ b/packages/ui-lib/src/Form/atoms/IconButton.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { resetButtonStyles } from '../../common';
 import Icon, { IconProps, IconWrapper } from '../../Icons/Icon';
 
-const StyledButton = styled.button<{color:string; hoverColor:string}>`
+const StyledButton = styled.button<{color:ISvgIcons['color']; hoverColor:ISvgIcons['color']}>`
   ${resetButtonStyles};
   [stroke]{
     stroke: ${({color}) => color};

--- a/packages/ui-lib/src/Form/molecules/CropTool.tsx
+++ b/packages/ui-lib/src/Form/molecules/CropTool.tsx
@@ -52,7 +52,7 @@ const TextGroup = styled.div`
   align-items: center;
   font-size: 20px;
   font-weight: 500;
-  color: ${({theme}) => theme.colors.icons.mono};
+  color: var(--mono);
 
   ${IconWrapper} {
     display: flex;

--- a/packages/ui-lib/src/Global/atoms/ContextItem.tsx
+++ b/packages/ui-lib/src/Global/atoms/ContextItem.tsx
@@ -102,7 +102,7 @@ const ContextWrapper = styled.div<{$menuOpen?: boolean}>`
     ${({ theme }) => theme.styles.global.mainMenu.iconBackground.hover};
     ${IconWrapper}{
       [stroke]{
-        stroke: ${({ theme }) => theme.colors.icons['inverse']};
+        stroke: var(--inverse);
       }
     }
   }
@@ -126,7 +126,7 @@ const ContextActionA = styled(Link) <{ $menuOpen?: boolean, $isActive: boolean }
     ${({ theme }) => theme.styles.global.mainMenu.iconBackground.hover};
     ${IconWrapper}{
       [stroke]{
-        stroke: ${({ theme }) => theme.colors.icons['inverse']};
+        stroke: var(--inverse);
       }
     }
   }
@@ -162,7 +162,7 @@ const ContextActionButton = styled.button<{ menuOpen?: boolean, isActive: boolea
     ${({ theme }) => theme.styles.global.mainMenu.iconBackground.hover};
     ${IconWrapper}{
       [stroke]{
-        stroke: ${({ theme }) => theme.colors.icons['inverse']};
+        stroke: var(--inverse);
       }
     }
   }

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -37,7 +37,7 @@ export interface IconProps {
 const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'grey-12', forSvgUsage = false }) => {
   const legacyColors = ['mono', 'dimmed', 'subtle', 'inverse', 'primary', 'danger'];
   if(legacyColors.indexOf(color) >= 0){
-    console.warn("Deprecation warning: The use of " + color + " is deprecated. Please replace it with theme color variable.")
+    console.warn("Deprecation warning: The use of " + color + " is deprecated. Please replace it with theme color variable.");
   }
 
   const iconWeight: number = dimensions.icons.weights[weight];

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -30,7 +30,7 @@ export interface IconProps {
   icon: string;
   size?: number;
   weight?: 'light' | 'regular' | 'heavy' | 'strong';
-  color?: string;
+  color?: ISvgIcons['color'];
   forSvgUsage?: boolean;
 }
 

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -35,10 +35,11 @@ export interface IconProps {
 }
 
 const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'grey-12', forSvgUsage = false }) => {
-  const legacyColors = ['mono', 'dimmed', 'subtle', 'inverse', 'primary', 'danger'];
-  if(legacyColors.indexOf(color) >= 0){
-    console.warn("Deprecation warning: The use of " + color + " is deprecated. Please replace it with theme color variable.");
-  }
+  // For later use in deprecation of aliases.
+  // const legacyColors = ['mono', 'dimmed', 'subtle', 'inverse', 'primary', 'danger'];
+  // if(legacyColors.indexOf(color) >= 0){
+  //   console.warn("Deprecation warning: The use of " + color + " is deprecated. Please replace it with theme color variable.");
+  // }
 
   const iconWeight: number = dimensions.icons.weights[weight];
   //@ts-ignore

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -15,6 +15,7 @@ const wrapperCss = css`
     }
   }
 `;
+
 const IconWrapper = styled.div`
   ${wrapperCss};
 `;
@@ -33,7 +34,11 @@ export interface IconProps {
   forSvgUsage?: boolean;
 }
 
-const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'mono', forSvgUsage = false }) => {
+const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'grey-12', forSvgUsage = false }) => {
+  const legacyColors = ['mono', 'dimmed', 'subtle', 'inverse', 'primary', 'danger'];
+  if(legacyColors.indexOf(color) >= 0){
+    console.warn("Deprecation warning: The use of " + color + " is deprecated. Please replace it with theme color variable.")
+  }
 
   const iconWeight: number = dimensions.icons.weights[weight];
   //@ts-ignore

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -49,11 +49,11 @@ const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color 
     IconSVG != null ?
       forSvgUsage ?
         <IconWrapperForSVG>
-          {IconSVG({ size: size, weight: iconWeight, color: `var(--${color})` })}
+          {IconSVG({ size: size, weight: iconWeight, color: `var(--${color}, var(--grey-12))` })}
         </IconWrapperForSVG>
         :
         <IconWrapper>
-          {IconSVG({ size: size, weight: iconWeight, color: `var(--${color})` })}
+          {IconSVG({ size: size, weight: iconWeight, color: `var(--${color}, var(--grey-12))` })}
         </IconWrapper>
       :
       null

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -28,9 +28,9 @@ export { IconWrapper, IconWrapperForSVG, IconSVGs };
 export interface IconProps {
   icon: string;
   size?: number;
-  weight?: 'light' | 'regular' | 'heavy' | 'strong'
-  color?: ISvgIcons['color']
-  forSvgUsage?: boolean
+  weight?: 'light' | 'regular' | 'heavy' | 'strong';
+  color?: string;
+  forSvgUsage?: boolean;
 }
 
 const Icon: React.FC<IconProps> = ({ icon, size = 24, weight = 'regular', color = 'mono', forSvgUsage = false }) => {

--- a/packages/ui-lib/src/Icons/index.d.ts
+++ b/packages/ui-lib/src/Icons/index.d.ts
@@ -1,5 +1,5 @@
 interface ISvgIcons extends React.SVGProps<SVGSVGElement> {
   size: number
-  color: 'mono' | 'dimmed' | 'subtle' | 'inverse' | 'primary' | 'danger' | 'white';
+  color: string
   weight: number
 }

--- a/packages/ui-lib/src/Misc/atoms/BasicSearchInput.tsx
+++ b/packages/ui-lib/src/Misc/atoms/BasicSearchInput.tsx
@@ -58,13 +58,13 @@ const CrossButton = styled.button`
 const StyledInput = styled.input<{ color: string }>`
   ${removeAutoFillStyle};
 
-  ${({ theme: {typography, colors}, theme, color }) => css`
+  ${({ theme: {typography}, theme, color }) => css`
     font-family: ${theme.fontFamily.ui};
     ${typography.filters.searchInput.value};
 
     &::placeholder {
       ${typography.filters.searchInput.placeholder};
-      color: ${colors.icons[color]};
+      color: var(--${color});
       font-size: 12px;
     }
   `};

--- a/packages/ui-lib/src/Misc/atoms/Tag.tsx
+++ b/packages/ui-lib/src/Misc/atoms/Tag.tsx
@@ -25,7 +25,7 @@ export const TagWrapper = styled.div<{ hoverColor:ISvgIcons['color']; enableHove
 
   ${IconWrapper} {
     [stroke]{
-      ${({theme}) => theme.colors.icons['dimmed']};
+      stroke: var(--dimmed);
     }
     margin-right: 8px;
     display: flex;
@@ -36,11 +36,11 @@ export const TagWrapper = styled.div<{ hoverColor:ISvgIcons['color']; enableHove
   ${({theme, hoverColor, enableHover}) => enableHover && css`
     &:hover {
       cursor: pointer;
-      border-color: ${theme.colors.icons[hoverColor]};
-      color: ${theme.colors.icons[hoverColor]};
+      border-color: var(--${hoverColor});
+      color: var(--${hoverColor});
       ${IconWrapper} {
         [stroke]{
-          stroke: ${theme.colors.icons[hoverColor]};
+          stroke: var(--${hoverColor});
         }
       }
     }

--- a/packages/ui-lib/src/Misc/atoms/Tag.tsx
+++ b/packages/ui-lib/src/Misc/atoms/Tag.tsx
@@ -33,7 +33,7 @@ export const TagWrapper = styled.div<{ hoverColor:ISvgIcons['color']; enableHove
     align-items: center;
   }
 
-  ${({theme, hoverColor, enableHover}) => enableHover && css`
+  ${({hoverColor, enableHover}) => enableHover && css`
     &:hover {
       cursor: pointer;
       border-color: var(--${hoverColor});

--- a/packages/ui-lib/src/Modals/Modal.tsx
+++ b/packages/ui-lib/src/Modals/Modal.tsx
@@ -35,7 +35,7 @@ const CloseButton = styled.button<{ selected?: boolean }>`
   position: absolute;
   right: 0;
   top: -30px;
-  color: ${({theme}) => theme.colors.icons.mono};
+  color: var(--mono);
   font-size: 14px;
   font-weight: 500;
 

--- a/packages/ui-lib/src/Tabs/atoms/MobileTab.tsx
+++ b/packages/ui-lib/src/Tabs/atoms/MobileTab.tsx
@@ -24,7 +24,7 @@ const LinkTab = styled.div<{ isActive: boolean }>`
 
     ${IconWrapper} {
       [stroke]{
-        stroke: ${theme.colors.icons['dimmed']};
+        stroke: var(--dimmed);
       }
     }
 


### PR DESCRIPTION
### Description

This updates icon color selections to use CSS variables instead of the older json based system. The older JSON stays in place for now so not to break project integration, however a deprecation warning has been added to the console.

From here, the color reference is the name of the color variable without the `--` prefix. For example, `grey-9` or `primary-6`.

- Updates all references done via `theme.colors.icons` to `var(--example-12)` css vars.
- Updates the `ISvgIcons` type so the color is simply a `string`.
- Added a deprecation `console.warn` message for use of the old references.

This work is required for the upcoming layouts feature but is being sent seperately for ease of review.