### PR TITLE
Submenu height fix.

### DIFF
--- a/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
+++ b/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import styled, { css } from 'styled-components';
 import {Link} from 'react-router-dom';
 import ContextItem from './ContextItem';
@@ -111,8 +111,8 @@ const SubmenuContainer = styled.div`
 
 `;
 
-const ContextContainer = styled.div<{ open: boolean, loading: 'true'|'false' }>`
-  min-height: 70px;
+const ContextContainer = styled.div<{ open: boolean, mobileMenu?: boolean }>`
+  min-height: ${({mobileMenu}) => mobileMenu ? '30px' : '70px'};
   width: inherit;
 
   ${SubmenuContainer}{
@@ -131,29 +131,19 @@ const ContextContainer = styled.div<{ open: boolean, loading: 'true'|'false' }>`
       opacity: 1;
     }
   `};
-
-  ${({loading}) => loading === 'true' && css`
-    ${SubmenuContainer}{
-      max-height: none !important;
-      opacity: 1;
-    }
-  `};
-
 `;
 
 interface IProps {
   item: IMenuItemTop
   contextKey: number
   submenuOpen: boolean
-  loading: boolean
   menuOpen?: boolean
   topLevelPath: string
-  minHeight?: number
+  mobileMenu?: boolean
   onClickCallback?: (...args: any[]) => void
-  readyCallback?: (...args: any[]) => void
 }
 
-const NavigationItem : React.FC<IProps> = ({item, menuOpen, submenuOpen, contextKey, loading, topLevelPath, onClickCallback, readyCallback}) => {
+const NavigationItem : React.FC<IProps> = ({item, menuOpen, submenuOpen, contextKey, topLevelPath, mobileMenu = false, onClickCallback }) => {
   const { icon, title, href, submenu, isExternalLink } = item;
   const isActive = topLevelPath === href;
 
@@ -162,13 +152,8 @@ const NavigationItem : React.FC<IProps> = ({item, menuOpen, submenuOpen, context
   const submenus : any[] = generateSubmenus(submenu, onClickCallback ) || [];
   const hasSubmenu : boolean = submenus.length > 0;
 
-  useEffect(() => {
-    // Is this still needed? Left in due to hotfixing.
-    if(readyCallback){ readyCallback(contextKey); }
-  }, [refSubmenu, readyCallback, contextKey]);
-
   return (
-    <ContextContainer open={submenuOpen} loading={loading ? 'true': 'false'}>
+    <ContextContainer open={submenuOpen} {...{mobileMenu}}>
       <ContextItem {...{title, href, isActive, icon, hasSubmenu, isExternalLink, submenuOpen, menuOpen, onClickCallback, contextKey}} />
       {hasSubmenu ? <SubmenuContainer ref={refSubmenu}>
         <SubmenuContainerInner>{submenus}</SubmenuContainerInner>

--- a/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
+++ b/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
@@ -19,6 +19,10 @@ const SubmenuHeader = styled.div`
   margin-left: 40px;
 `;
 
+const SubmenuContainerInner = styled.div`
+  overflow: hidden;
+`;
+
 const SubmenuItemTitle = styled.span`
   display: block;
   font-family: var(--font-ui);
@@ -91,8 +95,8 @@ const SubmenuContainer = styled.div`
   overflow: hidden;
 
   transition:
-    max-height var(--speed-normal) var(--easing-primary-in),
-    opacity var(--speed-fast) var(--easing-primary-in);
+    grid-template-rows var(--speed-normal) var(--easing-primary-in-out),
+    opacity var(--speed-fast) var(--easing-primary-in-out);
 
   &::after {
     display: block;
@@ -107,20 +111,23 @@ const SubmenuContainer = styled.div`
 
 `;
 
-const ContextContainer = styled.div<{ open: boolean, maxHeight: number, minHeight?: number, loading: 'true'|'false' }>`
-  min-height: ${({minHeight}) => minHeight ? `${minHeight}px` : `70px`};
+const ContextContainer = styled.div<{ open: boolean, loading: 'true'|'false' }>`
+  min-height: 70px;
   width: inherit;
 
   ${SubmenuContainer}{
-    max-height: 0;
-    opacity: 0;
-  }
-  ${({open, maxHeight}) => open && css`
+    display: grid;
+    grid-template-rows: 0fr;
+  };
+
+  ${({open}) => open && css`
     ${SubmenuContainer}{
+      grid-template-rows: 1fr;
+      
       transition:
-        max-height var(--speed-normal) var(--easing-primary-in),
-        opacity var(--speed-fast) var(--easing-primary-in);
-      max-height: ${maxHeight}px !important;
+        grid-template-rows var(--speed-normal) var(--easing-primary-in-out),
+        opacity var(--speed-fast) var(--easing-primary-in-out);
+      
       opacity: 1;
     }
   `};
@@ -146,29 +153,26 @@ interface IProps {
   readyCallback?: (...args: any[]) => void
 }
 
-const NavigationItem : React.FC<IProps> = ({item, menuOpen, submenuOpen, contextKey, loading, topLevelPath, minHeight, onClickCallback, readyCallback}) => {
+const NavigationItem : React.FC<IProps> = ({item, menuOpen, submenuOpen, contextKey, loading, topLevelPath, onClickCallback, readyCallback}) => {
   const { icon, title, href, submenu, isExternalLink } = item;
   const isActive = topLevelPath === href;
 
   const refSubmenu = useRef<any>(null);
-  const [submenuHeight, setSubmenuHeight] = useState<number>(0);
 
   const submenus : any[] = generateSubmenus(submenu, onClickCallback ) || [];
   const hasSubmenu : boolean = submenus.length > 0;
 
   useEffect(() => {
-    if(refSubmenu && refSubmenu.current && refSubmenu.current.clientHeight !== 0){
-      setSubmenuHeight(refSubmenu.current.clientHeight);
-    }
-
+    // Is this still needed? Left in due to hotfixing.
     if(readyCallback){ readyCallback(contextKey); }
-
-  }, [refSubmenu, setSubmenuHeight, readyCallback, contextKey]);
+  }, [refSubmenu, readyCallback, contextKey]);
 
   return (
-    <ContextContainer open={submenuOpen} loading={loading ? 'true': 'false'} maxHeight={submenuHeight} minHeight={minHeight}>
+    <ContextContainer open={submenuOpen} loading={loading ? 'true': 'false'}>
       <ContextItem {...{title, href, isActive, icon, hasSubmenu, isExternalLink, submenuOpen, menuOpen, onClickCallback, contextKey}} />
-      {hasSubmenu ? <SubmenuContainer ref={refSubmenu}>{submenus}</SubmenuContainer> : null}
+      {hasSubmenu ? <SubmenuContainer ref={refSubmenu}>
+        <SubmenuContainerInner>{submenus}</SubmenuContainerInner>
+      </SubmenuContainer> : null}
     </ContextContainer>
   );
 

--- a/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
+++ b/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import {Link} from 'react-router-dom';
 import ContextItem from './ContextItem';

--- a/packages/ui-lib/src/Global/organisms/MainMenu.tsx
+++ b/packages/ui-lib/src/Global/organisms/MainMenu.tsx
@@ -108,9 +108,7 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
   const { menuState, setMenuOpen, setMenuClose, togglePinned } = useMenu(defaultMenuOpen, canAlwaysPin);
 
   const [focusedContext, setFocusedContext] = useState<number>(0);
-  const [loading, setLoading] = useState<boolean>(true);
   const location = useLocation();
-  let checkedInItems: number = 0;
 
   /* Handling of menu open, closing and pinning. */
   const autoMenuOpen = useCallback((e: any) => {
@@ -143,15 +141,6 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
     setFocusedContext(focusedContext !== contextKey ? contextKey : -1);
   }, [setFocusedContext, focusedContext]);
 
-  /** Manage the loading cycle. */
-  const readyCallback = useCallback(() => {
-    // Basic count of menu items (that need to measure height) that have checked in.
-    checkedInItems++;
-    if (checkedInItems === content.items.length) {
-      setLoading(false);
-    }
-  }, [checkedInItems, content]);
-
   return (
     <PushContainer isPinned={menuState.isMenuPinned}>
       {ReactDom.createPortal(
@@ -178,7 +167,7 @@ const MainMenu: React.FC<IMenu> = ({ content, home = "/", logoMark, logoText, ke
                   menuOpen={menuState.isMenuOpen}
                   submenuOpen={key === focusedContext && menuState.isMenuOpen}
                   onClickCallback={setFocusedContextCb}
-                  {...{ item, loading, focusedContext, readyCallback }}
+                  {...{ item, focusedContext }}
                 />
               );
               })}

--- a/packages/ui-lib/src/Global/organisms/MobileMenu.tsx
+++ b/packages/ui-lib/src/Global/organisms/MobileMenu.tsx
@@ -25,10 +25,8 @@ const MobileMenu: React.FC<IMobileMenu> = ({
   closeId
 }) => {
 
-  const [loading, setLoading] = useState<boolean>(true);
   const [focusedContext, setFocusedContext] = useState<number>(0);
   const location = useLocation();
-  let checkedInItems: number = 0;
   const { setSelected }: ContextProps = useContext(TabContext);
 
 
@@ -48,15 +46,6 @@ const MobileMenu: React.FC<IMobileMenu> = ({
 
   }, [closeId, content.items, focusedContext, setSelected]);
 
-  /** Manage the loading cycle. */
-  const readyCallback = useCallback(() => {
-    // Basic count of menu items (that need to measure height) that have checked in.
-    checkedInItems++;
-    if (checkedInItems === content.items.length) {
-      setLoading(false);
-    }
-  }, [checkedInItems, content.items.length]);
-
   const handleCloseMenu = useCallback(() => {
     setSelected(closeId);
   },[closeId, setSelected]);
@@ -67,13 +56,13 @@ const MobileMenu: React.FC<IMobileMenu> = ({
         return (
           <ItemWrapper key={key} data-key={key}>
             <NavigationItem
-              minHeight={30}
+              mobileMenu
               topLevelPath={getTopLevelPath(location.pathname)}
               contextKey={key}
               menuOpen
               submenuOpen={key === focusedContext}
               onClickCallback={setFocusedContextCb}
-              {...{ item, loading, focusedContext, readyCallback }}
+              {...{ item, focusedContext }}
             />
           </ItemWrapper>
 


### PR DESCRIPTION
This completes the work from the hotfix of PR #504. It includes:

- Fixes to the mobile menu heights, removing the previous minHeight implementation and using a new `mobileMenu` prop to define the difference.
- Removes the `loading` state that was used to track when each `NavigationItem` had checked the height of its submenus. As it didn't appear to be used for anything else practical outside of these, it's been removed along with the ready callback which was part of this check.
- This has also been removed from the `mobileMenu`

Once this has been reviewed and you're happy with the menu functionality, we can deploy this. There is rush though as with the hotfix version of this.