### PR TITLE
Datepicker Month pagination hover color fix

### DIFF
--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -109,7 +109,11 @@ const CurrentMonth = styled.div`
   }
 `;
 
-const IconWrap = styled.div``;
+const IconWrap = styled.div`
+  [stroke]{
+    stroke: var(--grey-8);
+  }
+`;
 
 const PaginateMonth = styled.button`
   cursor: pointer;
@@ -123,17 +127,17 @@ const PaginateMonth = styled.button`
   line-height: 20px;
   text-transform: uppercase;
   letter-spacing: 0.4px;
-  color: var(--grey-9);
+  color: var(--grey-8);
   display: flex;
   justify-content: space-around;
   align-items: center;
 
   &:hover {
-    color: var(--white-1);
+    color: var(--grey-12);
 
     ${IconWrap}{
       [stroke]{
-        stroke: var(--white-1);
+        stroke: var(--grey-12);
       }
     }
   }


### PR DESCRIPTION
### Description

Month pagination in Datepicker had a hover color of white that works great in Darkmode but will not be visible in Light Mode. 
Fixed updating colors.

 ### Considerations on Implementation
 I have used colors that look more more contrasting but had no design to match up.

 ### Reviewing/Testing steps
Review on Storybook running on local
Filters -> Molecules -> Datepicker


<img width="553" alt="Screenshot 2024-09-05 at 15 17 47" src="https://github.com/user-attachments/assets/a5d31bab-581f-4913-908d-cf9c798a1378">

<img width="587" alt="Screenshot 2024-09-05 at 15 17 39" src="https://github.com/user-attachments/assets/4fb84290-f671-4e51-aaa2-094a824ac387">
