### PR TITLE
Feature/tooltips (Ref based)

### DIFF
--- a/packages/example/src/components/StatusComponent.tsx
+++ b/packages/example/src/components/StatusComponent.tsx
@@ -36,12 +36,7 @@ interface IStatusBundle {
 export const StatusComponent: React.FC<IStatusBundle> = ({ statusList }) => {
 
   const statusRefs = useRef<(React.RefObject<HTMLDivElement>)[]>([]);
-
-  React.useEffect(() => {
-    // Initialise each ref
-    statusRefs.current = statusList.map(() => React.createRef<HTMLDivElement>());
-  });
-  
+  statusRefs.current = statusList.map(() => React.createRef<HTMLDivElement>());
 
   return (
     <StatusWrapper>

--- a/packages/example/src/components/StatusComponent.tsx
+++ b/packages/example/src/components/StatusComponent.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useRef } from 'react';
 import { AlertType, ITooltipPosition, ITooltipType, Tooltip } from 'scorer-ui-kit';
 import styled, { css } from 'styled-components';
 
@@ -22,7 +22,6 @@ const StatusDot = styled.div<{ type?: AlertType, tooltipMessage?: string }>`
 `;
 
 interface IStatusDot {
-  id: string
   type?: AlertType
   tooltipMessage?: string
   tooltipIcon?: string
@@ -36,15 +35,23 @@ interface IStatusBundle {
 
 export const StatusComponent: React.FC<IStatusBundle> = ({ statusList }) => {
 
+  const statusRefs = useRef<(React.RefObject<HTMLDivElement>)[]>([]);
+
+  React.useEffect(() => {
+    // Initialise each ref
+    statusRefs.current = statusList.map(() => React.createRef<HTMLDivElement>());
+  });
+  
+
   return (
     <StatusWrapper>
       {
-        statusList.map(({ id, type, tooltipMessage, tooltipIcon, tooltipType, tooltipPosition }) => {
+        statusList.map(({ type, tooltipMessage, tooltipIcon, tooltipType, tooltipPosition }, index) => {
           return (
-            <Fragment key={id} >
-              <StatusDot id={id} type={type} tooltipMessage={tooltipMessage} />
+            <Fragment key={index}>
+              <StatusDot ref={statusRefs.current[index]} type={type} tooltipMessage={tooltipMessage} />
               {tooltipMessage && (
-                <Tooltip tooltipFor={id} message={tooltipMessage} icon={tooltipIcon} type={tooltipType} tooltipPosition={tooltipPosition} />)
+                <Tooltip tooltipFor={statusRefs.current[index]} message={tooltipMessage} icon={tooltipIcon} type={tooltipType} tooltipPosition={tooltipPosition} />)
               }
             </Fragment>
           )

--- a/packages/example/src/pages/TablePage.tsx
+++ b/packages/example/src/pages/TablePage.tsx
@@ -93,7 +93,7 @@ const TablePage: React.FC = () => {
           { text: 'Just Now' },
           { text: '242', unit: 'mb' },
           { text: '¥20,000' },
-          { customComponent: <StatusComponent statusList={[{ id: 'device1-a', type: 'success' }, { id: 'device1-b', type: 'success' }, { id: 'device1-c', type: 'success' }]} /> },
+          { customComponent: <StatusComponent statusList={[{ type: 'success' }, { type: 'success' }, { type: 'success' }]} /> },
           { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} /> },
         ]
     },
@@ -117,9 +117,9 @@ const TablePage: React.FC = () => {
               <StatusComponent
                 statusList={
                   [
-                    { id: 'device2-a', type: 'error', tooltipIcon: 'BigWarning', tooltipType: 'warning', tooltipMessage: '4 Images have reported upload failures', tooltipPosition: 'left' },
-                    { id: 'device2-b', type: 'warning', tooltipIcon: 'Information', tooltipType: 'neutral', tooltipMessage: '1 images file is corrupted', tooltipPosition: 'bottom' },
-                    { id: 'device2-c', type: 'info', tooltipIcon: 'Information', tooltipType: 'info', tooltipMessage: 'All Images have been updated in the server', tooltipPosition: 'right' },
+                    { type: 'error', tooltipIcon: 'BigWarning', tooltipType: 'warning', tooltipMessage: '4 Images have reported upload failures', tooltipPosition: 'left' },
+                    { type: 'warning', tooltipIcon: 'Information', tooltipType: 'neutral', tooltipMessage: '1 images file is corrupted', tooltipPosition: 'bottom' },
+                    { type: 'info', tooltipIcon: 'Information', tooltipType: 'info', tooltipMessage: 'All Images have been updated in the server', tooltipPosition: 'right' },
                   ]} />
           },
           { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} /> },
@@ -138,7 +138,7 @@ const TablePage: React.FC = () => {
           { text: '22nd March 2020' },
           { text: '2.1', unit: 'tb' },
           { text: '¥7,000' },
-          { customComponent: <StatusComponent statusList={[{ id: 'device3-a', type: 'warning', tooltipIcon: 'Information', tooltipType: 'neutral', tooltipMessage: 'Upload took too long' }, { id: 'device3-b', type: 'neutral' }, { id: 'device3-c', type: 'neutral' }]} /> },
+          { customComponent: <StatusComponent statusList={[{ type: 'warning', tooltipIcon: 'Information', tooltipType: 'neutral', tooltipMessage: 'Upload took too long' }, { type: 'neutral' }, { type: 'neutral' }]} /> },
           { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} /> },
         ],
     },
@@ -155,7 +155,7 @@ const TablePage: React.FC = () => {
           { text: '2nd April 2020' },
           { text: '153', unit: 'mb' },
           { text: '¥25,000' },
-          { customComponent: <StatusComponent statusList={[{ id: 'device4-a', type: 'neutral' }, { id: 'device4-b', type: 'neutral' }, { id: 'device4-c', type: 'neutral' }]} /> },
+          { customComponent: <StatusComponent statusList={[{ type: 'neutral' }, { type: 'neutral' }, { type: 'neutral' }]} /> },
           { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} /> },
         ]
     },
@@ -167,7 +167,7 @@ const TablePage: React.FC = () => {
           { text: '16th June 2020' },
           { text: '153', unit: 'mb' },
           { text: '¥25,000' },
-          { customComponent: <StatusComponent statusList={[{ id: 'device5-a', type: 'neutral' }, { id: 'device5-b', type: 'neutral' }, { id: 'device5-c', type: 'neutral' }]} /> },
+          { customComponent: <StatusComponent statusList={[{ type: 'neutral' }, { type: 'neutral' }, { type: 'neutral' }]} /> },
           { customComponent: <SplitButton mainButtonId={'a0'} buttonList={buttonList} /> },
         ]
     },

--- a/packages/storybook/src/stories/Alerts/Tooltip.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/Tooltip.stories.tsx
@@ -1,5 +1,5 @@
 import { boolean, select, text } from "@storybook/addon-knobs";
-import React from "react";
+import React, { useRef } from "react";
 import { PageTitle, Tooltip } from "scorer-ui-kit";
 import { generateIconList } from "../helpers";
 import styled from "styled-components";
@@ -16,7 +16,7 @@ const Content = styled.div`
   margin: 20px 0;
 `;
 
-const HoverSpan = styled.div`
+const HoverSpan = styled.span`
   color: var(--primary-11);
   display: inline-block;
   &:hover {
@@ -33,31 +33,38 @@ export const _Tooltip = () => {
   const icon = select("Icon", iconList, 'Information');
   const tooltipPosition = select("Tooltip Position", { TopLeft: 'top-left', Top: 'top', TopRight: 'top-right', BottomLeft: 'bottom-left', Bottom: 'bottom', BottomRight: 'bottom-right', LeftTop: 'left-top', Left: 'left', LeftBottom: 'left-bottom', RightTop: 'right-top', Right: 'right', RightBottom: 'right-bottom' }, 'top-right')
 
+  const exampleTriggerA = useRef<HTMLSpanElement>(null);
+  const exampleTriggerB = useRef<HTMLSpanElement>(null);
+  const exampleTriggerC = useRef<HTMLSpanElement>(null);
+  const exampleTriggerD = useRef<HTMLSpanElement>(null);
+  const exampleTriggerE = useRef<HTMLSpanElement>(null);
+
+
   return (
     <Container>
       <PageTitle
         title="Page with tooltips"
       />
       <Content>
-        The tooltip is a common graphical user interface (GUI) element in which, when <HoverSpan id='hoverSpanId'>hovering over</HoverSpan> a screen element or component, a text box displays information about that element, such as a description of a button's function, what an abbreviation stands for, or the exact absolute time stamp over a relative time ("… ago"). In this paragraph the tooltip will be display in a dynamic position.
+        The tooltip is a common graphical user interface (GUI) element in which, when <HoverSpan ref={exampleTriggerA}>hovering over</HoverSpan> a screen element or component, a text box displays information about that element, such as a description of a button's function, what an abbreviation stands for, or the exact absolute time stamp over a relative time ("… ago"). In this paragraph the tooltip will be display in a dynamic position.
       </Content>
       <Content>
-        The tooltip is a common graphical user interface (GUI) element in which, when <HoverSpan id='hoverSpanId2'>hovering over</HoverSpan> a screen element or component, a text box displays information about that element, such as a description of a button's function, what an abbreviation stands for, or the exact absolute time stamp over a relative time ("… ago"). In this paragraph the tooltip will be display in a dynamic position.
+        The tooltip is a common graphical user interface (GUI) element in which, when <HoverSpan ref={exampleTriggerB}>hovering over</HoverSpan> a screen element or component, a text box displays information about that element, such as a description of a button's function, what an abbreviation stands for, or the exact absolute time stamp over a relative time ("… ago"). In this paragraph the tooltip will be display in a dynamic position.
       </Content>
       <Content>
-        The tooltip is a common graphical user interface (GUI) element in which, when <HoverSpan id='hoverSpanId3'>hovering over</HoverSpan> a screen element or component, a text box displays information about that element, such as a description of a button's function, what an abbreviation stands for, or the exact absolute time stamp over a relative time ("… ago"). In this paragraph the tooltip will be display in a dynamic position.
+        The tooltip is a common graphical user interface (GUI) element in which, when <HoverSpan ref={exampleTriggerC}>hovering over</HoverSpan> a screen element or component, a text box displays information about that element, such as a description of a button's function, what an abbreviation stands for, or the exact absolute time stamp over a relative time ("… ago"). In this paragraph the tooltip will be display in a dynamic position.
       </Content>
       <Content>
-        The tooltip is a common graphical user interface (GUI) element in which, when <HoverSpan id='hoverSpanId4'>hovering over</HoverSpan> a screen element or component, a text box displays information about that element, such as a description of a button's function, what an abbreviation stands for, or the exact absolute time stamp over a relative time ("… ago"). In this paragraph the tooltip will be display in a dynamic position.
+        The tooltip is a common graphical user interface (GUI) element in which, when <HoverSpan ref={exampleTriggerD}>hovering over</HoverSpan> a screen element or component, a text box displays information about that element, such as a description of a button's function, what an abbreviation stands for, or the exact absolute time stamp over a relative time ("… ago"). In this paragraph the tooltip will be display in a dynamic position.
       </Content>
       <Content>
-        This tooltip <HoverSpan id='spanId5'>message</HoverSpan> position is fixed,  you can update it with the property tool position with the knobs bellow .
+        This tooltip <HoverSpan ref={exampleTriggerE}>message</HoverSpan> position is fixed,  you can update it with the property tool position with the knobs bellow .
       </Content>
-      <Tooltip tooltipFor='hoverSpanId' icon={noIcon ? undefined : icon} {...{ message }} />
-      <Tooltip tooltipFor='hoverSpanId2' icon={noIcon ? undefined : icon} {...{ message }} />
-      <Tooltip tooltipFor='hoverSpanId3' icon={noIcon ? undefined : icon} {...{ message }} />
-      <Tooltip tooltipFor='hoverSpanId4' icon={noIcon ? undefined : icon} {...{ message }} />
-      <Tooltip tooltipFor='spanId5' maxWidth='200px' icon={noIcon ? undefined : icon} {...{ type, message, tooltipPosition }} />
+      <Tooltip tooltipFor={exampleTriggerA} icon={noIcon ? undefined : icon} {...{ message }} />
+      <Tooltip tooltipFor={exampleTriggerB} icon={noIcon ? undefined : icon} {...{ message }} />
+      <Tooltip tooltipFor={exampleTriggerC} icon={noIcon ? undefined : icon} {...{ message }} />
+      <Tooltip tooltipFor={exampleTriggerD} icon={noIcon ? undefined : icon} {...{ message }} />
+      <Tooltip tooltipFor={exampleTriggerE} maxWidth='200px' icon={noIcon ? undefined : icon} {...{ type, message, tooltipPosition }} />
     </Container>
   )
 }

--- a/packages/ui-lib/src/Alerts/atom/Tooltip.tsx
+++ b/packages/ui-lib/src/Alerts/atom/Tooltip.tsx
@@ -290,7 +290,7 @@ const Tooltip: React.FC<ITooltip> = ({ icon, message, type, tooltipFor, tooltipP
   }, [tooltipFor]);
 
   useEffect(() => {
-    let currentRef = null;
+    let currentRef : HTMLElement | null = null;
     
     if(tooltipFor && tooltipFor.current){
       currentRef = tooltipFor.current;

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -488,19 +488,19 @@ export const colorVariables = css`
 
         /* tooltip */
     --tooltip-warning: var(--warning-a9);
-    --tooltip-warning-arrow: var(--warning-a9);
+    --tooltip-warning-arrow: var(--warning-9);
     --tooltip-warning-border: var(--warning-a7);
 
     --tooltip-success: var(--success-9);
-    --tooltip-success-arrow: var(--success-a7);
+    --tooltip-success-arrow: var(--success-8);
     --tooltip-success-border: var(--success-a7);
 
     --tooltip-info: var(--primary-8);
-    --tooltip-info-arrow: var(--primary-a8);
-    --tooltip-info-border: var(--primary-8);
+    --tooltip-info-arrow: var(--primary-8);
+    --tooltip-info-border: var(--primary-a8);
 
     --tooltip-neutral: var(--grey-8);
-    --tooltip-neutral-arrow: var(--grey-a7);
+    --tooltip-neutral-arrow: var(--grey-7);
     --tooltip-neutral-border: var(--grey-7);
 
       /* icons */


### PR DESCRIPTION
Exploring using `ref` based component interaction in place of `id` based. This updates  the main component and the example use in both the Storybook text hover code and the Example's table's status dots.

I experience one of the things you were warning about with the use of refs in the context such as the table example. I believe the solution I came to is suitable.

If you choose not to merge this, please feel free to close it (with some attention to the below). Thank you!

---

_As it was a minor update, I've pushed a commit to the main PR for those color updates. So hopefully the changes here will merge across with no impact or can be forgotten if this is rejected._

~~There is also a color update which should be updated in the `feature/tooltips` branch, even if this PR is rejected. It's easy to update manually as it's about 6 lines changed and just the css var name. This text in the background looking like it's above the tooltip arrow.~~