### PR TITLE
Add missing props from Select in Pagination

### DIFF
--- a/packages/storybook/src/stories/Misc/molecules/Pagination.stories.tsx
+++ b/packages/storybook/src/stories/Misc/molecules/Pagination.stories.tsx
@@ -13,7 +13,8 @@ const ItemsOptions = [
   {value:5, textValue:'5'},
   {value: 10, textValue: '10'},
   {value: 20, textValue: '20'},
-  {value: 30, textValue: '30'}
+  {value: 30, textValue: '30'},
+  {value: 100, textValue: '100'}
 ]
 
 export const _Pagination = () => {
@@ -23,7 +24,9 @@ export const _Pagination = () => {
   const pageText = text('Page Text', 'Page:');
   const buttonText= text('Button Text', 'GO');
   const itemsText = text('Items Per Page', 'Items Per Page:' )
-  const selectWidth = text('Select Width', '60px');
+  const itemsDefaultValue = number('Items Default Value', 10 );
+  const selectWidth = text('Select Width', '70px');
+  const selectId = text('SelectId', 'UniqID23');
   const totalPages = number('Total Pages', 20);
   const selectDisabled = boolean('Select Disabled', false)
   const itemOptionsObj = object('Items Options', ItemsOptions);
@@ -47,6 +50,7 @@ export const _Pagination = () => {
       itemsText={itemsText}
       selectWidth={selectWidth}
       selectDisabled ={selectDisabled}
+      itemsDefaultValue={itemsDefaultValue}
       itemsOptions={itemOptionsObj}
       onPageChange={onPageChange}
       onItemsChange={onItemsChange}

--- a/packages/ui-lib/src/Misc/molecules/Pagination.tsx
+++ b/packages/ui-lib/src/Misc/molecules/Pagination.tsx
@@ -131,8 +131,10 @@ interface OwnProps {
   activePage?: number
   buttonText?: string
   itemsText?: string
+  itemsDefaultValue?: number
   selectWidth?: string
   selectDisabled?: boolean
+  selectId?: string
   itemsOptions: IItemsOption[]
   onPageChange: (page: number) => void
   onItemsChange: (items: number) => void
@@ -147,6 +149,8 @@ const Pagination: React.FC<IPagination> = (props) => {
     activePage = 1,
     buttonText = 'GO',
     itemsText = 'Items Per Page',
+    itemsDefaultValue,
+    selectId = 'paginationPages',
     selectWidth = '60px',
     selectDisabled = false,
     itemsOptions = [],
@@ -302,8 +306,8 @@ const Pagination: React.FC<IPagination> = (props) => {
       <ItemsSelectWrapper width={selectWidth}>
         <SelectField
           disabled={selectDisabled}
-          label={{ htmlFor: 'paginationPages', text: itemsText, isSameRow: true }}
-          defaultValue={1}
+          label={{ htmlFor: selectId, text: itemsText, isSameRow: true }}
+          defaultValue={itemsDefaultValue ? itemsDefaultValue : itemsOptions[0].value || 1}
           changeCallback={onItemsSelectChange}
         >
           <Fragment>


### PR DESCRIPTION
### Description

There were 2 fixed values for id and defaultValue in the Select of the Pagination component.
Update of default Value is necessary for local storage of the user selection, this fix will enable that option.


 ### Reviewing/Testing steps

Run Pagination component in Storybook and test different values in the itemsDefaultValue

### Screenshots 
<img width="1193" alt="Screenshot 2024-07-30 at 8 42 26" src="https://github.com/user-attachments/assets/d4b61fe5-9649-4678-a30e-25dec7a46f93">
