### PR TITLE
Pagination activePage prop not updating value

### DIFF
--- a/packages/storybook/src/stories/Misc/molecules/Pagination.stories.tsx
+++ b/packages/storybook/src/stories/Misc/molecules/Pagination.stories.tsx
@@ -18,7 +18,7 @@ const ItemsOptions = [
 ]
 
 export const _Pagination = () => {
-  const controlledActivePage = number('Active Page', 21)
+  const controlledActivePage = number('Active Page', 1)
   const [currentPage, setCurrentPage] = useState(controlledActivePage);
   const buttonOnClick = action('Page changed');
   const itemsChange = action('Items Per Page')

--- a/packages/storybook/src/stories/Misc/molecules/Pagination.stories.tsx
+++ b/packages/storybook/src/stories/Misc/molecules/Pagination.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, number, object, text } from '@storybook/addon-knobs';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {Pagination}  from 'scorer-ui-kit';
 
 export default {
@@ -18,7 +18,8 @@ const ItemsOptions = [
 ]
 
 export const _Pagination = () => {
-  const [currentPage, setCurrentPage] = useState(1);
+  const controlledActivePage = number('Active Page', 21)
+  const [currentPage, setCurrentPage] = useState(controlledActivePage);
   const buttonOnClick = action('Page changed');
   const itemsChange = action('Items Per Page')
   const pageText = text('Page Text', 'Page:');
@@ -31,7 +32,6 @@ export const _Pagination = () => {
   const selectDisabled = boolean('Select Disabled', false)
   const itemOptionsObj = object('Items Options', ItemsOptions);
 
-
   const onPageChange = (page: number) => {
     buttonOnClick(page);
     setCurrentPage(page)
@@ -41,8 +41,13 @@ export const _Pagination = () => {
     itemsChange(items)
   }
 
+  useEffect(() => {
+    setCurrentPage(controlledActivePage);
+  },[controlledActivePage])
+
   return (
     <Pagination
+      selectId={selectId}
       pageText={pageText}
       totalPages={totalPages}
       activePage={currentPage}

--- a/packages/ui-lib/src/Misc/molecules/Pagination.tsx
+++ b/packages/ui-lib/src/Misc/molecules/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, HTMLAttributes, useCallback, useState, useRef, Fragment } from 'react';
+import React, { ChangeEvent, HTMLAttributes, useCallback, useState, useRef, Fragment, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
 import Button from '../../Form/atoms/Button';
 import Icon from '../../Icons/Icon';
@@ -145,7 +145,7 @@ export type IPagination = OwnProps & HTMLAttributes<HTMLDivElement>
 const Pagination: React.FC<IPagination> = (props) => {
   const {
     pageText = 'Page:',
-    totalPages = 199,
+    totalPages = 1,
     activePage = 1,
     buttonText = 'GO',
     itemsText = 'Items Per Page',
@@ -300,6 +300,10 @@ const Pagination: React.FC<IPagination> = (props) => {
       e.preventDefault();
     }
   };
+
+  useEffect(() => {
+    setPageValue(activePage.toString());
+  }, [activePage]);
 
   return (
     <PaginationContainer>

--- a/packages/ui-lib/src/Misc/molecules/Pagination.tsx
+++ b/packages/ui-lib/src/Misc/molecules/Pagination.tsx
@@ -159,7 +159,7 @@ const Pagination: React.FC<IPagination> = (props) => {
   } = props;
 
   const [fieldState, setFieldState] = useState<string>('default');
-  const [pageValue, setPageValue] = useState<string>(activePage.toString());
+  const [pageValue, setPageValue] = useState<string>(activePage ? activePage.toString() : '1');
   const [disableGo, setDisabledGo] = useState<boolean>(parseInt(pageValue) > totalPages && fieldState !== '' ? false : true);
   const [shouldShake, setShouldShake] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -302,8 +302,13 @@ const Pagination: React.FC<IPagination> = (props) => {
   };
 
   useEffect(() => {
+    if(!activePage || !isValidInput(activePage ? activePage.toString() : '')) {
+      console.warn('Pagination: invalid activePage prop value was sent');
+      return;
+    }
+
     setPageValue(activePage.toString());
-  }, [activePage]);
+  }, [activePage, isValidInput]);
 
   return (
     <PaginationContainer>


### PR DESCRIPTION
### Description

 This is a fix request for the Pagination Component that was not updating value from property.
 
 The specific scenario requested is:
 
 ```
Suppose if user previously choose 10 items per page, and then goes to last page and thereafter he changes page size again to 20, in that case total pages count decreases but the current selected page does not change as shown in snapshot below and its false to show such case in UI so I think activePage prop is not bind with its passed value due to which we get this situation.
 ```
 
 
  ### Considerations in the implementation
I have updated the code to update  pageValue if activePage is updated.
Page Value is an temporary state to check the validity of input of the user.
activePage is been validated under the user input standards.


 Updated default value of total pages from 199 to 1, seems like a more reasonable default value 😄 
 
 ### Reviewing/Testing steps
 
 Storybook -> Misc- > Pagination
 New ActivePage Prop has been added to Pagination Story, I didn't find a way to update this knobs variable when the user updates the value by input :/ 

However testing should be performed manually by updating TotalPages to a lower Value then sending a new value of Active Page
 
 
<img width="794" alt="Screenshot 2024-10-15 at 14 24 19" src="https://github.com/user-attachments/assets/ebc84561-c54b-4127-bb11-a87711f68ea3">


<img width="850" alt="Screenshot 2024-10-15 at 14 51 05" src="https://github.com/user-attachments/assets/328b403f-905f-4196-a637-6b4bdd28280b">

<img width="828" alt="Screenshot 2024-10-15 at 14 51 28" src="https://github.com/user-attachments/assets/ba916b06-9d7a-40fe-81a6-86987233473c">

<img width="809" alt="Screenshot 2024-10-15 at 14 51 45" src="https://github.com/user-attachments/assets/c9a7c69f-cc70-4255-a862-24192ce61d6a">
