### PR TITLE
Datepicker  Date Range availability

### DIFF
--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { object, select, text } from '@storybook/addon-knobs';
+import { boolean, object, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { DatePicker, FilterDropdownContainer } from 'scorer-ui-kit';
 
@@ -29,14 +29,12 @@ start.setDate(0);
 start.setDate(start.getDate() - 20);
 const end: Date = new Date();
 end.setDate(1);
-end.setDate(end.getDate() + 20);
+end.setDate(end.getDate() + 70);
 
 const datesRange = {
   start: start,
   end: end
 }
-
-
 
 export const _DatePicker = () => {
   const language = select('Language', { English: 'en', Japanese: 'ja' }, 'ja');
@@ -47,7 +45,8 @@ export const _DatePicker = () => {
   const timeZoneTitle = text('Time Zone Title', 'Timezone');
   const timeZoneValueTitle = text('Time Zone Value', 'JST');
   const updateCallback = action('Date / Time Updated');
-  const availableRangeDates = object('Available Range', datesRange)
+  const sendRange = boolean('Send Available Range', false);
+  const availableRangeDates = object('Available Range', datesRange);
 
   return (
     <Container>
@@ -56,13 +55,13 @@ export const _DatePicker = () => {
           timeMode,
           dateMode,
           timeZoneValueTitle,
-          availableRange: availableRangeDates
         }}
           updateCallback={exampleCallback(updateCallback)}
           dateTimeTextUpper={language === 'ja' ? 'から' : dateTimeTextUpper}
           dateTimeTextLower={language === 'ja' ? 'まで' : dateTimeTextLower}
           timeZoneTitle={language === 'ja' ? '時間帯' : timeZoneTitle}
           lang={language}
+          availableRange={sendRange ? availableRangeDates : undefined}
         />
       </FilterDropdownContainer>
     </Container>);

--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -29,19 +29,17 @@ START_RANGE.setDate(0);
 START_RANGE.setDate(START_RANGE.getDate() - 20);
 const END_RANGE: Date = new Date();
 END_RANGE.setDate(1);
-END_RANGE.setDate(END_RANGE.getDate() + 70);
+END_RANGE.setDate(END_RANGE.getDate() + 60);
 
 
 const TODAY: Date = new Date();
-const START: Date = new Date();
-const END: Date = new Date();
-START.setDate(TODAY.getDate() - 4);
-END.setDate(TODAY.getDate() + 4);
+const TWO_WEEKS_BEFORE: Date = new Date();
+TWO_WEEKS_BEFORE.setDate(TODAY.getDate() - 15);
 
 
 const initialValue = {
-  start: START,
-  end: END
+  start: TWO_WEEKS_BEFORE,
+  end: TODAY
 }
 const datesRange = {
   start: START_RANGE,
@@ -58,7 +56,7 @@ export const _DatePicker = () => {
   const timeZoneTitle = text('Time Zone Title', 'Timezone');
   const timeZoneValueTitle = text('Time Zone Value', 'JST');
   const updateCallback = action('Date / Time Updated');
-  const sendRange = boolean('Send Available Range', false);
+  const sendRange = boolean('Send Available Range', true);
   const availableRangeDates = object('Available Range', datesRange);
 
   return (

--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -24,20 +24,33 @@ const exampleCallback = <T extends Function>(fn: T): T => {
   return fn;
 };
 
-const start: Date = new Date();
-start.setDate(0);
-start.setDate(start.getDate() - 20);
-const end: Date = new Date();
-end.setDate(1);
-end.setDate(end.getDate() + 70);
+const START_RANGE: Date = new Date();
+START_RANGE.setDate(0);
+START_RANGE.setDate(START_RANGE.getDate() - 20);
+const END_RANGE: Date = new Date();
+END_RANGE.setDate(1);
+END_RANGE.setDate(END_RANGE.getDate() + 70);
 
+
+const TODAY: Date = new Date();
+const START: Date = new Date();
+const END: Date = new Date();
+START.setDate(TODAY.getDate() - 4);
+END.setDate(TODAY.getDate() + 4);
+
+
+const initialValue = {
+  start: START,
+  end: END
+}
 const datesRange = {
-  start: start,
-  end: end
+  start: START_RANGE,
+  end: END_RANGE
 }
 
 export const _DatePicker = () => {
   const language = select('Language', { English: 'en', Japanese: 'ja' }, 'ja');
+  const initialValueObj = object('Initial Value', initialValue);
   const dateMode = select('Date Mode', { single: 'single', interval: 'interval' }, 'interval');
   const timeMode = select('Time Mode', { off: 'off', single: 'single', interval: 'interval' }, 'interval');
   const dateTimeTextUpper = text('Date Time Text Upper', 'From');
@@ -61,6 +74,7 @@ export const _DatePicker = () => {
           dateTimeTextLower={language === 'ja' ? 'まで' : dateTimeTextLower}
           timeZoneTitle={language === 'ja' ? '時間帯' : timeZoneTitle}
           lang={language}
+          initialValue={initialValueObj}
           availableRange={sendRange ? availableRangeDates : undefined}
         />
       </FilterDropdownContainer>

--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { select, text } from '@storybook/addon-knobs';
+import { object, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { DatePicker, FilterDropdownContainer } from 'scorer-ui-kit';
 
@@ -24,6 +24,20 @@ const exampleCallback = <T extends Function>(fn: T): T => {
   return fn;
 };
 
+const start: Date = new Date();
+start.setDate(0);
+start.setDate(start.getDate() - 20);
+const end: Date = new Date();
+end.setDate(1);
+end.setDate(end.getDate() + 20);
+
+const datesRange = {
+  start: start,
+  end: end
+}
+
+
+
 export const _DatePicker = () => {
   const language = select('Language', { English: 'en', Japanese: 'ja' }, 'ja');
   const dateMode = select('Date Mode', { single: 'single', interval: 'interval' }, 'interval');
@@ -33,6 +47,7 @@ export const _DatePicker = () => {
   const timeZoneTitle = text('Time Zone Title', 'Timezone');
   const timeZoneValueTitle = text('Time Zone Value', 'JST');
   const updateCallback = action('Date / Time Updated');
+  const availableRangeDates = object('Available Range', datesRange)
 
   return (
     <Container>
@@ -40,7 +55,8 @@ export const _DatePicker = () => {
         <DatePicker {...{
           timeMode,
           dateMode,
-          timeZoneValueTitle
+          timeZoneValueTitle,
+          availableRange: availableRangeDates
         }}
           updateCallback={exampleCallback(updateCallback)}
           dateTimeTextUpper={language === 'ja' ? 'から' : dateTimeTextUpper}

--- a/packages/ui-lib/src/Filters/index.ts
+++ b/packages/ui-lib/src/Filters/index.ts
@@ -1,4 +1,4 @@
-import DatePicker, { DateInterval, isDateInterval } from './molecules/DatePicker';
+import DatePicker, { DateInterval, isDateInterval, DateRange } from './molecules/DatePicker';
 import FilterDropdownContainer from './atoms/FilterDropdownContainer';
 import FilterButton from './atoms/FilterButton';
 import FilterDropdown from './molecules/FilterDropdown';
@@ -47,5 +47,6 @@ export type {
   IFilterValue,
   DateInterval,
   IFilterDatePicker,
-  FilterButtonDesign
+  FilterButtonDesign,
+  DateRange
 };

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -132,14 +132,14 @@ const PaginateMonth = styled.button`
   align-items: center;
 
   transition: color var(--speed-fast) var(--easing-primary-in-out);
-  
+
   ${IconWrap}{
     svg * {
       transition: stroke var(--speed-fast) var(--easing-primary-in-out);
     }
   }
 
-  &:hover {
+  &:hover:enabled  {
     color: var(--grey-12);
 
     ${IconWrap}{
@@ -148,6 +148,12 @@ const PaginateMonth = styled.button`
       }
     }
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
 `;
 
 const CalBody = styled.div`
@@ -281,6 +287,12 @@ export interface DateInterval {
   start: Date;
   end: Date;
 }
+
+export interface DateRange {
+  start: Date | null;
+  end: Date | null;
+}
+
 export interface IDatePicker {
   initialValue?: Date | DateInterval
   dateMode?: DateMode
@@ -290,6 +302,7 @@ export interface IDatePicker {
   dateTimeTextLower?: string
   timeZoneTitle?: string
   timeZoneValueTitle?: string
+  availableRange?: DateRange
   updateCallback?: (data: DateInterval | Date) => void
   lang?: 'en' | 'ja'
 }
@@ -304,6 +317,7 @@ const DatePicker: React.FC<IDatePicker> = ({
   hasEmptyValue = false,
   updateCallback = () => { },
   initialValue,
+  availableRange,
   lang = 'en'
 }) => {
 
@@ -316,6 +330,9 @@ const DatePicker: React.FC<IDatePicker> = ({
   const isInitialMount = useRef(true);
   const [isTimeRangeValid, setIsTimeRangeValid] = useState<boolean>(true);
   const dayGuide = lang === 'ja' ? jpDayGuide : enDayGuide;
+
+  console.log('availableRange', availableRange);
+
 
   useEffect(() => {
     if (isInitialMount.current) {
@@ -432,7 +449,7 @@ const DatePicker: React.FC<IDatePicker> = ({
       <CalendarArea>
         <CalendarHeader>
 
-          <PaginateMonth type='button' onClick={() => setFocusedMonth(addMonths(focusedMonth, -1))}>
+          <PaginateMonth type='button' disabled={isPrevMonthOutOfRange(focusedMonth, availableRange?.start)} onClick={() => setFocusedMonth(addMonths(focusedMonth, -1))}>
             <IconWrap><Icon icon='Left' color='dimmed' size={10} /></IconWrap>
             {format(addMonths(focusedMonth, -1), "MMM", { locale: lang === 'ja' ? ja : enUS })}
           </PaginateMonth>
@@ -442,7 +459,7 @@ const DatePicker: React.FC<IDatePicker> = ({
             {format(focusedMonth, "MMMM", { locale: lang === 'ja' ? ja : enUS })}
           </CurrentMonth>
 
-          <PaginateMonth type='button' onClick={() => setFocusedMonth(addMonths(focusedMonth, 1))}>
+          <PaginateMonth type='button' disabled={isNextMonthOutOfRange(focusedMonth, availableRange?.end)} onClick={() => setFocusedMonth(addMonths(focusedMonth, 1))}>
             {format(addMonths(focusedMonth, 1), "MMM", { locale: lang === 'ja' ? ja : enUS })}
             <IconWrap><Icon icon='Right' color='dimmed' size={10} /></IconWrap>
           </PaginateMonth>
@@ -541,4 +558,30 @@ const getInitialValue = (hasEmptyValue: boolean, initialValue?: Date | DateInter
   const validInitial = initialValue ? initialValue : initializeInterval(startOfDay(new Date()));
 
   return (validInitial instanceof Date) ? initializeInterval(validInitial) : validInitial;
+};
+
+const isPrevMonthOutOfRange = (focusedMonth: Date, startRange: Date | null | undefined) => {
+
+    if(startRange === null || startRange === undefined) {
+      return false;
+    }
+
+    if(focusedMonth.getMonth() <= startRange.getMonth() ) {
+      return true;
+    }
+
+    return false;
+};
+
+const isNextMonthOutOfRange = (focusedMonth: Date, endRange: Date | null | undefined) => {
+
+  if(endRange === null || endRange === undefined) {
+    return false;
+  }
+
+  if(focusedMonth.getMonth() >= endRange.getMonth() ) {
+    return true;
+  }
+
+  return false;
 };

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -262,8 +262,23 @@ const CalCellB = styled(CalCell) <{ thisMonth?: boolean, isToday?: boolean, stat
   `}
 
   &:disabled {
-    color: var(--grey-6) !important;
+    color: var(--grey-6);
     cursor: not-allowed;
+
+    ${({ state }) => (state === 'single' || state === 'start' || state === 'end') && css`
+      color: var(--white-1);
+      background: var(--red-a9);
+    `}
+
+    ${({ state }) => (state === 'inside') && css`
+      color: var(--white-1);
+      background: var(--red-a7);
+      &:nth-child(7n+1), &:nth-child(7n){
+        &::after {
+          background: var(--red-a7);
+        }
+      }
+    `};
   }
 
 `;
@@ -486,7 +501,16 @@ const DatePicker: React.FC<IDatePicker> = ({
             return (
               <CalRow key={index}>
                 {days.map((day, index) => {
-                  return <CalCellB key={index} disabled={isDayOutOfRange(day, availableRange)} onClick={() => onCellClick(day)} state={cellState(day, selectedRange)} thisMonth={isSameMonth(day, focusedMonth)} isToday={isToday(day)}>{format(day, "d")}</CalCellB>;
+                  return (
+                    <CalCellB
+                      key={index}
+                      disabled={isDayOutOfRange(day, availableRange)}
+                      onClick={() => onCellClick(day)}
+                      state={cellState(day, selectedRange)}
+                      thisMonth={isSameMonth(day, focusedMonth)}
+                      isToday={isToday(day)}>{format(day, "d")}
+                    </CalCellB>
+                  );
                 })}
               </CalRow>
             );

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -564,29 +564,38 @@ const getInitialValue = (hasEmptyValue: boolean, initialValue?: Date | DateInter
   return (validInitial instanceof Date) ? initializeInterval(validInitial) : validInitial;
 };
 
-const isPrevMonthOutOfRange = (focusedMonth: Date, availableRange: DateRange | undefined) => {
-  if (!availableRange || !availableRange.start) return false;
+const isPrevMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): boolean => {
+  if (!availableRange?.start) return false;
 
-  if(focusedMonth.getFullYear() < availableRange.start.getFullYear()) {
-    return true;
-  }
+  try {
+    const startYear = availableRange.start.getFullYear();
+    const startMonth = availableRange.start.getMonth();
 
-  if (isSameYear(focusedMonth, availableRange.start) && focusedMonth.getMonth() <= availableRange.start.getMonth()) {
-    return true;
+    if (focusedMonth.getFullYear() < startYear ||
+      (focusedMonth.getFullYear() === startYear && focusedMonth.getMonth() <= startMonth)) {
+      return true;
+    }
+  } catch (error) {
+    console.warn('Invalid available range:', availableRange, error);
   }
 
   return false;
 };
 
-const isNextMonthOutOfRange = (focusedMonth: Date, availableRange: DateRange | undefined) => {
-  if (!availableRange ||!availableRange.end) return false;
 
-  if(focusedMonth.getFullYear() > availableRange.end.getFullYear()) {
-    return true;
-  }
+const isNextMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): boolean => {
+  if (!availableRange?.end) return false;
 
-  if (isSameYear(focusedMonth, availableRange.end) && focusedMonth.getMonth() >= availableRange.end.getMonth()) {
-    return true;
+  try {
+    const endYear = availableRange.end.getFullYear();
+    const endMonth = availableRange.end.getMonth();
+
+    if (focusedMonth.getFullYear() > endYear || isSameYear(focusedMonth, endYear) && focusedMonth.getMonth() >= endMonth) {
+      return true;
+    }
+
+  } catch (error) {
+    console.warn('Invalid available range:', availableRange, error);
   }
 
   return false;
@@ -597,12 +606,16 @@ const isDayOutOfRange = (currentDay: Date, availableRange?: DateRange): boolean 
 
   const { start, end } = availableRange;
 
-  if (start && currentDay < start && !isSameDay(currentDay, start)) {
-    return true;
-  }
+  try {
+    if (start && currentDay < start && !isSameDay(currentDay, start)) {
+      return true;
+    }
 
-  if (end && currentDay > end && !isSameDay(currentDay, end)) {
-    return true;
+    if (end && currentDay > end && !isSameDay(currentDay, end)) {
+      return true;
+    }
+  } catch (error) {
+    console.warn('Invalid available range:', availableRange, error);
   }
 
   return false;

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import Icon from '../../Icons/Icon';
 import DateTimeBlock from '../atoms/DateTimeBlock';
 
-import { format, startOfMonth, endOfMonth, eachDayOfInterval, isAfter, eachWeekOfInterval, addMonths, endOfWeek, intervalToDuration, isSameMonth, isSameDay, isSameYear, isToday, startOfDay, endOfDay, isWithinInterval, set, add, isEqual } from 'date-fns';
+import { format, startOfMonth, endOfMonth, eachDayOfInterval, isAfter, eachWeekOfInterval, addMonths, endOfWeek, intervalToDuration, isSameMonth, isSameDay, isToday, startOfDay, endOfDay, isWithinInterval, set, add, isEqual } from 'date-fns';
 import { ja, enUS } from 'date-fns/locale';
 import { resetButtonStyles } from '../../common';
 
@@ -582,7 +582,6 @@ const isPrevMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): 
   return false;
 };
 
-
 const isNextMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): boolean => {
   if (!availableRange?.end) return false;
 
@@ -590,16 +589,17 @@ const isNextMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): 
     const endYear = availableRange.end.getFullYear();
     const endMonth = availableRange.end.getMonth();
 
-    if (focusedMonth.getFullYear() > endYear || isSameYear(focusedMonth, endYear) && focusedMonth.getMonth() >= endMonth) {
+    if (focusedMonth.getFullYear() > endYear ||
+      (focusedMonth.getFullYear() === endYear && focusedMonth.getMonth() >= endMonth)) {
       return true;
     }
-
   } catch (error) {
     console.warn('Invalid available range:', availableRange, error);
   }
 
   return false;
 };
+
 
 const isDayOutOfRange = (currentDay: Date, availableRange?: DateRange): boolean => {
   if (!availableRange) return false;

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -3,8 +3,9 @@ import styled, { css } from 'styled-components';
 import Icon from '../../Icons/Icon';
 import DateTimeBlock from '../atoms/DateTimeBlock';
 
-import { format, startOfMonth, endOfMonth, eachDayOfInterval, isAfter, eachWeekOfInterval, addMonths, endOfWeek, intervalToDuration, isSameMonth, isSameDay, isToday, startOfDay, endOfDay, isWithinInterval, set, add, isEqual } from 'date-fns';
+import { format, startOfMonth, endOfMonth, eachDayOfInterval, isAfter, eachWeekOfInterval, addMonths, endOfWeek, intervalToDuration, isSameMonth, isSameDay, isSameYear, isToday, startOfDay, endOfDay, isWithinInterval, set, add, isEqual } from 'date-fns';
 import { ja, enUS } from 'date-fns/locale';
+import { resetButtonStyles } from '../../common';
 
 /**
  * Convert a single days duration to an interval.
@@ -173,7 +174,8 @@ const CalHRow = styled(CalRow)`
   border-bottom: var(--grey-6) 1px solid;
 `;
 
-const CalCell = styled.div`
+const CalCell = styled.button`
+  ${resetButtonStyles};
   display: flex;
   text-align: center;
   justify-content: center;
@@ -209,7 +211,7 @@ const CalCellB = styled(CalCell) <{ thisMonth?: boolean, isToday?: boolean, stat
   `}
 
   ${({ state }) => (state !== 'single' && state !== 'start' && state !== 'end') && css`
-    &:hover {
+    &:hover:enabled {
       background: var(--primary-a6);
       color: var(--white-1);
     }
@@ -258,6 +260,11 @@ const CalCellB = styled(CalCell) <{ thisMonth?: boolean, isToday?: boolean, stat
       right: -10px;
     }
   `}
+
+  &:disabled {
+    color: var(--grey-6) !important;
+    cursor: not-allowed;
+  }
 
 `;
 
@@ -330,9 +337,6 @@ const DatePicker: React.FC<IDatePicker> = ({
   const isInitialMount = useRef(true);
   const [isTimeRangeValid, setIsTimeRangeValid] = useState<boolean>(true);
   const dayGuide = lang === 'ja' ? jpDayGuide : enDayGuide;
-
-  console.log('availableRange', availableRange);
-
 
   useEffect(() => {
     if (isInitialMount.current) {
@@ -407,10 +411,10 @@ const DatePicker: React.FC<IDatePicker> = ({
   useEffect(() => {
     const { start, end } = selectedRange ? selectedRange : TODAY_INTERVAL;
 
-    if((timeMode ==='interval' && isAfter(add(start, { minutes: 1 }), end))){
-      if(isEqual(end, endOfDay(start)) && end.getSeconds() > 0) { // Midnight exception
+    if ((timeMode === 'interval' && isAfter(add(start, { minutes: 1 }), end))) {
+      if (isEqual(end, endOfDay(start)) && end.getSeconds() > 0) { // Midnight exception
         setIsTimeRangeValid(true);
-      }else {
+      } else {
         setIsTimeRangeValid(false);
       }
 
@@ -418,7 +422,7 @@ const DatePicker: React.FC<IDatePicker> = ({
       setIsTimeRangeValid(true);
     }
 
-  },[selectedRange, timeMode]);
+  }, [selectedRange, timeMode]);
 
   const updateStartDate = useCallback((start: Date) => {
     const { end } = selectedRange ? selectedRange : TODAY_INTERVAL;
@@ -436,8 +440,8 @@ const DatePicker: React.FC<IDatePicker> = ({
     <Container>
 
       <DateTimeArea>
-        <DateTimeBlock {...{isTimeRangeValid}} title={dateTimeTextUpper} hasDate hasTime={timeMode !== 'off'} date={selectedRange ? selectedRange.start : TODAY_INTERVAL.start} setDateCallback={updateStartDate} />
-        <DateTimeBlock {...{isTimeRangeValid}} title={dateTimeTextLower} hasDate={dateMode === 'interval'} hasTime={timeMode === 'interval'} date={selectedRange ? selectedRange.end : TODAY_INTERVAL.end} allowAfterMidnight setDateCallback={updateEndDate} />
+        <DateTimeBlock {...{ isTimeRangeValid }} title={dateTimeTextUpper} hasDate hasTime={timeMode !== 'off'} date={selectedRange ? selectedRange.start : TODAY_INTERVAL.start} setDateCallback={updateStartDate} />
+        <DateTimeBlock {...{ isTimeRangeValid }} title={dateTimeTextLower} hasDate={dateMode === 'interval'} hasTime={timeMode === 'interval'} date={selectedRange ? selectedRange.end : TODAY_INTERVAL.end} allowAfterMidnight setDateCallback={updateEndDate} />
 
         <TimeZoneOption>
           <TimeZoneLabel>{timeZoneTitle}</TimeZoneLabel>
@@ -449,7 +453,7 @@ const DatePicker: React.FC<IDatePicker> = ({
       <CalendarArea>
         <CalendarHeader>
 
-          <PaginateMonth type='button' disabled={isPrevMonthOutOfRange(focusedMonth, availableRange?.start)} onClick={() => setFocusedMonth(addMonths(focusedMonth, -1))}>
+          <PaginateMonth type='button' disabled={isPrevMonthOutOfRange(focusedMonth, availableRange)} onClick={() => setFocusedMonth(addMonths(focusedMonth, -1))}>
             <IconWrap><Icon icon='Left' color='dimmed' size={10} /></IconWrap>
             {format(addMonths(focusedMonth, -1), "MMM", { locale: lang === 'ja' ? ja : enUS })}
           </PaginateMonth>
@@ -459,7 +463,7 @@ const DatePicker: React.FC<IDatePicker> = ({
             {format(focusedMonth, "MMMM", { locale: lang === 'ja' ? ja : enUS })}
           </CurrentMonth>
 
-          <PaginateMonth type='button' disabled={isNextMonthOutOfRange(focusedMonth, availableRange?.end)} onClick={() => setFocusedMonth(addMonths(focusedMonth, 1))}>
+          <PaginateMonth type='button' disabled={isNextMonthOutOfRange(focusedMonth, availableRange)} onClick={() => setFocusedMonth(addMonths(focusedMonth, 1))}>
             {format(addMonths(focusedMonth, 1), "MMM", { locale: lang === 'ja' ? ja : enUS })}
             <IconWrap><Icon icon='Right' color='dimmed' size={10} /></IconWrap>
           </PaginateMonth>
@@ -482,7 +486,7 @@ const DatePicker: React.FC<IDatePicker> = ({
             return (
               <CalRow key={index}>
                 {days.map((day, index) => {
-                  return <CalCellB key={index} onClick={() => onCellClick(day)} state={cellState(day, selectedRange)} thisMonth={isSameMonth(day, focusedMonth)} isToday={isToday(day)}>{format(day, "d")}</CalCellB>;
+                  return <CalCellB key={index} disabled={isDayOutOfRange(day, availableRange)} onClick={() => onCellClick(day)} state={cellState(day, selectedRange)} thisMonth={isSameMonth(day, focusedMonth)} isToday={isToday(day)}>{format(day, "d")}</CalCellB>;
                 })}
               </CalRow>
             );
@@ -560,26 +564,44 @@ const getInitialValue = (hasEmptyValue: boolean, initialValue?: Date | DateInter
   return (validInitial instanceof Date) ? initializeInterval(validInitial) : validInitial;
 };
 
-const isPrevMonthOutOfRange = (focusedMonth: Date, startRange: Date | null | undefined) => {
+const isPrevMonthOutOfRange = (focusedMonth: Date, availableRange: DateRange | undefined) => {
+  if (!availableRange || !availableRange.start) return false;
 
-    if(startRange === null || startRange === undefined) {
-      return false;
-    }
-
-    if(focusedMonth.getMonth() <= startRange.getMonth() ) {
-      return true;
-    }
-
-    return false;
-};
-
-const isNextMonthOutOfRange = (focusedMonth: Date, endRange: Date | null | undefined) => {
-
-  if(endRange === null || endRange === undefined) {
-    return false;
+  if(focusedMonth.getFullYear() < availableRange.start.getFullYear()) {
+    return true;
   }
 
-  if(focusedMonth.getMonth() >= endRange.getMonth() ) {
+  if (isSameYear(focusedMonth, availableRange.start) && focusedMonth.getMonth() <= availableRange.start.getMonth()) {
+    return true;
+  }
+
+  return false;
+};
+
+const isNextMonthOutOfRange = (focusedMonth: Date, availableRange: DateRange | undefined) => {
+  if (!availableRange ||!availableRange.end) return false;
+
+  if(focusedMonth.getFullYear() > availableRange.end.getFullYear()) {
+    return true;
+  }
+
+  if (isSameYear(focusedMonth, availableRange.end) && focusedMonth.getMonth() >= availableRange.end.getMonth()) {
+    return true;
+  }
+
+  return false;
+};
+
+const isDayOutOfRange = (currentDay: Date, availableRange?: DateRange): boolean => {
+  if (!availableRange) return false;
+
+  const { start, end } = availableRange;
+
+  if (start && currentDay < start && !isSameDay(currentDay, start)) {
+    return true;
+  }
+
+  if (end && currentDay > end && !isSameDay(currentDay, end)) {
     return true;
   }
 

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -57,6 +57,7 @@ import {
   DatePicker,
   DateInterval,
   isDateInterval,
+  DateRange,
   IFilterDatePicker,
   FilterDropdownContainer,
   FilterButton,
@@ -417,5 +418,6 @@ export type {
   ISplitLayoutHandles,
   AlertType,
   ITooltipType,
-  FilterButtonDesign
+  FilterButtonDesign,
+  DateRange
 };


### PR DESCRIPTION
### Description

This PR introduces the ability to restrict the selectable date range in the Date Picker component as requested.

```
The date picker needs two additional props:

- Upper selectable date limit
- Lower selectable date limit

`In the DatePicker UI this will restrict` the selectable date range with dates outside that range being un-selectable. This feature is only required for date and not for time ranges.

As a stretch goal, if there is time please also consider adding the following options:

- Only future dates selectable (today and onward)
*This would be for use cases such as scheduling a task.*
- Only past dates selectable (today and past)
*The use case for this is commonly viewing data logs.*
```

 ### Considerations on Implementation
 
To enable this functionality, a new optional prop, `availableRange`, of type `DateRange`, has been added.

The `DateRange` interface is similar to `DateInterval`, as both include a start and end date. However, DateRange allows either start or end to be set to null, providing more flexibility for scenarios without strict date limits.

Only future dates selectable : Set the `start` date to today’s date and `end` to `null`.
Only past dates selectable: Set `start` to `null` and `end` to today’s date.

[Design](https://www.figma.com/design/5pU39qhggEXCHM5uVl7Sr5/SCORER---UI-Kit-Library?node-id=3271-28053&m=dev) updates from Figma


Disabled Previous and Next Month :  0.5 opacity  and show cursor: not-allowed;
Disabled Days: Color is grey-6 and show cursor: not-allowed, will not change background when hovered.


Disabled selected range updated

![Screenshot 2024-11-12 at 15 32 21](https://github.com/user-attachments/assets/e84b91d2-ebbc-4234-9b83-915283fb8507)


 ### Reviewing/Testing steps

 Run storybook on local Filters -> Molecules -> DatePicker
 
 Check select the prop: Send Available Range
 Update prop:  Available Range
 
These scenarios to disable parts of the DatePicker component were considered and tested during implementation:
 
- Validate Months caring for different Years.
- Validate Previous Month
- Validate Next Month
- Validate days inside range

 