### PR TITLE
Add missing colorIcon in PageHeader

### DIFF
--- a/packages/storybook/src/stories/Pages/PageHeader.stories.tsx
+++ b/packages/storybook/src/stories/Pages/PageHeader.stories.tsx
@@ -69,6 +69,7 @@ export const _PageHeader = () => {
   const pageAreaText = text("Page Area", "Area Name");
   const pageAreaHref = text("Page Area Href", "#");
   const pageIcon = select("Icon", iconList, 'Link');
+  const pageIconColor = select("Icon Color", { Mono: "mono", Dimmed: "dimmed", Subtle: "subtle", Inverse: "inverse", Primary: "primary" , Danger: "danger", Undefined: undefined}, undefined);
   const updateDocTitle = boolean("Update Doc Title", true);
   const noTagsExample = boolean("No tags Example", false);
   const areaTitleBottom = boolean("Area Title Bottom", false);
@@ -85,6 +86,7 @@ export const _PageHeader = () => {
   return <Container>
         <PageHeader
           icon={noIconExample ? undefined : pageIcon || undefined}
+          iconColor={pageIconColor}
           introductionText={introductionText}
           title={pageTitle}
           areaTitle={pageAreaText}

--- a/packages/ui-lib/src/Pages/molecules/PageHeader.tsx
+++ b/packages/ui-lib/src/Pages/molecules/PageHeader.tsx
@@ -45,6 +45,7 @@ interface IProps {
   areaHref?: string
   areaTitle?: string
   icon?: string
+  iconColor?: string
   introductionText?: string
   updateDocTitle?: boolean
   hideAreaInDocTitle?: boolean
@@ -53,12 +54,24 @@ interface IProps {
   rightContent?: React.ReactNode | React.FC | ReactElement;
 }
 
-const PageHeader: React.FC<IProps> = ({ title, icon, introductionText, areaHref, areaTitle, updateDocTitle = true, hideAreaInDocTitle, tagList, areaTitleBottom, rightContent }) => {
+const PageHeader: React.FC<IProps> = ({
+  title,
+  icon,
+  iconColor='primary-9',
+  introductionText,
+  areaHref,
+  areaTitle,
+  updateDocTitle = true,
+  hideAreaInDocTitle,
+  tagList,
+  areaTitleBottom,
+  rightContent
+}) => {
 
   return (
     <Container>
       <LeftPanel>
-        <PageTitle iconColor='primary-9' {...{ title, icon, areaHref, areaTitle, updateDocTitle, hideAreaInDocTitle, areaTitleBottom }} />
+        <PageTitle iconColor={iconColor} {...{ title, icon, areaHref, areaTitle, updateDocTitle, hideAreaInDocTitle, areaTitleBottom }} />
         {!tagList ?
           null
           :


### PR DESCRIPTION
### Description

Hot fix of the missed  colorIcon prop in Page header


 ### Reviewing/Testing steps

Run storybook Page Header and select different colors for iconColor
![Screenshot 2024-08-26 at 18 13 10](https://github.com/user-attachments/assets/da6e5c27-a16d-41d0-a2e4-ead462187aa3)
