### PR TITLE
Fix to layout breaks on examples and stories.

### DIFF
--- a/packages/example/src/style.ts
+++ b/packages/example/src/style.ts
@@ -4,17 +4,8 @@ import { BaseStyles } from 'scorer-ui-kit';
 const GlobalStyle = createGlobalStyle`
   ${BaseStyles};
 
-  // Custom changes for examples usage.
-  html, body, #root {
-    height: 100%;
-  }
-
   body {
     background: var(--grey-3);
-  }
-  
-  #root {
-    display: flex;
   }
 `
 export default GlobalStyle;

--- a/packages/example/src/style.ts
+++ b/packages/example/src/style.ts
@@ -3,5 +3,18 @@ import { BaseStyles } from 'scorer-ui-kit';
 
 const GlobalStyle = createGlobalStyle`
   ${BaseStyles};
+
+  // Custom changes for examples usage.
+  html, body, #root {
+    height: 100%;
+  }
+
+  body {
+    background: var(--grey-3);
+  }
+  
+  #root {
+    display: flex;
+  }
 `
 export default GlobalStyle;

--- a/packages/ui-lib/src/Global/atoms/Layout.tsx
+++ b/packages/ui-lib/src/Global/atoms/Layout.tsx
@@ -6,8 +6,6 @@ export const MOBILE_NAVBAR_HEIGHT = 68;
 
 export const Layout = styled.div`
   display: flex;
-  flex-direction: row;
-  flex: 1;
 `;
 
 export const MobileLayout = styled.div``;

--- a/packages/ui-lib/src/theme/ThemeHelpers.ts
+++ b/packages/ui-lib/src/theme/ThemeHelpers.ts
@@ -16,10 +16,6 @@ const BaseStyles = css`
     color: var(--grey-11);
   }
   
-  #root {
-    display: flex;
-  }
-
 `;
 
 export {

--- a/packages/ui-lib/src/theme/ThemeHelpers.ts
+++ b/packages/ui-lib/src/theme/ThemeHelpers.ts
@@ -14,6 +14,7 @@ const BaseStyles = css`
   body {
     font-family: var(--font-ui);
     color: var(--grey-11);
+    background: linear-gradient(180.00deg, var(--grey-2) 0%, var(--grey-3) 100%) var(--grey-3); 
   }
   
 `;

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -28,11 +28,6 @@ ${colorVariables};
 
     --input-height: 40px;
     
-
-  }
-  
-  body {
-    background: linear-gradient(180.00deg, var(--grey-2) 0%, var(--grey-3) 100%) var(--grey-3); 
   }
 
   .button-small {


### PR DESCRIPTION
Removes the flex from the `#root` selector which was breaking the layout of some examples and stories. It was added as part of a fix to the layouts not spanning the full height of the container and backgrounds being cut off when scrolling, however it seems that this flex on #root was redundant.