### PR TITLE
Added Filename and a home button to examples

### DIFF
--- a/packages/example/src/components/ExamplesFilename.tsx
+++ b/packages/example/src/components/ExamplesFilename.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import styled from 'styled-components';
+import {Link} from 'react-router-dom';
+import { Icon } from 'scorer-ui-kit';
+
+export const FilenameTag = styled.div`
+  display: inline-block;
+  padding: 0 4px;
+  margin-top: 12px;
+  border-radius: 3px;
+  font-family: "Courier", sans-serif;
+  font-weight: 300;
+  font-size: 12px;
+  color: var(--white);
+  background: var(--primary-a9);
+  border: 1px solid var(--primary-10);
+  font-weight: 400;
+`;
+
+const Container = styled.div`
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 16px;
+  z-index: 100;
+  
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  gap: 0px;
+
+  background-color: var(--grey-3);
+  border-color: 1px solid var(--grey-a6);
+  padding: 4px 4px;
+  border-radius: 4px;
+  
+  ${FilenameTag}{
+    margin: 0;
+  }
+`;
+
+const BackButton = styled.div`
+  flex: 1;
+  
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
+  padding: 0 4px;
+
+  a {
+    text-decoration: none;
+    height: 16px;
+    width: 16px;
+    line-height: 16px;
+    border-radius: 3px;
+    color: var(--grey-10);
+    svg {
+      path {
+        stroke: var(--grey-10);
+      }
+    }
+
+    &:hover {
+      svg {
+        path {
+          stroke: var(--primary-9);
+        }
+      }
+    }
+  }
+`;
+
+const ExamplesFilename : React.FC = ({ children }) => {
+ return(
+  <Container>
+    <BackButton>
+      <Link to={'/'}><Icon size={12} icon='Home' /></Link>
+    </BackButton>
+    <FilenameTag>{ children }</FilenameTag>
+  </Container>
+ ); 
+};
+
+export default ExamplesFilename;

--- a/packages/example/src/pages/CustomAlertsPage.tsx
+++ b/packages/example/src/pages/CustomAlertsPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AlertBar } from 'scorer-ui-kit';
 import styled from 'styled-components';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const Container = styled.div`
   margin: 10px;
@@ -21,7 +22,9 @@ const CustomAlertWrapper = styled.div`
 const CustomAlertsPage = () => {
   return(
     <Container>
-      <h3> Default Based Colors</h3>
+      <ExamplesFilename>CustomAlertsPage.tsx</ExamplesFilename>
+
+      <h3>Default Based Colors</h3>
       <AlertBar message='Base color error message' type='error' hideCloseButton></AlertBar>
       <AlertBar message='Base color info message' type='info' hideCloseButton></AlertBar>
 

--- a/packages/example/src/pages/CustomUserDrawerPage.tsx
+++ b/packages/example/src/pages/CustomUserDrawerPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { TopBar } from 'scorer-ui-kit';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 
 const Container = styled.div`
@@ -55,7 +56,10 @@ const CustomUserDrawerPage : React.FC = () => {
 
   // userDrawerBespoke: See examples for implementation of this prop.
 
-  return <Container><TopBar {...{userDrawerBespoke, loggedInUser, userSubmenu, hasSearch, useNotifications, logoutLink, searchPlaceholder, hasLanguage}}/></Container>;
+  return <Container>
+    <ExamplesFilename>CustomUserDrawerPage.tsx</ExamplesFilename>
+    <TopBar {...{userDrawerBespoke, loggedInUser, userSubmenu, hasSearch, useNotifications, logoutLink, searchPlaceholder, hasLanguage}}/>
+  </Container>;
 };
 
 export default CustomUserDrawerPage;

--- a/packages/example/src/pages/FormPage.tsx
+++ b/packages/example/src/pages/FormPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Form, TextField, PasswordField, PageHeader } from 'scorer-ui-kit';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const Container = styled.div`
     margin: 100px 200px;
@@ -8,6 +9,7 @@ const Container = styled.div`
 
 const FormPage : React.FC = () => {
   return <Container>
+    <ExamplesFilename>FormPage.tsx</ExamplesFilename>
     <PageHeader title={"Input State Examples"} areaTitle={'Forms'} areaHref={'/'} />
     <Form>
       <TextField name={'my_field'} label={'Basic'} placeholder={'Placeholder...'} fieldState={ 'default' } />

--- a/packages/example/src/pages/GlobalUIPage.tsx
+++ b/packages/example/src/pages/GlobalUIPage.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { ThemeProvider } from 'styled-components';
 import { GlobalUI, defaultTheme, PageHeader, useThemeToggle, ButtonsStack, IButtonStack } from "scorer-ui-kit";
 import styled from "styled-components";
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const ExampleContentBlock = styled.div`
   h2 {
@@ -32,6 +33,8 @@ const GlobalUIPage: FC = () => {
 
   return (
       <ThemeProvider theme={defaultTheme}>
+        <ExamplesFilename>GlobalUIPage.tsx</ExamplesFilename>
+        
         <GlobalUI
           accountOptionText="Account Options"
           canAlwaysPin

--- a/packages/example/src/pages/Index.tsx
+++ b/packages/example/src/pages/Index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import {Link} from 'react-router-dom';
+import { FilenameTag } from '../components/ExamplesFilename';
+
 const Container = styled.div`
   margin: 0 auto;
   padding: 100px 100px;
@@ -74,6 +76,7 @@ const Description = styled.div`
   color: var(--grey-11);
 `;
 
+
 const LinksPage : React.FC = () => {
   return <Container>
     <Header>SCORER UI Kit</Header>
@@ -97,82 +100,87 @@ const LinksPage : React.FC = () => {
       <Subheader>Examples</Subheader>
       <List>
         <Item>
-          <Link to='/globalUI'>
-            <Title>Global UI</Title>
-            <Description>A full global UI example.</Description>
-          </Link>
-        </Item>
-        <Item>
           <Link to='/layouts'>
-            <Title>Layout</Title>
+            <Title>Global UI - Layout</Title>
             <Description>A basic implementation example of the page Layout component.</Description>
+            <FilenameTag>Layouts.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to='/split-layouts'>
             <Title>Split Layout</Title>
             <Description>A page layout with the drag-to-resize layout component.</Description>
+            <FilenameTag>SplitLayout.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/customdrawer`}>
             <Title>Custom User Drawer</Title>
             <Description>Shows how to add custom injected section to the user drawer.</Description>
+            <FilenameTag>CustomUserDrawerPage.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/tabs`}>
             <Title>Tabs Example</Title>
             <Description>A simple implementation of tabs.</Description>
+            <FilenameTag>TabsPage.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/table`}>
             <Title>Table Example</Title>
             <Description>A TypeTable implementation with examples on setup and how to use selections.</Description>
+            <FilenameTag>TablePage.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/line`}>
             <Title>Line</Title>
             <Description>The line tool used commonly for setting up of areas of interest used in system configurations.</Description>
+            <FilenameTag>LinePage.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/linertc`}>
             <Title>Line WebRTC</Title>
             <Description>A variation of the Line tool using a WebRTC video background instead of a static image.</Description>
-
+            <FilenameTag>LineRTCPage.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/linevideo`}>
             <Title>Line Video</Title>
             <Description>A variation of the Line tool using a video background instead of a static image.</Description>
+            <FilenameTag>LineVideoPage.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/forms`}>
             <Title>Forms</Title>
             <Description>Form inputs and state examples.</Description>
+            <FilenameTag>FormPage.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/ptz`}>
             <Title>PTZ</Title>
             <Description>An example of a working PTZ control. Requires a PTZ camera login.</Description>
+            <FilenameTag>PTZPage.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/login`}>
             <Title>Login</Title>
             <Description>A code sample of our commonly used login view.</Description>
+            <FilenameTag>Login.tsx</FilenameTag>
           </Link>
         </Item>
         <Item>
           <Link to={`/customalert`}>
             <Title>Component Theme Override Example</Title>
             <Description>Override CSS based theme for components.</Description>
+            <FilenameTag>CustomAlertsPage.tsx</FilenameTag>
           </Link>
         </Item>
       </List>
@@ -185,6 +193,7 @@ const LinksPage : React.FC = () => {
           <Link to='/globalUI'>
             <Title>Global UI (Deprecated)</Title>
             <Description>The legacy implementation used for page layouts.</Description>
+            <FilenameTag>GlobalUIPage.tsx</FilenameTag>
           </Link>
         </Item>
       </List>

--- a/packages/example/src/pages/Index.tsx
+++ b/packages/example/src/pages/Index.tsx
@@ -17,8 +17,8 @@ const Section = styled.section`
 
 const Header = styled.h1`
   font-family: var(--font-ui);
-  font-weight: 100;
-  color: var(--grey-8);
+  font-weight: 200;
+  color: var(--grey-10);
   padding: 0;
   margin: 0 0 36px;
 `;
@@ -26,7 +26,7 @@ const Header = styled.h1`
 const Subheader = styled.h2`
   font-family: var(--font-ui);
   font-weight: 300;
-  color: var(--grey-11);
+  color: var(--grey-12);
 `;
 
 const List = styled.div`
@@ -39,7 +39,6 @@ const List = styled.div`
 `;
 
 const Item = styled.div`
-  /* max-width: 480px; */
   height: 100%;
   
   a {
@@ -51,7 +50,7 @@ const Item = styled.div`
     text-decoration: none;
     border-radius: 3px;
     box-shadow: 0 4px 8px var(--black-a6);
-    border: 1px solid transparent;
+    border: 1px solid var(--grey-4);
 
     &:hover {
       background: var(--grey2);
@@ -65,7 +64,7 @@ const Title = styled.div`
   font-family: var(--font-ui);
   letter-spacing: 0.4px;
   font-size: 14px;
-  color: var(--grey-11);
+  color: var(--grey-12);
   font-weight: 500;
 `;
 

--- a/packages/example/src/pages/Layouts.tsx
+++ b/packages/example/src/pages/Layouts.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import styled from "styled-components";
 import { ThemeProvider } from 'styled-components';
 import { GlobalUI, defaultTheme, PageHeader, useThemeToggle, ContentLayout, Tab, TabList, TabContent, Label, Button, TextField, FullWidthContentBlock, IHeaderContent, ButtonsStack, IButtonStack } from "scorer-ui-kit";
+import ExamplesFilename from "../components/ExamplesFilename";
 
 const FullWidthExampleContent = styled.div`
   width: 100%;
@@ -43,6 +44,7 @@ const Layouts: FC = () => {
 
   return (
       <ThemeProvider theme={defaultTheme}>
+        <ExamplesFilename>Layouts.tsx</ExamplesFilename>
         <GlobalUI
           accountOptionText="Account Options"
           canAlwaysPin

--- a/packages/example/src/pages/LinePage.tsx
+++ b/packages/example/src/pages/LinePage.tsx
@@ -15,6 +15,7 @@ import {
   Input
 } from 'scorer-ui-kit';
 import { IPointSet, LineUIOptions } from 'scorer-ui-kit/dist/LineUI';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const Line: React.FC<{}> = () => {
   const [state, dispatch] = useReducer(LineReducer, []);
@@ -204,6 +205,8 @@ const Line: React.FC<{}> = () => {
 
   return (
     <Layout >
+      <ExamplesFilename>LinePage.tsx</ExamplesFilename>
+
       <Sidebar>
         <Logo logoTextTop={'SCORER'} logoTextBottom={'UI Kit'} />
         <SidebarBox style={{ flex: '1' }} >

--- a/packages/example/src/pages/LineRTCPage.tsx
+++ b/packages/example/src/pages/LineRTCPage.tsx
@@ -17,6 +17,7 @@ import {
   useMediaModal
 } from 'scorer-ui-kit';
 import { LineUIOptions, LineUIVideoOptions } from 'scorer-ui-kit/dist/LineUI';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const SwitchBox = styled.div`
   margin-bottom: 15px;
@@ -194,6 +195,7 @@ const Line: React.FC<{}> = () => {
 
   return (
     <Layout >
+      <ExamplesFilename>LineRTCPage.tsx</ExamplesFilename>
       <Sidebar>
         <Logo logoTextTop={'SCORER'} logoTextBottom={'UI Kit'} />
         <SidebarBox style={{ flex: '1' }} >

--- a/packages/example/src/pages/LineVideoPage.tsx
+++ b/packages/example/src/pages/LineVideoPage.tsx
@@ -18,6 +18,7 @@ import {
 import styled from 'styled-components';
 import {LineUIOptions} from 'scorer-ui-kit/dist/LineUI';
 import {LineUIVideoOptions} from 'scorer-ui-kit/dist/LineUI';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const StyledButton = styled(ButtonWithIcon)`
   width: 100%;
@@ -217,6 +218,8 @@ const Line: React.FC<{}> = () => {
 
   return (
     <Layout >
+      <ExamplesFilename>LineVideoPage.tsx</ExamplesFilename>
+
       <Sidebar>
         <Logo logoTextTop={'SCORER'} logoTextBottom={'UI Kit'} />
 

--- a/packages/example/src/pages/Login.tsx
+++ b/packages/example/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { ButtonWithLoading, TextField, PasswordField, Form, AlertBar, AlertWrapp
 import GhostLogo from '../svg/ghost-logo.svg';
 import {LoginScreen} from '../svg';
 import {Link} from 'react-router-dom';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const widthDesk = 480;
 
@@ -26,6 +27,7 @@ const fadeInAnimation = keyframes`
   }
 `;
 
+const Wrap = styled.div``
 const Box = styled.div<{ margin?: string; flex?: string;}>`
   button{
     width: 100%;
@@ -276,54 +278,58 @@ const Login: React.FC<OwnProps> = ({
   },[form, onLogin]);
 
   return (
-    <Container>
-      <LoginBox>
-        <LogoContainer>
-          <Logo />
-          <LogoBackground src={GhostLogo} {...{design}} />
-        </LogoContainer>
-        <LoginForm onSubmit={onSubmit} spacing='25px'>
-          <Title>Sign In To Your Account</Title>
-          <SubTitle>This service requires an account to login. If you do not have one, please make one first.</SubTitle>
-          <TextField
-            fieldState='default'
-            required
-            label='Username'
-            onChange={onFieldChange('username')}
-            value={form.username}
-            name='username'
-            id='username'
-          />
+    <Wrap>
+      {/* Only use `<Container>` contents if copying this example for a project. */}
+      <ExamplesFilename>Login.tsx</ExamplesFilename>
+      <Container>
+        <LoginBox>
+          <LogoContainer>
+            <Logo />
+            <LogoBackground src={GhostLogo} {...{design}} />
+          </LogoContainer>
+          <LoginForm onSubmit={onSubmit} spacing='25px'>
+            <Title>Sign In To Your Account</Title>
+            <SubTitle>This service requires an account to login. If you do not have one, please make one first.</SubTitle>
+            <TextField
+              fieldState='default'
+              required
+              label='Username'
+              onChange={onFieldChange('username')}
+              value={form.username}
+              name='username'
+              id='username'
+            />
 
-          <PasswordField
-            fieldState='default'
-            required
-            label='Password'
-            onChange={onFieldChange('password')}
-            value={form.password}
-            name='password'
-            id='password'
-          />
-          {alert && <AlertBar type={alert.type} message={alert.message} />}
+            <PasswordField
+              fieldState='default'
+              required
+              label='Password'
+              onChange={onFieldChange('password')}
+              value={form.password}
+              name='password'
+              id='password'
+            />
+            {alert && <AlertBar type={alert.type} message={alert.message} />}
 
-          <Box flex='1'>
-            <ButtonWithLoading loading={loading} type='submit' onClick={onSubmit}>Login</ButtonWithLoading>
-          </Box>
-          <ForgotLinkWrapper>
-            <ForgotLink to='#'>Forgotten Password</ForgotLink>
-          </ForgotLinkWrapper>
+            <Box flex='1'>
+              <ButtonWithLoading loading={loading} type='submit' onClick={onSubmit}>Login</ButtonWithLoading>
+            </Box>
+            <ForgotLinkWrapper>
+              <ForgotLink to='#'>Forgotten Password</ForgotLink>
+            </ForgotLinkWrapper>
 
-        </LoginForm>
-      </LoginBox>
-      <CopyRightGroup>
-        <CopyRight>Copyright {new Date().getFullYear()} - Future Standard Co. Ltd. All Rights Reserved. </CopyRight>
-        <CopyRightLink to='#'>Terms</CopyRightLink>
-        <CopyRightDot>&middot;</CopyRightDot>
-        <CopyRightLink to='#'>Privacy</CopyRightLink>
-      </CopyRightGroup>
+          </LoginForm>
+        </LoginBox>
+        <CopyRightGroup>
+          <CopyRight>Copyright {new Date().getFullYear()} - Future Standard Co. Ltd. All Rights Reserved. </CopyRight>
+          <CopyRightLink to='#'>Terms</CopyRightLink>
+          <CopyRightDot>&middot;</CopyRightDot>
+          <CopyRightLink to='#'>Privacy</CopyRightLink>
+        </CopyRightGroup>
 
 
-    </Container>
+      </Container>
+    </Wrap>
   );
 };
 

--- a/packages/example/src/pages/PTZPage.tsx
+++ b/packages/example/src/pages/PTZPage.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState, useCallback } from 'react';
 import { Controls, PTZContext, Sidebar, SidebarHeading, AlertBar, Form, ButtonWithLoading, TextField, PasswordField, BackLink, Layout, Logo, SidebarBox } from 'scorer-ui-kit';
 import styled from 'styled-components';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 
 interface DeviceConnectionInfo {
@@ -44,6 +45,7 @@ const PTZ: React.FC<Props> = () => {
 
   return (
     <Layout>
+      <ExamplesFilename>PTZPage.tsx</ExamplesFilename>
       <Sidebar>
         <Logo logoTextTop={'SCORER'} logoTextBottom={'UI Kit'} />
         <SidebarBox>

--- a/packages/example/src/pages/SplitLayout.tsx
+++ b/packages/example/src/pages/SplitLayout.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from "react";
 import { ThemeProvider } from 'styled-components';
 import { GlobalUI, defaultTheme, useThemeToggle, ContentLayout, SplitLayout, FlexContentPlaceholder } from "scorer-ui-kit";
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const SplitLayouts: FC = () => {
 
@@ -14,6 +15,7 @@ const SplitLayouts: FC = () => {
 
   return (
       <ThemeProvider theme={defaultTheme}>
+        <ExamplesFilename>SplitLayout.tsx</ExamplesFilename>
         <GlobalUI
           accountOptionText="Account Options"
           canAlwaysPin

--- a/packages/example/src/pages/TablePage.tsx
+++ b/packages/example/src/pages/TablePage.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { TypeTable, PageHeader, Content, useModal, SplitButton } from 'scorer-ui-kit';
 import { ITableColumnConfig, ITypeTableData } from 'scorer-ui-kit/dist/Tables';
 import { StatusComponent } from '../components/StatusComponent';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const Container = styled.div`
   margin: 100px 200px;
@@ -197,6 +198,7 @@ const TablePage: React.FC = () => {
   }, [rows, setRows]);
 
   return <Container>
+    <ExamplesFilename>TablePage.tsx</ExamplesFilename>
     <Content>
       <PageHeader title="Table Example" areaTitle="Examples" areaHref={'/'} />
       <TypeTable selectable={true} {...{ columnConfig, rows, selectCallback, toggleAllCallback, hasThumbnail: true }} />

--- a/packages/example/src/pages/TabsPage.tsx
+++ b/packages/example/src/pages/TabsPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { PageHeader, Content, Button, Label, TextField, Tabs, Tab, TabList, TabContent } from 'scorer-ui-kit';
+import ExamplesFilename from '../components/ExamplesFilename';
 
 const Container = styled.div`
   margin: 100px 200px;
@@ -24,6 +25,7 @@ const Tab2Container = styled.div`
 const TabsPage: React.FC = () => {
 
   return <Container>
+    <ExamplesFilename>TabsPage.tsx</ExamplesFilename>
     <Content>
       <PageHeader title="Tabs Example" areaTitle="Examples" areaHref={'/'} />
       <Tabs>


### PR DESCRIPTION
This feature adds two minor but useful improvements to Examples.

1. The index has a label on now with the filename of the source code it uses.
2. The individual examples also have a small label in the bottom center for this.
3. Next to this label in examples is a small home button to get back to the top level.

This is intended to help reduce friction when sharing examples and helping engineeers find the code to reference.

There is also a few minor changes to color and border on the index to help is be more readable in dark mode.

![image](https://github.com/user-attachments/assets/1c028ea5-e8bb-4359-9d89-f7d2315688b8)
![image](https://github.com/user-attachments/assets/66ee499f-cd08-4ebf-8c9e-69527d6dfec7)
