### PR TITLE
Bump for release v2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -37847,7 +37847,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
### Description
 Release v2.60

**Features**

- Page Examples: The listed projects on the homepage now include a label displaying the source document name. Additionally, each example page features a "Home" button at the bottom center, allowing users to return to the main page.

- Input, InputField, TextArea, TextAreaField, and PasswordField Components: These components have been reworked to align with new design. Updates include:

  - Updated sizes and colors, incorporating new CSS variables.
  - A blue dot is now displayed by default on the label when the required prop is passed. This required prop indicates that the field is required, while fieldState='required' is used when a form has been submitted but the field is left empty. (If a project does not use the blue dot for required fields, you can override the CSS variable --input-required-dot-display to none.)
  - Feedback messages are no longer shown by default, as they are not frequently used. To display feedback messages, the new showFeedback boolean prop must be passed.
You can learn more about these updates in [PR #496](https://github.com/future-standard/scorer-ui-kit/pull/496)

**Deprecated Features and Breaking Changes**
- The Zeplin Storybook connection development project has been temporarily removed due to security risks and outdated support. Existing Zeplin connections to the UI Kit webpage will remain unaffected, but no new integrations will be added going forward.
