### PR TITLE
Hotfix: Main Menu - Sub Menus wrong height if contents was changed after initialisation

### DIFF
--- a/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
+++ b/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
@@ -19,6 +19,10 @@ const SubmenuHeader = styled.div`
   margin-left: 40px;
 `;
 
+const SubmenuContainerInner = styled.div`
+  overflow: hidden;
+`;
+
 const SubmenuItemTitle = styled.span`
   display: block;
   font-family: var(--font-ui);
@@ -91,8 +95,8 @@ const SubmenuContainer = styled.div`
   overflow: hidden;
 
   transition:
-    max-height var(--speed-normal) var(--easing-primary-in),
-    opacity var(--speed-fast) var(--easing-primary-in);
+    grid-template-rows var(--speed-normal) var(--easing-primary-in-out),
+    opacity var(--speed-fast) var(--easing-primary-in-out);
 
   &::after {
     display: block;
@@ -107,20 +111,23 @@ const SubmenuContainer = styled.div`
 
 `;
 
-const ContextContainer = styled.div<{ open: boolean, maxHeight: number, minHeight?: number, loading: 'true'|'false' }>`
-  min-height: ${({minHeight}) => minHeight ? `${minHeight}px` : `70px`};
+const ContextContainer = styled.div<{ open: boolean, loading: 'true'|'false' }>`
+  min-height: 70px;
   width: inherit;
 
   ${SubmenuContainer}{
-    max-height: 0;
-    opacity: 0;
-  }
-  ${({open, maxHeight}) => open && css`
+    display: grid;
+    grid-template-rows: 0fr;
+  };
+
+  ${({open}) => open && css`
     ${SubmenuContainer}{
+      grid-template-rows: 1fr;
+      
       transition:
-        max-height var(--speed-normal) var(--easing-primary-in),
-        opacity var(--speed-fast) var(--easing-primary-in);
-      max-height: ${maxHeight}px !important;
+        grid-template-rows var(--speed-normal) var(--easing-primary-in-out),
+        opacity var(--speed-fast) var(--easing-primary-in-out);
+      
       opacity: 1;
     }
   `};
@@ -146,29 +153,26 @@ interface IProps {
   readyCallback?: (...args: any[]) => void
 }
 
-const NavigationItem : React.FC<IProps> = ({item, menuOpen, submenuOpen, contextKey, loading, topLevelPath, minHeight, onClickCallback, readyCallback}) => {
+const NavigationItem : React.FC<IProps> = ({item, menuOpen, submenuOpen, contextKey, loading, topLevelPath, onClickCallback, readyCallback}) => {
   const { icon, title, href, submenu, isExternalLink } = item;
   const isActive = topLevelPath === href;
 
   const refSubmenu = useRef<any>(null);
-  const [submenuHeight, setSubmenuHeight] = useState<number>(0);
 
   const submenus : any[] = generateSubmenus(submenu, onClickCallback ) || [];
   const hasSubmenu : boolean = submenus.length > 0;
 
   useEffect(() => {
-    if(refSubmenu && refSubmenu.current && refSubmenu.current.clientHeight !== 0){
-      setSubmenuHeight(refSubmenu.current.clientHeight);
-    }
-
+    // Is this still needed? Left in due to hotfixing.
     if(readyCallback){ readyCallback(contextKey); }
-
-  }, [refSubmenu, setSubmenuHeight, readyCallback, contextKey]);
+  }, [refSubmenu, readyCallback, contextKey]);
 
   return (
-    <ContextContainer open={submenuOpen} loading={loading ? 'true': 'false'} maxHeight={submenuHeight} minHeight={minHeight}>
+    <ContextContainer open={submenuOpen} loading={loading ? 'true': 'false'}>
       <ContextItem {...{title, href, isActive, icon, hasSubmenu, isExternalLink, submenuOpen, menuOpen, onClickCallback, contextKey}} />
-      {hasSubmenu ? <SubmenuContainer ref={refSubmenu}>{submenus}</SubmenuContainer> : null}
+      {hasSubmenu ? <SubmenuContainer ref={refSubmenu}>
+        <SubmenuContainerInner>{submenus}</SubmenuContainerInner>
+      </SubmenuContainer> : null}
     </ContextContainer>
   );
 

--- a/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
+++ b/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import {Link} from 'react-router-dom';
 import ContextItem from './ContextItem';


### PR DESCRIPTION
In the main menu, when sub-menu items were being added or removed conditionally the useEffect that was calculating the height of the container to animated the closing was not firing. This led to the container being the wrong height and rendering incorrectly.

I've removed this max-height approach and replaced it with a CSS only method that will render the open height natively in the browser, meaning it is scalable and does not require and recalculation in our code to achieve.

This implementation leaves in some code that appears to be redundant but would take additional fix and review time that is riskier to deploy for this hotfix, due to delivery pressures on the projects relied on. However, I will follow up immediately on these changes in PR #505.

Note: This breaks the layout of the mobile menu menu heights. This is not an issue for this hotfix.

Here are two videos, the first is the issue. You'll see the default state, some items added to code and saved which causes a broken sub menu state. This is fixed on refresh.

https://github.com/user-attachments/assets/95c0c4fb-01f0-45cb-905d-14a0e0a01e71



And the fixed version that works as intended.

https://github.com/user-attachments/assets/9c2d169d-d90d-4f36-855e-457507c91c43

