### PR TITLE
Fix overlapping SplitButton when using it on table

### DIFF
--- a/packages/example/src/pages/TablePage.tsx
+++ b/packages/example/src/pages/TablePage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
-import { TypeTable, PageHeader, Content, useModal } from 'scorer-ui-kit';
+import { TypeTable, PageHeader, Content, useModal, SplitButton } from 'scorer-ui-kit';
 import { ITableColumnConfig, ITypeTableData } from 'scorer-ui-kit/dist/Tables';
 
 
@@ -42,6 +42,12 @@ const columnConfig: ITableColumnConfig[] = [
     cellStyle: 'highImportance',
     alignment: 'right',
     hasCopyButton: true
+  },
+  {
+    header: 'Actions',
+    sortable: false,
+    cellStyle: 'highImportance',
+    alignment: 'right',
   }
 ];
 
@@ -62,6 +68,12 @@ const TablePage: React.FC = () => {
     });
   }, [createModal]);
 
+  const buttonList = useMemo(() => [
+    {id: 'a0', text: 'Main Action', icon: 'Success',  onClickCallback: () => {} },
+    {id: 'a1', text: '日本語の場合はランダム', onClickCallback:  () => {} },
+    {id: 'a2', text: 'Save Action', icon: 'Analyse', hasOnSelectLoading:true , onClickCallback: () => {} },
+    {id: 'a3', text: 'Download Action', icon: 'Download', onClickCallback: () => {}, disabled:true  },
+  ],[])
 
   const initialRows: ITypeTableData = useMemo(() => [
     {
@@ -76,7 +88,8 @@ const TablePage: React.FC = () => {
           { text: 'Device Name', href: '#' },
           { text: 'Just Now' },
           { text: '242', unit: 'mb' },
-          { text: '¥20,000' }
+          { text: '¥20,000' },
+          { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} />}
         ]
     },
     {
@@ -93,7 +106,8 @@ const TablePage: React.FC = () => {
           { text: 'Another Device', href: '#' },
           { text: '1st October 2019' },
           { text: '2.1', unit: 'gb' },
-          { text: '¥4,000' }
+          { text: '¥4,000' },
+          { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} />}
         ],
     },
     {
@@ -108,7 +122,8 @@ const TablePage: React.FC = () => {
           { text: 'Old Device', href: '#' },
           { text: '22nd March 2020' },
           { text: '2.1', unit: 'tb' },
-          { text: '¥7,000' }
+          { text: '¥7,000' },
+          { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} />}
         ],
     },
     {
@@ -123,7 +138,8 @@ const TablePage: React.FC = () => {
           { text: 'Magic Edge Cloud', href: '#' },
           { text: '2nd April 2020' },
           { text: '153', unit: 'mb' },
-          { text: '¥25,000' }
+          { text: '¥25,000' },
+          { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} />}
         ]
     },
     {
@@ -133,10 +149,11 @@ const TablePage: React.FC = () => {
           { text: 'Special Camera', href: '#' },
           { text: '16th June 2020' },
           { text: '153', unit: 'mb' },
-          { text: '¥25,000' }
+          { text: '¥25,000' },
+          { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} />}
         ]
-    }
-  ], [openCustomModal]);
+    },
+  ], [buttonList, openCustomModal]);
 
 
   const [rows, setRows] = useState<ITypeTableData>(initialRows)

--- a/packages/ui-lib/src/Form/molecules/SplitButton.tsx
+++ b/packages/ui-lib/src/Form/molecules/SplitButton.tsx
@@ -6,10 +6,15 @@ import { TypeButtonSizes, TypeButtonDesigns } from '..';
 import { resetButtonStyles } from '../../common';
 import { useClickOutside } from '../../hooks';
 
-
-const TOGGLE_ICON_WIDTH = 20;
+const TOGGLE_ICON_WIDTH = 30;
 
 const Container = styled.div`
+  height: var(--button-height);
+  overflow: visible;
+`;
+
+const ButtonsWrapper = styled.div<{ isOpen: boolean }>`
+  ${({ isOpen }) => isOpen && `z-index: 100`};
   font-family: var(--font-ui);
   position: relative;
   display: inline-flex;
@@ -30,9 +35,9 @@ interface IButtonItem {
   onClickCallback?: () => void
 }
 
-type ISplitButtonItem = IButtonItem &  ButtonHTMLAttributes<HTMLButtonElement>;
+type ISplitButtonItem = IButtonItem & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export interface ISplitButtonProps  {
+export interface ISplitButtonProps {
   mainButtonId: string
   buttonList: ISplitButtonItem[]
   isSortAscending?: boolean
@@ -97,71 +102,73 @@ const ToggleIcon = styled.button`
 
 `;
 
-const validateMaxWidth = (btnTextMaxWidth: number| null | undefined, textMaxWidth?: string) : string | undefined  => {
+const validateMaxWidth = (btnTextMaxWidth: number | null | undefined, textMaxWidth?: string): string | undefined => {
 
-  if(textMaxWidth)
+  if (textMaxWidth)
     return textMaxWidth;
 
-  if(btnTextMaxWidth)
+  if (btnTextMaxWidth)
     return `${btnTextMaxWidth - TOGGLE_ICON_WIDTH}px`;
 
   return undefined;
 };
 
-const SplitButton: React.FC<ISplitButtonProps> = ({mainButtonId, buttonList, design='primary', size, textMaxWidth, disabled = false, ...rest}) => {
+const SplitButton: React.FC<ISplitButtonProps> = ({ mainButtonId, buttonList, design = 'primary', size, textMaxWidth, disabled = false, ...rest }) => {
 
   const [isOpen, setIsOpen] = useState(false);
   const mainButtonRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonsWrapperRef = useRef<HTMLDivElement>(null);
 
   const toggleOpen = useCallback(() => {
-      setIsOpen((prev) => !prev);
-  },[]);
+    setIsOpen((prev) => !prev);
+  }, []);
 
-  const closeCallback = useCallback(()=>{
+  const closeCallback = useCallback(() => {
     setIsOpen(false);
-  },[]);
+  }, []);
 
-  useClickOutside(containerRef, closeCallback);
+  useClickOutside(buttonsWrapperRef, closeCallback);
 
-  return(
-    <Container ref={containerRef} className={`split-button-${design} button-${size}`} {...rest}>
-      <MainButtonWrapper ref={mainButtonRef}>
-        {buttonList.filter((button) => button.id === mainButtonId)
-            .map(({id, text, icon, disabled: disabledItemProp, ...props}) => (
-            <SplitButtonOption
-              key={id}
-              noBorderTop
-              disabled={disabled || disabledItemProp}
-              closeCallback={closeCallback}
-              icon={icon || 'NoIcon'}
-              {...{text, design, size}}
-              {...props}
+  return (
+    <Container>
+      <ButtonsWrapper ref={buttonsWrapperRef} className={`split-button-${design} button-${size}`} isOpen={isOpen} {...rest}>
+        <MainButtonWrapper ref={mainButtonRef}>
+          {buttonList.filter((button) => button.id === mainButtonId)
+            .map(({ id, text, icon, disabled: disabledItemProp, ...props }) => (
+              <SplitButtonOption
+                key={id}
+                noBorderTop
+                disabled={disabled || disabledItemProp}
+                closeCallback={closeCallback}
+                icon={icon || 'NoIcon'}
+                {...{ text, design, size }}
+                {...props}
               />
             ))
-        }
-        <ToggleIcon onClick={toggleOpen} disabled={disabled}>
-          { <Icon icon={isOpen ? 'Close' : 'Down'} size={8} />}
-        </ToggleIcon>
-      </MainButtonWrapper>
-      { (isOpen && !disabled) ?
+          }
+          <ToggleIcon onClick={toggleOpen} disabled={disabled}>
+            {<Icon icon={isOpen ? 'Close' : 'Down'} size={8} />}
+          </ToggleIcon>
+        </MainButtonWrapper>
+        {(isOpen && !disabled) ?
           <Fragment>
             {buttonList.filter((button) => button.id !== mainButtonId)
-                .map(({id, text, icon, disabled: disabledItemProp, ...props}) => (
+              .map(({ id, text, icon, disabled: disabledItemProp, ...props }) => (
                 <SplitButtonOption
                   key={id}
                   icon={icon || 'NoIcon'}
-                  {...{text, design, size}}
+                  {...{ text, design, size }}
                   disabled={disabledItemProp}
-                  textMaxWidth={validateMaxWidth(mainButtonRef.current?.clientWidth,textMaxWidth)}
+                  textMaxWidth={validateMaxWidth(mainButtonRef.current?.clientWidth, textMaxWidth)}
                   {...props}
                   closeCallback={closeCallback}
-                  />
+                />
               ))
             }
           </Fragment>
           : null
-      }
+        }
+      </ButtonsWrapper>
     </Container>
   );
 };


### PR DESCRIPTION
### Description
Bug Fix for SplitButton

When the SplitButton is around other split buttons the dropdowns overlap because the z-index is the same.
I have updated it so if it's open z-index will be 100 which is the same that other dropdowns in this library 

 ### Reviewing/ Testing Steps

Run locally the TablePage in Examples project