### PR TITLE
Form component refactors

### DIFF
--- a/packages/example/src/pages/FormPage.tsx
+++ b/packages/example/src/pages/FormPage.tsx
@@ -10,13 +10,13 @@ const FormPage : React.FC = () => {
   return <Container>
     <PageHeader title={"Input State Examples"} areaTitle={'Forms'} areaHref={'/'} />
     <Form>
-      <TextField name={'my_field'} label={'Basic'} placeholder={'Placeholder...'} fieldState={ 'default' } />
-      <TextField name={'my_field'} label={'Required'} placeholder={''} fieldState={ 'required' } />
-      <TextField name={'my_field'} label={'Loading'} placeholder={''} fieldState={ 'processing' } />
-      <TextField name={'my_field'} label={'Valid'} placeholder={''} fieldState={ 'valid' } />
-      <TextField name={'my_field'} label={'Error'} placeholder={''} fieldState={ 'invalid' } />
-      <TextField name={'my_field'} label={'Error'} placeholder={''} fieldState={ 'invalid' } feedbackMessage={'Error: Oh noes!!!'}/>
-      <PasswordField name={'my_field'} label={'My Field'} placeholder={''} fieldState={ 'default' } />
+      <TextField name={'my_field'} label={'Basic'} placeholder={'Placeholder...'} fieldState={ 'default' } showFeedback={true} />
+      <TextField name={'my_field'} label={'Required'} placeholder={''} fieldState={ 'required' } showFeedback={true} />
+      <TextField name={'my_field'} label={'Loading'} placeholder={''} fieldState={ 'processing' } showFeedback={true} />
+      <TextField name={'my_field'} label={'Valid'} placeholder={''} fieldState={ 'valid' } showFeedback={true} />
+      <TextField name={'my_field'} label={'Error'} placeholder={''} fieldState={ 'invalid' } showFeedback={true} />
+      <TextField name={'my_field'} label={'Error'} placeholder={''} fieldState={ 'invalid' } showFeedback={true} feedbackMessage={'Error: Oh noes!!!'}/>
+      <PasswordField name={'my_field'} label={'My Field'} placeholder={''} fieldState={ 'default' } showFeedback={true} />
     </Form>
   </Container>
 };

--- a/packages/storybook/src/stories/Filters/molecules/FilterDropdown.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterDropdown.stories.tsx
@@ -23,9 +23,7 @@ export default {
   decorators: []
 };
 
-const Content = styled.div`
-  background-color: var(--grey-1);
-`;
+const Content = styled.div``;
 const Divider = styled.div``;
 
 const Wrapper = styled.div`

--- a/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
+++ b/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
@@ -56,7 +56,6 @@ export default {
 
 const Container = styled.div`
   margin: 20px;
-  background-color: var(--grey-1);
 `;
 
 const TypeTableWrapper = styled.div`

--- a/packages/storybook/src/stories/Form/Input/Input.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/Input.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import {  text, select } from "@storybook/addon-knobs";
+import {  text, select, boolean } from "@storybook/addon-knobs";
 import {TextField} from 'scorer-ui-kit';
 
 const Container = styled.div`
@@ -20,7 +20,8 @@ export const TextInput = () => {
   const inputFeedback = text("Input Feedback", "This is a feedback message.");
   const inputPlaceholder = text("Placeholder", "Placeholder...");
   const inputState = select("State", { Default: "default",  Disabled: 'disabled', Required: 'required',  Valid: 'valid',  Invalid: 'invalid', Processing: 'processing' }, "default");
+  const fieldRequired = boolean("Required", false);
 
   return <Container>
-    <TextField id={inputName} name={inputName} label={inputLabel} placeholder={inputPlaceholder} fieldState={inputState} feedbackMessage={inputFeedback} /></Container>;
+    <TextField id={inputName} name={inputName} label={inputLabel} placeholder={inputPlaceholder} fieldState={inputState} feedbackMessage={inputFeedback} required={fieldRequired} /></Container>;
 };

--- a/packages/storybook/src/stories/Form/Input/Input.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/Input.stories.tsx
@@ -17,11 +17,21 @@ export const TextInput = () => {
 
   const inputName = text("Input Name", "my_input");
   const inputLabel = text("Label", "My Input");
+  const showFeedback = boolean("Show Feedback", false);
   const inputFeedback = text("Input Feedback", "This is a feedback message.");
   const inputPlaceholder = text("Placeholder", "Placeholder...");
   const inputState = select("State", { Default: "default",  Disabled: 'disabled', Required: 'required',  Valid: 'valid',  Invalid: 'invalid', Processing: 'processing' }, "default");
   const fieldRequired = boolean("Required", false);
 
   return <Container>
-    <TextField id={inputName} name={inputName} label={inputLabel} placeholder={inputPlaceholder} fieldState={inputState} feedbackMessage={inputFeedback} required={fieldRequired} /></Container>;
+    <TextField 
+      id={inputName} 
+      name={inputName} 
+      label={inputLabel} 
+      placeholder={inputPlaceholder} 
+      fieldState={inputState} 
+      showFeedback={showFeedback}
+      feedbackMessage={inputFeedback} 
+      required={fieldRequired} />
+    </Container>;
 };

--- a/packages/storybook/src/stories/Form/Input/PasswordInput.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/PasswordInput.stories.tsx
@@ -20,8 +20,20 @@ export const PasswordInput = () => {
   const inputValue = text("Value", "Test");
   const inputPlaceholder = text("Placeholder", "Placeholder...");
   const fieldRequired = boolean("Required", false);
+  const showFeedback = boolean("Show Feedback", false);
+  const inputFeedback = text("Feedback", "This is a feedback message.");
   const inputState = select("State", { Default: "default",  Disabled: 'disabled', Required: 'required',  Valid: 'valid',  Invalid: 'invalid', Processing: 'processing' }, "default");
 
-  return <Container><PasswordField name={inputName} label={inputLabel} defaultValue={inputValue} placeholder={inputPlaceholder} fieldState={inputState} required={fieldRequired} /></Container>;
+  return <Container>
+    <PasswordField 
+      name={inputName} 
+      label={inputLabel} 
+      defaultValue={inputValue} 
+      placeholder={inputPlaceholder} 
+      fieldState={inputState} 
+      showFeedback={showFeedback}
+      feedbackMessage={inputFeedback}
+      required={fieldRequired} />
+  </Container>;
 
 };

--- a/packages/storybook/src/stories/Form/Input/PasswordInput.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/PasswordInput.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import {  text, select } from "@storybook/addon-knobs";
+import {  text, select, boolean } from "@storybook/addon-knobs";
 import {PasswordField} from 'scorer-ui-kit';
 
 const Container = styled.div`
@@ -19,8 +19,9 @@ export const PasswordInput = () => {
   const inputLabel = text("Label", "My Input");
   const inputValue = text("Value", "Test");
   const inputPlaceholder = text("Placeholder", "Placeholder...");
+  const fieldRequired = boolean("Required", false);
   const inputState = select("State", { Default: "default",  Disabled: 'disabled', Required: 'required',  Valid: 'valid',  Invalid: 'invalid', Processing: 'processing' }, "default");
 
-  return <Container><PasswordField name={inputName} label={inputLabel} defaultValue={inputValue} placeholder={inputPlaceholder} fieldState={inputState} /></Container>;
+  return <Container><PasswordField name={inputName} label={inputLabel} defaultValue={inputValue} placeholder={inputPlaceholder} fieldState={inputState} required={fieldRequired} /></Container>;
 
 };

--- a/packages/storybook/src/stories/Form/Input/SmallInput.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/SmallInput.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import {  text, select } from "@storybook/addon-knobs";
+import {  text, select, boolean } from "@storybook/addon-knobs";
 import {SmallInput} from 'scorer-ui-kit';
 
 export default {
@@ -21,6 +21,7 @@ export const _SmallInput = () => {
   const inputLabel = text("Label", "My Input");
   const inputUnit = text("Unit", "º");
   const inputPlaceholder = text("Placeholder", "Placeholder...");
+  const fieldRequired = boolean("Required", false);
   const inputState = select("State", { Default: "default",  Disabled: 'disabled', Required: 'required',  Valid: 'valid',  Invalid: 'invalid', Processing: 'processing' }, "default");
 
   return <Container>
@@ -32,6 +33,7 @@ export const _SmallInput = () => {
       label={inputLabel}
       placeholder={inputPlaceholder}
       fieldState={inputState}
+      required={fieldRequired}
       disabled={inputState === 'disabled'}
     />
   </Container>;

--- a/packages/storybook/src/stories/Form/Input/TextAreaField.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/TextAreaField.stories.tsx
@@ -17,6 +17,7 @@ export default {
 export const _TextAreaField = () => {
   const fieldName = text("Textarea Name", "example_texarea");
   const fieldLabel = text("Label", "Textarea Example");
+  const showFeedback = boolean("Show Feedback", false);
   const fieldFeedback = text("Feedback", "This is a feedback message.");
   const fieldPlaceholder = text("Placeholder", "Placeholder...");
   const fieldRequired = boolean("Required", false);
@@ -34,8 +35,9 @@ export const _TextAreaField = () => {
         id={fieldName}
         name={fieldName}
         label={fieldLabel}
-        placeholder = {fieldPlaceholder}
-        feedbackMessage = {fieldFeedback}
+        placeholder={fieldPlaceholder}
+        showFeedback={showFeedback}
+        feedbackMessage={fieldFeedback}
         fieldState={currentState}
         required={fieldRequired}
       ></TextAreaField>

--- a/packages/storybook/src/stories/Form/Input/TextAreaField.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/TextAreaField.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import {  text, select } from "@storybook/addon-knobs";
+import {  text, select, boolean } from "@storybook/addon-knobs";
 import { TextAreaField } from 'scorer-ui-kit';
 
 const Container = styled.div`
@@ -19,6 +19,7 @@ export const _TextAreaField = () => {
   const fieldLabel = text("Label", "Textarea Example");
   const fieldFeedback = text("Feedback", "This is a feedback message.");
   const fieldPlaceholder = text("Placeholder", "Placeholder...");
+  const fieldRequired = boolean("Required", false);
   const currentState = select("State",
     { Default: "default",
       Disabled: 'disabled',
@@ -36,6 +37,7 @@ export const _TextAreaField = () => {
         placeholder = {fieldPlaceholder}
         feedbackMessage = {fieldFeedback}
         fieldState={currentState}
+        required={fieldRequired}
       ></TextAreaField>
     </Container>
 };

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -107,6 +107,7 @@ const InputContainer = styled.div<{hasAction?: boolean}>`
 const Container = styled.div<{ fieldState: TypeFieldState }>`
   display: flex;
   position: relative;
+  flex-direction: column;
 
   ${StyledInput}{
 
@@ -115,7 +116,7 @@ const Container = styled.div<{ fieldState: TypeFieldState }>`
     }
 
     ${({fieldState}) => css`
-      ${['default', 'disabled'].indexOf(fieldState) !== -1 && css`
+      ${['default', 'disabled'].indexOf(fieldState) === -1 && css`
         border-top-right-radius: 0px;
         border-bottom-right-radius: 0px;
       `};

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -64,6 +64,7 @@ const StyledInput = styled.input<{ fieldState : TypeFieldState }>`
   ${({fieldState}) => css`
     border: 1px solid var(--input-${fieldState}-border-color);
     background: var(--input-${fieldState}-background-color);
+    box-shadow: var(--input-box-shadow-x) var(--input-box-shadow-y) var(--input-box-shadow-blur) var(--input-box-shadow-spread)  var(--input-${fieldState}-shadow-color, transparent);
   `};
 
   font-family: var(--font-data);
@@ -78,6 +79,11 @@ const StyledInput = styled.input<{ fieldState : TypeFieldState }>`
 
   color: var(--input-color-default);
   font-size: 14px;
+
+  transition: 
+    border var(--speed-fast) var(--easing-primary-out),
+    background-color var(--speed-fast) var(--easing-primary-out),
+    box-shadow var(--speed-fast) var(--easing-primary-out);
 
   &::placeholder {
     font-family: var(--font-data);
@@ -104,48 +110,45 @@ const InputContainer = styled.div<{hasAction?: boolean}>`
 
 `;
 
-const Container = styled.div<{ fieldState: TypeFieldState }>`
-  display: flex;
-  position: relative;
-  flex-direction: row;
+const Container = styled.div<{ fieldState: TypeFieldState, showFeedback?: boolean }>`
+  ${({fieldState, showFeedback}) => css`
+  
+    display: flex;
+    position: relative;
+    flex-direction: row;
 
-  ${StyledInput}{
+    ${StyledInput}{
 
-    &:disabled {
-      cursor: not-allowed;
-    }
-
-    ${({fieldState}) => css`
-      ${['default', 'disabled'].indexOf(fieldState) === -1 && css`
+      &:disabled {
+        cursor: not-allowed;
+      }
+      
+      ${['default', 'disabled'].indexOf(fieldState) === -1 && showFeedback && css`
         border-top-right-radius: 0px;
         border-bottom-right-radius: 0px;
       `};
 
-      &:focus {
-        box-shadow: 0 3px 3px 0 var(--input-${fieldState}-shadow-color);
-      }
-    `};
-  }
+    }
 
-  ${FeedbackContainer} {
-    ${({fieldState}) => css`
+    ${FeedbackContainer} {
       ${['default', 'disabled'].indexOf(fieldState) !== -1 && css`
         display: none;
       `};
       border-color: var(--input-${fieldState}-border-color);
       background: var(--input-${fieldState}-border-color);
-    `}
-  }
+    }
 
-  &:focus-within ${StyledInput} {
-    ${({fieldState}) => css`
+    &:focus-within ${StyledInput} {
       border-color: var(--input-${fieldState}-focused-border-color, var(--input-${fieldState}-border-color));
-    `}
-  }
+      box-shadow: var(--input-focused-box-shadow-x) var(--input-focused-box-shadow-y) var(--input-focused-box-shadow-blur) var(--input-focused-box-shadow-spread) var(--input-${fieldState}-focused-shadow-color);
+    }
+  `}
+
 `;
 
 interface OwnProps {
   fieldState?: TypeFieldState;
+  showFeedback?: boolean;
   feedbackMessage?: string;
   actionCallback?: ()=>void;
   actionIcon?: string
@@ -159,6 +162,7 @@ const Input : React.FC<InputProps> = ({
   placeholder = '',
   defaultValue,
   fieldState = 'default',
+  showFeedback = false,
   feedbackMessage,
   actionCallback,
   actionIcon,
@@ -186,7 +190,7 @@ const Input : React.FC<InputProps> = ({
   };
 
   return (
-    <Container fieldState={fieldState || 'default'}>
+    <Container fieldState={fieldState || 'default'} {...{showFeedback}}>
 
       <InputContainer hasAction={isActionButton}>
         <StyledInput fieldState={fieldState || 'default'} disabled={fieldState === 'disabled' || fieldState === 'processing'} type={type} placeholder={placeholder} defaultValue={defaultValue} {...props} />
@@ -199,7 +203,7 @@ const Input : React.FC<InputProps> = ({
         ) : null}
       </InputContainer>
 
-      {fieldState ? (
+      {fieldState && showFeedback ? (
         <FeedbackContainer>
           <FeedbackIcon>{feedbackIcon(fieldState)}</FeedbackIcon>
           {feedbackMessage ? (

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -107,7 +107,7 @@ const InputContainer = styled.div<{hasAction?: boolean}>`
 const Container = styled.div<{ fieldState: TypeFieldState }>`
   display: flex;
   position: relative;
-  flex-direction: column;
+  flex-direction: row;
 
   ${StyledInput}{
 

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -25,9 +25,7 @@ const FeedbackContainer = styled.div`
   flex-shrink: 0;
 
   background-color: transparent;
-  ${({theme}) => css`
-    border: 1px solid ${theme.styles.form.input.default.normal.borderColor};
-  `};
+  border: 1px solid transparent;
 
   border-left: none;
   border-radius: 0 3px 3px 0;
@@ -42,7 +40,8 @@ const FeedbackMessage = styled.div`
   flex: 0 1 400px;
   padding: 0 10px 0 0;
 
-  ${({theme}) => theme.typography.form.feedback.message};
+  font-weight: 500;
+  color: var(--white-1);
 `;
 
 const FeedbackIcon = styled.div`
@@ -54,7 +53,7 @@ const FeedbackIcon = styled.div`
 
   ${IconWrapper} {
     [stroke]{
-      stroke: ${({theme}) => theme.colors.pureBase};
+      stroke: var(--white-1);
     }
   }
 `;
@@ -62,13 +61,14 @@ const FeedbackIcon = styled.div`
 const StyledInput = styled.input<{ fieldState : TypeFieldState }>`
   ${removeAutoFillStyle};
 
-  ${({theme, fieldState}) => css`
-    min-height: ${theme.dimensions.form.input.height};
-    font-family: ${theme.fontFamily.data};
-    border: 1px solid ${theme.styles.form.input[fieldState].normal.borderColor};
+  ${({fieldState}) => css`
+    border: 1px solid var(--input-${fieldState}-border-color);
+    background: var(--input-${fieldState}-background-color);
   `};
 
-  height: 100%;
+  font-family: var(--font-data);
+
+  height: var(--input-height);
   width: 100%;
   border-radius: 3px;
 
@@ -76,12 +76,17 @@ const StyledInput = styled.input<{ fieldState : TypeFieldState }>`
   box-sizing: border-box;
   outline: none;
 
-  ${({theme: {typography}}) => css`
-    ${typography.form.input.value.normal};
-    &::placeholder {
-      ${typography.form.input.placeholder.normal};
-    }
-  `};
+  color: var(--grey-12);
+  font-family: Lato;
+  font-size: 14px;
+
+  &::placeholder {
+    font-family: var(--font-data);
+    color: var(--grey-10);
+    font-style: italic;
+    font-weight: 400;
+  }
+
 `;
 
 const InputContainer = styled.div<{hasAction?: boolean}>`
@@ -100,36 +105,42 @@ const InputContainer = styled.div<{hasAction?: boolean}>`
 
 `;
 
-const Container = styled.div<{ fieldState: string }>`
+const Container = styled.div<{ fieldState: TypeFieldState }>`
   display: flex;
   position: relative;
 
   ${StyledInput}{
-    ${({theme, fieldState}) => theme.styles.form.input[fieldState].normal};
-
-    &:focus {}
 
     &:disabled {
       cursor: not-allowed;
     }
 
-    ${({ fieldState }) => ['default', 'disabled'].indexOf(fieldState) === -1 && css`
-      border-top-right-radius: 0px;
-      border-bottom-right-radius: 0px;
-    `}
+    ${({fieldState}) => css`
+      ${['default', 'disabled'].indexOf(fieldState) !== -1 && css`
+        border-top-right-radius: 0px;
+        border-bottom-right-radius: 0px;
+      `};
+
+      &:focus {
+        box-shadow: 0 3px 3px 0 var(--input-${fieldState}-shadow-color);
+      }
+    `};
   }
 
   ${FeedbackContainer} {
-    background: ${({theme, fieldState}) => theme.styles.form.input[fieldState].normal.borderColor};
-    border-color: ${({theme, fieldState}) => theme.styles.form.input[fieldState].normal.borderColor};
-
-    ${({ fieldState }) => ['default', 'disabled'].indexOf(fieldState) !== -1 && css`
-      display:none;
+    ${({fieldState}) => css`
+      ${['default', 'disabled'].indexOf(fieldState) !== -1 && css`
+        display: none;
+      `};
+      border-color: var(--input-${fieldState}-border-color);
+      background: var(--input-${fieldState}-border-color);
     `}
   }
 
   &:focus-within ${StyledInput} {
-    ${({theme, fieldState}) => theme.styles.form.input[fieldState].focused};
+    ${({fieldState}) => css`
+      border-color: var(--input-${fieldState}-focused-border-color, var(--input-${fieldState}-border-color));
+    `}
   }
 `;
 
@@ -164,11 +175,11 @@ const Input : React.FC<InputProps> = ({
       case 'disabled':
         break;
       case 'required':
-        return <Icon icon='Required' size={20} />;
+        return <Icon icon='Required' size={16} />;
       case 'valid':
-        return <Icon icon='Success' size={20} />;
+        return <Icon icon='Success' size={16} />;
       case 'invalid':
-        return <Icon icon='Invalid' size={20} />;
+        return <Icon icon='Invalid' size={16} />;
       case 'processing':
         return <Spinner size='medium' styling='primary' />;
     }

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -76,13 +76,12 @@ const StyledInput = styled.input<{ fieldState : TypeFieldState }>`
   box-sizing: border-box;
   outline: none;
 
-  color: var(--grey-12);
-  font-family: Lato;
+  color: var(--input-color-default);
   font-size: 14px;
 
   &::placeholder {
     font-family: var(--font-data);
-    color: var(--grey-10);
+    color: var(--input-color-placeholder);
     font-style: italic;
     font-weight: 400;
   }

--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -44,7 +44,6 @@ const LabelText = styled.span<{ rightAlign: boolean, required?: boolean }>`
       width: 8px;
       background-color: var(--primary-9);
       border-radius: 4px;
-      /* margin-left: 8px; */
     }
   `}
 `;

--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -1,5 +1,5 @@
 import React, { LabelHTMLAttributes } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const StyledLabel = styled.label<{ rightAlign: boolean }>`
   font-family: ${({ theme }) => theme.fontFamily.ui};
@@ -21,8 +21,12 @@ export const StyledLabel = styled.label<{ rightAlign: boolean }>`
   };
 `;
 
-const LabelText = styled.span<{ rightAlign: boolean }>`
-  display: block;
+const LabelText = styled.span<{ rightAlign: boolean, required?: boolean }>`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+
+
   ${({ rightAlign }) => rightAlign
       ? `
         margin-left: 12px;
@@ -31,12 +35,25 @@ const LabelText = styled.span<{ rightAlign: boolean }>`
         margin-bottom: 10px;
       `
   }
+
+  ${({required}) => required && css`
+    &::after {
+      content: '';
+      display: var(--input-required-dot-display);
+      height: 8px;
+      width: 8px;
+      background-color: var(--primary-9);
+      border-radius: 4px;
+      /* margin-left: 8px; */
+    }
+  `}
 `;
 
 interface OwnProps {
   htmlFor: string
   labelText: string
   rightAlign?: boolean
+  required?: boolean
 }
 type Props = OwnProps & LabelHTMLAttributes<HTMLLabelElement>
 
@@ -44,12 +61,13 @@ const Label: React.FC<Props> = ({
   htmlFor,
   labelText,
   rightAlign = false,
+  required = false,
   children,
   ...props }) => {
 
   return (
     <StyledLabel {...{ htmlFor, rightAlign }} {...props}>
-      <LabelText {...{ rightAlign }}>{labelText}</LabelText>
+      <LabelText {...{ rightAlign, required }}>{labelText}</LabelText>
       {children}
     </StyledLabel>
   );

--- a/packages/ui-lib/src/Form/atoms/SmallInput.tsx
+++ b/packages/ui-lib/src/Form/atoms/SmallInput.tsx
@@ -92,6 +92,7 @@ const SmallInput : React.FC<Props> = ({
   placeholder = '',
   defaultValue,
   fieldState = 'default',
+  required = false,
   className,
   ...props
 }) => {
@@ -100,7 +101,7 @@ const SmallInput : React.FC<Props> = ({
 
   return (
     <Container className={className} fieldState={fieldState || 'default'}>
-      <Label labelText={label} htmlFor={name || ''}>
+      <Label labelText={label} htmlFor={name || ''} {...{required}}>
         <InputContainer fieldState={fieldState || 'default'}>
           <StyledInput fieldState={fieldState || 'default'} type={type} placeholder={placeholder} defaultValue={defaultValue} {...props} />
           {unit ? <UnitKey>{unit}</UnitKey> : null}

--- a/packages/ui-lib/src/Form/atoms/SmallInput.tsx
+++ b/packages/ui-lib/src/Form/atoms/SmallInput.tsx
@@ -41,8 +41,8 @@ const InputContainer = styled.div<{fieldState : TypeFieldState, hasAction?: bool
   border-radius: 3px;
   
   ${({fieldState}) => css`
-    border: 1px solid var(--input-border-${fieldState});
-    background: var(--input-background-${fieldState});
+    border: 1px solid var(--input-${fieldState}-border-color);
+    background: var(--input-${fieldState}-background-color);
     transition: 
       border var(--speed-normal) var(--easing-primary-out),
       background-color var(--speed-normal) var(--easing-primary-out);
@@ -63,17 +63,19 @@ const UnitKey = styled.div`
   flex: 0 1;
   font-size: 12px;
   font-family: var(--font-ui);
-  line-height: var(--common-height);
   color: var(--input-color-unit);
+  margin-top: 1px;
 `;
 
 const Container = styled.div<{ fieldState: string }>`
   position: relative;
-
-  &:focus-within ${InputContainer} {
-    transition: boxShadow var(--speed-fast) var(--easing-primary-in-out);
-    box-shadow: 0 3px 3px var(--input-focused-shadow-color);
-  }
+  
+  ${({fieldState}) => fieldState && css`
+    &:focus-within ${InputContainer} {
+      transition: boxShadow var(--speed-fast) var(--easing-primary-in-out);
+      box-shadow: 0 3px 3px var(--input-${fieldState}-focused-shadow-color, var(--input-${fieldState}-shadow-color));
+    }
+  `};
 `;
 
 interface OwnProps {

--- a/packages/ui-lib/src/Form/atoms/TextArea.tsx
+++ b/packages/ui-lib/src/Form/atoms/TextArea.tsx
@@ -19,6 +19,7 @@ const StyledTextArea = styled.textarea<{ fieldState : TypeFieldState}>`
     font-family: var(--font-data);
     border: 1px solid var(--input-${fieldState}-border-color);
     background: var(--input-${fieldState}-background-color);
+    box-shadow: var(--input-box-shadow-x) var(--input-box-shadow-y) var(--input-box-shadow-blur) var(--input-box-shadow-spread)  var(--input-${fieldState}-shadow-color, transparent);
   `};
 
   padding: 8px 15px;
@@ -28,9 +29,15 @@ const StyledTextArea = styled.textarea<{ fieldState : TypeFieldState}>`
   width: 100%;
   border-radius: 3px;
 
+
   color: var(--input-color-default);
   font-size: 14px;
   
+  transition: 
+    border var(--speed-fast) var(--easing-primary-out),
+    background-color var(--speed-fast) var(--easing-primary-out),
+    box-shadow var(--speed-fast) var(--easing-primary-out);
+
   &::placeholder {
     font-family: var(--font-data);
     color: var(--input-color-placeholder);
@@ -62,28 +69,24 @@ const FeedbackMessage = styled.div`
   color: var(--white-1);
 `;
 
-const Container =  styled.div<{ fieldState: string }>`
-  ${({fieldState}) => css`      
+const Container =  styled.div<{ fieldState: string, showFeedback?: boolean }>`
+  ${({fieldState, showFeedback}) => css`      
     display: flex;
     position: relative;
     flex-direction: column;
 
     ${StyledTextArea}{
-      ${['default', 'disabled'].indexOf(fieldState) === -1 && css`
+      ${['default', 'disabled'].indexOf(fieldState) === -1 && showFeedback && css`
         border-bottom-left-radius: 0px;
         border-bottom-right-radius: 0px;
       `};
-
-      &:focus {
-        box-shadow: 0px 3px 7px 0px var(--primary-a3);
-      }
       
       &:disabled {
         cursor: not-allowed;
       }
       
       &:focus {
-        box-shadow: 0 3px 3px 0 var(--input-${fieldState}-focused-shadow-color);
+        box-shadow: var(--input-focused-box-shadow-x) var(--input-focused-box-shadow-y) var(--input-focused-box-shadow-blur) var(--input-focused-box-shadow-spread) var(--input-${fieldState}-focused-shadow-color);
       }
     }
 
@@ -105,6 +108,7 @@ const Container =  styled.div<{ fieldState: string }>`
 
 interface OwnProps {
   fieldState: TypeFieldState
+  showFeedback?: boolean
   feedbackMessage?: string
 }
 
@@ -113,6 +117,7 @@ type Props = OwnProps & TextareaHTMLAttributes<HTMLTextAreaElement>
 const TextArea : React.FC<Props> = ({
   placeholder = '',
   fieldState = 'default',
+  showFeedback = false,
   feedbackMessage,
   children,
   ...props
@@ -136,7 +141,7 @@ const TextArea : React.FC<Props> = ({
   };
 
   return (
-    <Container fieldState={fieldState || 'default'}>
+    <Container fieldState={fieldState || 'default'} {...{showFeedback}}>
       <StyledTextArea
         fieldState={fieldState || 'default'}
         placeholder={placeholder}
@@ -144,7 +149,7 @@ const TextArea : React.FC<Props> = ({
         {...props}
       >{children}
       </StyledTextArea>
-      {fieldState && (
+      {showFeedback && fieldState && (
         <FeedbackContainer>
           <FeedbackIcon>{feedbackIcon(fieldState)}</FeedbackIcon>
           <FeedbackMessage>{feedbackMessage}</FeedbackMessage>

--- a/packages/ui-lib/src/Form/atoms/TextArea.tsx
+++ b/packages/ui-lib/src/Form/atoms/TextArea.tsx
@@ -15,10 +15,11 @@ const FeedbackIcon = styled.div`
 
 const StyledTextArea = styled.textarea<{ fieldState : TypeFieldState}>`
 
-${({theme, fieldState}) => css`
-  font-family: ${theme.fontFamily.data};
-  border: 1px solid ${theme.styles.form.input[fieldState].normal.borderColor};
-`};
+  ${({fieldState}) => css`
+    font-family: var(--font-data);
+    border: 1px solid var(--input-${fieldState}-border-color);
+    background: var(--input-${fieldState}-background-color);
+  `};
 
   padding: 8px 15px;
   box-sizing: border-box;
@@ -27,21 +28,23 @@ ${({theme, fieldState}) => css`
   width: 100%;
   border-radius: 3px;
 
-  ${({theme: {typography}}) => css`
-  ${typography.form.input.value.normal};
+  color: var(--input-color-default);
+  font-size: 14px;
+  
   &::placeholder {
-    ${typography.form.input.placeholder.normal};
+    font-family: var(--font-data);
+    color: var(--input-color-placeholder);
+    font-style: italic;
+    font-weight: 400;
   }
-`};
+
 `;
 
 const FeedbackContainer = styled.div`
   flex-shrink: 0;
   padding: 8px 0;
   background-color: transparent;
-  ${({theme}) => css`
-    border: 1px solid ${theme.styles.form.input.default.normal.borderColor};
-  `};
+  border: 1px solid transparent;
 
   border-left: none;
   border-radius: 0 0 3px 3px;
@@ -55,55 +58,49 @@ const FeedbackContainer = styled.div`
 const FeedbackMessage = styled.div`
   flex: 0 1 400px;
   padding: 0 10px 0 0;
-  ${({theme}) => theme.typography.form.feedback.message};
+  font-weight: 500;
+  color: var(--white-1);
 `;
 
 const Container =  styled.div<{ fieldState: string }>`
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  ${StyledTextArea}{
-    ${({theme, fieldState}) => theme.styles.form.input[fieldState].normal};
+  ${({fieldState}) => css`      
+    display: flex;
+    position: relative;
+    flex-direction: column;
 
-    &:focus {
-      box-shadow: 0px 3px 7px 0px var(--primary-a3);
+    ${StyledTextArea}{
+      ${['default', 'disabled'].indexOf(fieldState) === -1 && css`
+        border-bottom-left-radius: 0px;
+        border-bottom-right-radius: 0px;
+      `};
+
+      &:focus {
+        box-shadow: 0px 3px 7px 0px var(--primary-a3);
+      }
+      
+      &:disabled {
+        cursor: not-allowed;
+      }
+      
+      &:focus {
+        box-shadow: 0 3px 3px 0 var(--input-${fieldState}-focused-shadow-color);
+      }
     }
 
-    &:disabled {
-      cursor: not-allowed;
+    ${FeedbackContainer} {
+      border-color: var(--input-${fieldState}-border-color);
+      background: var(--input-${fieldState}-border-color);
+
+      ${['default', 'disabled'].indexOf(fieldState) !== -1 && css`
+        display:none;
+      `}
     }
 
-    ${({ fieldState }) => ['default', 'disabled'].indexOf(fieldState) === -1 && css`
-      border-bottom-left-radius: 0px;
-      border-bottom-right-radius: 0px;
-    `}
-  }
+    &:focus-within ${FeedbackContainer} {
+      border-color: var(--input-${fieldState}-focused-border-color, var(--input-${fieldState}-border-color));
+    }
 
-  ${FeedbackContainer} {
-    background: ${({theme, fieldState}) => theme.styles.form.input[fieldState].normal.borderColor};
-    border-color: ${({theme, fieldState}) => theme.styles.form.input[fieldState].normal.borderColor};
-
-    ${({ fieldState }) => ['default', 'disabled'].indexOf(fieldState) !== -1 && css`
-      display:none;
-    `}
-  }
-
-  &:focus-within ${FeedbackContainer} {
-    ${({ fieldState }) =>
-
-    fieldState === 'required' ? `
-      box-shadow: 0px 3px 7px 0px var(--primary-a3);
-    ` : null};
-
-    ${({ fieldState }) => fieldState === 'valid' ? `
-      box-shadow: 0px 3px 5px 0px var(--success-a3);
-    ` : null};
-
-    ${({ fieldState }) => fieldState === 'invalid' ? `
-      box-shadow: 0px 3px 7px 0px var(--warning-a3);
-    ` : null};
-  }
-
+  `};
 `;
 
 interface OwnProps {

--- a/packages/ui-lib/src/Form/molecules/PasswordField.tsx
+++ b/packages/ui-lib/src/Form/molecules/PasswordField.tsx
@@ -4,9 +4,10 @@ import Label from '../atoms/Label';
 import { TypeFieldState } from '..';
 
 interface OwnProps {
-  name: string;
+  name: string
   label: string
   fieldState: TypeFieldState
+  showFeedback?: boolean
   feedbackMessage?: string
 }
 type Props = OwnProps & InputHTMLAttributes<HTMLInputElement>

--- a/packages/ui-lib/src/Form/molecules/PasswordField.tsx
+++ b/packages/ui-lib/src/Form/molecules/PasswordField.tsx
@@ -12,7 +12,7 @@ interface OwnProps {
 type Props = OwnProps & InputHTMLAttributes<HTMLInputElement>
 
 
-const PasswordField : React.FC<Props> = ({ name, label, fieldState, feedbackMessage, ...props}) => {
+const PasswordField : React.FC<Props> = ({ name, label, fieldState, feedbackMessage, required, ...props}) => {
 
   const [ showValue, setShowValue ] = useState<boolean>(false);
   const [ actionIcon, setActionIcon ] = useState<string>('PasswordHide');
@@ -26,8 +26,8 @@ const PasswordField : React.FC<Props> = ({ name, label, fieldState, feedbackMess
   };
 
   return (
-    <Label htmlFor={name} labelText={label}>
-      <Input type={showValue ? 'text' : 'password'} actionCallback={actionCallback} actionIcon={actionIcon} {...{ name, fieldState, feedbackMessage, ...props}} />
+    <Label htmlFor={name} labelText={label} {...{required}}>
+      <Input type={showValue ? 'text' : 'password'} actionCallback={actionCallback} actionIcon={actionIcon} {...{ name, fieldState, feedbackMessage, required, ...props}} />
     </Label>)
   ;
 

--- a/packages/ui-lib/src/Form/molecules/TextAreaField.tsx
+++ b/packages/ui-lib/src/Form/molecules/TextAreaField.tsx
@@ -17,12 +17,13 @@ const TextAreaField : React.FC<Props> = ({
   label,
   fieldState='default',
   feedbackMessage,
+  required = false,
   children,
   ...props
 }) => {
   return(
-    <Label htmlFor={name} labelText={label}>
-      <TextArea {...{ fieldState, feedbackMessage, name, ...props }} />
+    <Label htmlFor={name} labelText={label} {...{required}}>
+      <TextArea {...{ fieldState, feedbackMessage, name, required, ...props }} />
     </Label>
   );
 };

--- a/packages/ui-lib/src/Form/molecules/TextAreaField.tsx
+++ b/packages/ui-lib/src/Form/molecules/TextAreaField.tsx
@@ -7,6 +7,7 @@ interface OwnProps {
   name: string
   label: string
   fieldState: TypeFieldState
+  showFeedback?: boolean
   feedbackMessage?: string
 }
 

--- a/packages/ui-lib/src/Form/molecules/TextField.tsx
+++ b/packages/ui-lib/src/Form/molecules/TextField.tsx
@@ -7,6 +7,7 @@ interface OwnProps {
   name: string
   label: string
   fieldState: TypeFieldState
+  showFeedback?: boolean
   feedbackMessage?: string
 }
 

--- a/packages/ui-lib/src/Form/molecules/TextField.tsx
+++ b/packages/ui-lib/src/Form/molecules/TextField.tsx
@@ -13,10 +13,10 @@ interface OwnProps {
 type Props = OwnProps & InputProps
 
 
-const TextField : React.FC<Props> = ({ name, label, fieldState='default', feedbackMessage, type:_type , ...props }) => {
+const TextField : React.FC<Props> = ({ name, label, fieldState='default', feedbackMessage, required, type:_type , ...props }) => {
   return (
-    <Label htmlFor={name} labelText={label}>
-      <Input type='text' {...{fieldState, feedbackMessage, name, ...props }} />
+    <Label htmlFor={name} labelText={label} {...{required}}>
+      <Input type='text' {...{fieldState, feedbackMessage, required, name, ...props }} />
     </Label>
   );
 };

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -36,6 +36,16 @@ const ThemeVariables = createGlobalStyle`
     --button-icon-size: 14px;
     --button-icon-h-padding: 8px;
 
+    --input-box-shadow-x: 0;
+    --input-box-shadow-y: 0;
+    --input-box-shadow-blur: 0;
+    --input-box-shadow-spread: 0;
+
+    --input-focused-box-shadow-x: 0;
+    --input-focused-box-shadow-y: 3px;
+    --input-focused-box-shadow-blur: 3px;
+    --input-focused-box-shadow-spread: 0;
+
   }
 
   .button-size-xsmall {

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -23,6 +23,7 @@ const ThemeVariables = createGlobalStyle`
     --global-menu-width-open: 280px;
 
     --input-height: 40px;
+    --input-required-dot-display: inline-block;
 
     --button-font-size: 14px;
     --button-height: 32px;

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -562,35 +562,16 @@ export const colorVariables = css`
     --global-menu-icon-background-active: var(--primary-9);
 
     /* Inputs */
-    --input-border-default: var(--grey-6);
-    --input-border-default-focused: var(--grey-8);
-    --input-border-disabled: var(--grey-6);
-    --input-border-required: var(--primary-6);
-    --input-border-valid: var(--success-9);
-    --input-border-invalid: var(--warning-9);
-    --input-border-processing: var(--primary-10);
-
-    --input-background-default: var(--grey-1);
-    --input-background-disabled: var(--grey-3);
-    --input-background-required: var(--primary-1);
-    --input-background-valid: var(--success-1);
-    --input-background-invalid: var(--warning-1);
-    --input-background-processing: var(--primary-2);
-
     --input-color-default: var(--grey-12);
     --input-color-disabled: var(--grey-10);
     --input-color-placeholder: var(--grey-10);
     --input-color-unit: var(--grey-10);
-
-    --input-focused-shadow-color: var(--black-a5);
     
     --input-selection-control-default: var(--grey-8);
     --input-selection-control-default-disabled: var(--grey-6);
     --input-selection-control-selected: var(--primary-9);
     --input-selection-control-selected-disabled: var(--primary-8);
     
-    
-    // New ones
     --input-default-background-color: var(--grey-1);
     --input-default-border-color: var(--grey-6);
     /* --input-default-shadow-color: var(--grey-3); */

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -574,7 +574,7 @@ export const colorVariables = css`
     
     --input-default-background-color: var(--grey-1);
     --input-default-border-color: var(--grey-6);
-    /* --input-default-shadow-color: var(--grey-3); */
+    --input-default-shadow-color: transparent;
 
     --input-default-focused-background-color: var(--grey-1);
     --input-default-focused-border-color: var(--grey-6);
@@ -582,11 +582,11 @@ export const colorVariables = css`
 
     --input-disabled-background-color: var(--grey-3);
     --input-disabled-border-color: var(--grey-6);
-    /* --input-disabled-shadow-color: var(--grey-3); */
+    --input-disabled-shadow-color: transparent;
 
     --input-required-background-color: var(--grey-1);
     --input-required-border-color: var(--primary-6);
-    /* --input-required-shadow-color: var(--grey-3); */
+    --input-required-shadow-color: transparent;
 
     --input-required-focused-background-color: var(--grey-1);
     --input-required-focused-border-color: var(--primary-6);
@@ -594,7 +594,7 @@ export const colorVariables = css`
 
     --input-valid-background-color: var(--grey-1);
     --input-valid-border-color: var(--success-9);
-    /* --input-valid-shadow-color: var(--grey-3); */
+    --input-valid-shadow-color: transparent;
 
     --input-valid-focused-background-color: var(--grey-1);
     --input-valid-focused-border-color: var(--success-9);
@@ -602,7 +602,7 @@ export const colorVariables = css`
 
     --input-invalid-background-color: var(--grey-1);
     --input-invalid-border-color: var(--warning-9);
-    /* --input-invalid-shadow-color: var(--grey-3); */
+    --input-invalid-shadow-color: transparent;
 
     --input-invalid-focused-background-color: var(--grey-1);
     --input-invalid-focused-border-color: var(--warning-9);
@@ -610,7 +610,7 @@ export const colorVariables = css`
 
     --input-processing-background-color: var(--grey-3)2;
     --input-processing-border-color: var(--primary-10);
-    /* --input-processing-shadow-color: var(--grey-3); */
+    --input-processing-shadow-color: transparent;
 
     --input-processing-focused-background-color: var(--grey-2);
     --input-processing-focused-border-color: var(--primary-10);

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -588,6 +588,52 @@ export const colorVariables = css`
     --input-selection-control-default-disabled: var(--grey-6);
     --input-selection-control-selected: var(--primary-9);
     --input-selection-control-selected-disabled: var(--primary-8);
+    
+    
+    // New ones
+    --input-default-background-color: var(--grey-1);
+    --input-default-border-color: var(--grey-6);
+    /* --input-default-shadow-color: var(--grey-3); */
+
+    --input-default-focused-background-color: var(--grey-1);
+    --input-default-focused-border-color: var(--grey-6);
+    --input-default-focused-shadow-color: var(--grey-3);
+
+    --input-disabled-background-color: var(--grey-3);
+    --input-disabled-border-color: var(--grey-6);
+    /* --input-disabled-shadow-color: var(--grey-3); */
+
+    --input-required-background-color: var(--grey-1);
+    --input-required-border-color: var(--primary-6);
+    /* --input-required-shadow-color: var(--grey-3); */
+
+    --input-required-focused-background-color: var(--grey-1);
+    --input-required-focused-border-color: var(--primary-6);
+    --input-required-focused-shadow-color: var(--grey-3);
+
+    --input-valid-background-color: var(--grey-1);
+    --input-valid-border-color: var(--success-9);
+    /* --input-valid-shadow-color: var(--grey-3); */
+
+    --input-valid-focused-background-color: var(--grey-1);
+    --input-valid-focused-border-color: var(--success-9);
+    --input-valid-focused-shadow-color: var(--grey-3);
+
+    --input-invalid-background-color: var(--grey-1);
+    --input-invalid-border-color: var(--warning-9);
+    /* --input-invalid-shadow-color: var(--grey-3); */
+
+    --input-invalid-focused-background-color: var(--grey-1);
+    --input-invalid-focused-border-color: var(--warning-9);
+    --input-invalid-focused-shadow-color: var(--grey-3);
+
+    --input-processing-background-color: var(--grey-3)2;
+    --input-processing-border-color: var(--primary-10);
+    /* --input-processing-shadow-color: var(--grey-3); */
+
+    --input-processing-focused-background-color: var(--grey-2);
+    --input-processing-focused-border-color: var(--primary-10);
+    --input-processing-focused-shadow-color: var(--grey-3);
 
   }
 


### PR DESCRIPTION
## Updates
This PR contains two main changes:
1. Refactor inputs to match designs and use the new CSS variables.
2. Introduced a new blue dot 🔵 next to field labels to signify they are required fields.

This refactors some the common form fields that have had design tweaks and seeks to replace legacy theming with the new CSS variables.

### 1. Input Refactors and Prop Improvements
This is similar to previous refactors. It updates sizes and colors, introducing the usage of new CSS variables and removing the old theme integrations.

`Input`, `InputField`, `TextArea`, `TextAreaField` and `PasswordField` have a new `showFeedback?: boolean` prop which if not set will default to `false`. This is because the feedback messages are no often used in designs however this feature is planned to be iterated, in which case the new feature will use the same props. Even in this instance we want to retain more control over when these are shown.

This also allows us to properly utilise these input states without having the feedback area appear incorrectly.

**Action when updating to this version of the UI Kit:** If your project uses any of the mentioned components and those instances have `feedbackMessage` in use you need to add the `showFeedback={true}` as a prop to once more recreate the previous behaviour.

### 2. Required - Blue Dot 🔵
This pattern has been used on some more recent designs and will begin to appear with more regularity moving forward. It looks like this...
![image](https://github.com/user-attachments/assets/c0b24e3c-251e-4253-a4b1-c0575647d507)

- Label has a blue dot that will show if passed a `required` prop. The various `xxField` components and stories have been updated with this. If any of these appear to be missing, please report it as a bug.
- If a project does not use the blue dot for required fields but required is used as a prop, you can override the CSS variable `--input-required-dot-display` to be `none` instead. This can be done globally or on a component level. See examples for CSS overrides.
- Please note: This `required` field is different to the `required` value in the componets `fieldState` prop. This new `required` prop signifies that the field is required where as the `fieldState='required'` is used when the form has been submitted but the field was left empty.

### Additional Change Notes
- Stories that had backgrounds added and awkward borders as a result have been removed. All stories already used the correct background.