### PR TITLE
Add disableCheckbox option to rows

### DIFF
--- a/packages/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
+++ b/packages/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
@@ -107,6 +107,7 @@ const dataRows : ITypeTableData = [
 export const _LoadingTable = () => {
   const isLoading = boolean("IsLoading", true);
   const emptyTable = boolean("Show Empty Table", true);
+  const disableOneCheckbox = boolean('Disable 1st Checkbox', false);
   const emptyTableTitle = text("emptyTableTitle","No Data Available");
   const emptyTableText = text("emptyTableText", 'There is currently no data');
   const loadingText = text("loadingText", 'Loading Data..')
@@ -117,25 +118,27 @@ export const _LoadingTable = () => {
 
   const [rows, setRows] = useState<ITypeTableData>(initialRows);
 
-  const toggleAllCallback = useCallback((checked:boolean) => {
-    const newRows = [...rows];
-
-    newRows.forEach((row) => {
-      row._checked = checked;
-  });
-
-    setRows(newRows);
-  }, [rows, setRows]);
+  const toggleAllCallback = useCallback((checked: boolean) => {
+    setRows((prevRows) => {
+      const newRows = [...prevRows];
+      newRows.forEach((row) => {
+        row._checked = checked;
+      });
+      return newRows;
+    });
+  }, [setRows]);
 
     // Sent to checkbox in TableRow via Table component.
-    const selectCallback = useCallback((checked:boolean, id?: string | number) => {
-      const newRows = [...rows];
-      const targetRowIndex = newRows.findIndex(row => row.id === id)
-      newRows[targetRowIndex]._checked = checked;
-
-      setRows(newRows);
-
-    }, [rows, setRows]);
+    const selectCallback = useCallback((checked: boolean, id?: string | number) => {
+      setRows((prevRows) => {
+        const newRows = [...prevRows];
+        const targetRowIndex = newRows.findIndex((row) => row.id === id);
+        if (targetRowIndex > -1) {
+          newRows[targetRowIndex]._checked = checked;
+        }
+        return newRows;
+      });
+    }, [setRows]);
 
   useEffect(() => {
     if(emptyTable) {
@@ -147,6 +150,14 @@ export const _LoadingTable = () => {
       setRows(initialRows);
     }
   }, [emptyTable])
+
+  useEffect(() => {
+    setRows((prevRows) => {
+      const newRows = [...prevRows];
+      newRows[0].checkboxDisabled = disableOneCheckbox;
+      return newRows;
+    });
+  }, [disableOneCheckbox])
 
   return (
     <Container>

--- a/packages/ui-lib/src/Tables/atoms/TypeTableRow.tsx
+++ b/packages/ui-lib/src/Tables/atoms/TypeTableRow.tsx
@@ -38,7 +38,7 @@ const TypeTableRow : React.FC<IProps> = ({selectable = false, selectCallback, ha
 
   return (
     <RowContainer isEmpty={isEmpty}>
-      {selectable ? <TypeTableCell hideDivider><Checkbox checked={rowData._checked} onChangeCallback={wrappedSelectCallback} /></TypeTableCell> : null}
+      {selectable ? <TypeTableCell hideDivider><Checkbox checked={rowData._checked} disabled={rowData.checkboxDisabled} onChangeCallback={wrappedSelectCallback} /></TypeTableCell> : null}
       {hasStatus ?  <TypeTableCell hideDivider><TypeTableDeviceStatus status={rowData.header?.status} /></TypeTableCell> : null}
       {hasThumbnail ? <TypeTableCell hideDivider><TableRowThumbnail image={rowData.header?.image} mediaUrl={rowData.header?.mediaUrl} mediaType={rowData.header?.mediaType} closeText={closeText} onClickThumbnail={rowData.header?.onClickThumbnail}/></TypeTableCell> : null}
       {hasTypeIcon ? <TypeTableCell hideDivider><Icon icon={rowData.header?.icon || ''} color='dimmed' weight='regular' size={16} /></TypeTableCell> : null}

--- a/packages/ui-lib/src/Tables/index.ts
+++ b/packages/ui-lib/src/Tables/index.ts
@@ -59,6 +59,7 @@ export interface IRowHeader {
 
 export interface IRowData {
   _checked?: boolean
+  checkboxDisabled?: boolean
   id?: number | string
   header?: IRowHeader
   columns: ICellData[]

--- a/packages/ui-lib/src/Tables/molecules/TypeTableHeader.tsx
+++ b/packages/ui-lib/src/Tables/molecules/TypeTableHeader.tsx
@@ -139,8 +139,7 @@ interface ITableHeader {
   hasThumbnail: boolean
   hasTypeIcon: boolean
   allChecked: boolean
-  isEmptyTable: boolean
-  isLoading: boolean
+  disableAllChecked: boolean
   hasHeaderGroups: boolean
   columnConfig: ITableColumnConfig[]
   defaultAscending: boolean
@@ -154,8 +153,7 @@ const TypeTableHeader: React.FC<ITableHeader> = ({
   hasThumbnail,
   hasTypeIcon,
   allChecked,
-  isEmptyTable,
-  isLoading,
+  disableAllChecked,
   hasHeaderGroups,
   columnConfig,
   defaultAscending,
@@ -207,7 +205,7 @@ const TypeTableHeader: React.FC<ITableHeader> = ({
     <HeaderRow>
       {selectable ? (
         <HeaderItem headerStyle='header' fixedWidth={30}>
-          <Checkbox checked={allChecked} disabled={isEmptyTable || isLoading} onChangeCallback={toggleAllCallbackWrapper} />
+          <Checkbox checked={allChecked} disabled={disableAllChecked} onChangeCallback={toggleAllCallbackWrapper} />
         </HeaderItem>)
         : null}
       {hasStatus ? <HeaderItem headerStyle='header' fixedWidth={10} /> : null}

--- a/packages/ui-lib/src/Tables/organisms/TypeTable.tsx
+++ b/packages/ui-lib/src/Tables/organisms/TypeTable.tsx
@@ -56,6 +56,10 @@ const isChecked = ({ _checked = false }: IRowData) => {
   return _checked === true;
 };
 
+const isCheckBoxDisabled = ({checkboxDisabled = false}: IRowData) => {
+  return checkboxDisabled === true;
+};
+
 interface IProps {
   columnConfig: ITableColumnConfig[]
   rows: ITypeTableData
@@ -103,15 +107,25 @@ const TypeTable: React.FC<IProps> = ({
 */
 
   const [allChecked, setAllChecked] = useState(false);
+  const [disableAllChecked, setDisableAllChecked] = useState(false);
   const isEmptyTable = (rows.length === 1) && (rows[0].columns.length === 0) && (!isLoading);
 
   useEffect(() => {
     let areAllChecked = false;
+    let disableCheckAll = false;
+
     if (rows.every(isChecked) && (rows.length > 0) && !isEmptyTable) {
       areAllChecked = true;
     }
+
+    if (rows.some(isCheckBoxDisabled) || isEmptyTable || isLoading) {
+      disableCheckAll = true;
+    }
+
     setAllChecked(areAllChecked);
-  }, [isEmptyTable, rows]);
+    setDisableAllChecked(disableCheckAll);
+
+  }, [isEmptyTable, isLoading, rows]);
 
   return (
     <Container>
@@ -124,8 +138,7 @@ const TypeTable: React.FC<IProps> = ({
             hasTypeIcon,
             defaultAscending,
             allChecked,
-            isEmptyTable,
-            isLoading,
+            disableAllChecked,
             hasHeaderGroups,
             columnConfig,
             toggleAllCallback,


### PR DESCRIPTION
### Description

This is an update request for TypeTable component.
Currently the checkboxes in the rows can't be disabled by developer side.
This update will allow to disable them while still checking the states for the allChecked Checkbox

 ### Considerations on Implementation

I decided to use the logic if at lease one checkbox in rows is disable the checkAll/ unCheckAll will be disable too.
Attaching the reasoning of this logic
![Screenshot 2024-10-29 at 14 42 57](https://github.com/user-attachments/assets/8d72778c-f90c-4d76-b253-c39c9fe1848a)

I updated the example toggles to use previous as base prevent useEffect forever cycle when updating.

 ### Reviewing/Testing steps
 
Test on storybook `Tables -> Molecules -> LoadingTable`  local using disable 1st checkbox 

<img width="992" alt="Screenshot 2024-10-29 at 14 47 33" src="https://github.com/user-attachments/assets/41432e46-85e1-4661-b546-5b46fe31ea6d">
