### PR TITLE
Add Toggle Button with Story

### DIFF
--- a/packages/storybook/src/stories/Filters/atoms/ToggleButton.stories.tsx
+++ b/packages/storybook/src/stories/Filters/atoms/ToggleButton.stories.tsx
@@ -1,0 +1,120 @@
+import React, { useCallback, useState } from "react";
+import { ToggleButton } from "scorer-ui-kit";
+import { boolean, object, select, text } from "@storybook/addon-knobs";
+import { action } from "@storybook/addon-actions";
+import styled from "styled-components";
+
+export default {
+  title: 'Filters/atoms',
+  component: ToggleButton,
+  decorators: []
+};
+
+const layoutOptions = [
+  { text: 'Grid', value: 'grid', icon: 'LayoutGrid' },
+  { text: 'List', value: 'list', icon: 'LayoutList' }
+]
+
+const CameraData = styled.div``;
+const Camera = styled.li``;
+
+const Container = styled.div``;
+const DataGroup = styled.ol<{ layout: string }>`
+  margin-top: 20px;
+  display: grid;
+  ${({ layout }) => layout === 'grid' &&
+    `
+      list-style-type: none;
+      grid-template-columns: repeat(4, 300px);
+      gap: 16px;
+        ${Camera} {
+          padding: 100px 20px;
+          border: 1px solid var(--grey-9);
+          text-align: center;
+        }
+    `
+  };
+`;
+
+const StatusSpan = styled.span<{ isOnline?: boolean }>`
+    ${({ isOnline }) => isOnline ?
+    `
+      color: var(--success);
+    `
+    :
+    `
+      color: var(--warning);
+    `}
+  `;
+
+export const _ToggleButton = () => {
+  const [selectedLayout, setSelectedLayout] = useState(0)
+
+  const disabled = boolean('Disabled', false);
+  const design = select('Design type', { Default: 'default', Basic: 'basic' }, 'default');
+  const categoryLabel = text('Category Label', 'Layout:');
+  const options = object('Options', layoutOptions);
+  const showToggleValue = action('Button Value: ');
+
+  const onToggle = useCallback((index: number, value: string | number) => {
+    setSelectedLayout(index);
+    showToggleValue(value);
+  }, [showToggleValue])
+
+  return (
+    <Container>
+      <ToggleButton
+        {...{
+          categoryLabel,
+          options,
+          onToggle,
+          disabled,
+          design,
+          selectedIndex: selectedLayout
+        }} />
+
+      <DataGroup layout={layoutOptions[selectedLayout].value}>
+        <Camera>
+          <CameraData>
+            Camera01 - <StatusSpan isOnline>Online</StatusSpan>
+          </CameraData>
+        </Camera>
+        <Camera>
+          <CameraData>
+            Camera02 - <StatusSpan isOnline>Online</StatusSpan>
+          </CameraData>
+        </Camera>
+        <Camera>
+          <CameraData>
+            Camera03 - <StatusSpan>OffLine</StatusSpan>
+          </CameraData>
+        </Camera>
+        <Camera>
+          <CameraData>
+            Camera04 - <StatusSpan>OffLine</StatusSpan>
+          </CameraData>
+        </Camera>
+        <Camera>
+          <CameraData>
+            Camera05 - <StatusSpan>OffLine</StatusSpan>
+          </CameraData>
+        </Camera>
+        <Camera>
+          <CameraData>
+            Camera06 - <StatusSpan>OffLine</StatusSpan>
+          </CameraData>
+        </Camera>
+        <Camera>
+          <CameraData>
+            Camera07 - <StatusSpan isOnline>Online</StatusSpan>
+          </CameraData>
+        </Camera>
+        <Camera>
+          <CameraData>
+            Camera08 - <StatusSpan isOnline>Online</StatusSpan>
+          </CameraData>
+        </Camera>
+      </DataGroup>
+    </Container>
+  )
+}

--- a/packages/storybook/src/stories/Filters/atoms/ToggleButton.stories.tsx
+++ b/packages/storybook/src/stories/Filters/atoms/ToggleButton.stories.tsx
@@ -25,7 +25,7 @@ const DataGroup = styled.ol<{ layout: string }>`
   ${({ layout }) => layout === 'grid' &&
     `
       list-style-type: none;
-      grid-template-columns: repeat(4, 300px);
+      grid-template-columns: repeat(3, 300px);
       gap: 16px;
         ${Camera} {
           padding: 100px 20px;
@@ -112,6 +112,11 @@ export const _ToggleButton = () => {
         <Camera>
           <CameraData>
             Camera08 - <StatusSpan isOnline>Online</StatusSpan>
+          </CameraData>
+        </Camera>
+        <Camera>
+          <CameraData>
+            Camera09 - <StatusSpan>Online</StatusSpan>
           </CameraData>
         </Camera>
       </DataGroup>

--- a/packages/ui-lib/src/Filters/FilterTypes.ts
+++ b/packages/ui-lib/src/Filters/FilterTypes.ts
@@ -7,6 +7,7 @@ import { IFilterDropdown } from './molecules/FilterDropdown';
 type IFilterItem = { text: string; value: string | number; }
 type IFilterValue = IFilterItem | IFilterItem[] | null;
 type IFilterType = 'search' | 'dropdown' | 'datepicker';
+type IToggleOption = { text: string; value: string | number; icon: string }
 
 // Type checking for IFilterItem
 // https://stackoverflow.com/questions/14425568/interface-type-check-with-typescript
@@ -78,5 +79,6 @@ export type {
   ISearchFilter,
   IFilterDropdownExt,
   IFilterDatePicker,
-  IFilterDropdownConfig
+  IFilterDropdownConfig,
+  IToggleOption,
 };

--- a/packages/ui-lib/src/Filters/atoms/FilterButton.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterButton.tsx
@@ -66,18 +66,18 @@ const StyledButton = styled.button<{ isOpen?: boolean, hasFlipArrow?: boolean, d
 
   &:hover:enabled, &:active:enabled {
     color: var(--grey-12);
-    
+
     ${({design}) => design === 'basic'? '' : css`
       box-shadow: 0px 4px 9px 0px var(--primary-a2);
       border-color: var(--primary-7);
     `};
-    
+
     ${IconWrapper} {
       [stroke]{
         stroke: var(--primary-9);
       }
     }
-    
+
     ${({isOpen}) => !isOpen && css`
       ${FlipArrowContainer} ${IconWrapper} {
         [stroke]{
@@ -85,7 +85,7 @@ const StyledButton = styled.button<{ isOpen?: boolean, hasFlipArrow?: boolean, d
         }
       };
     `};
-      
+
   }
 
   &:disabled {
@@ -106,7 +106,7 @@ const StyledButton = styled.button<{ isOpen?: boolean, hasFlipArrow?: boolean, d
         }
       }
     }
-    
+
     ${FlipArrowContainer} ${IconWrapper} {
       [stroke]{
         stroke: var(--white-1);
@@ -159,9 +159,9 @@ const FilterButton: React.FC<IFilterButton> = ({
           />
         </FlipWrapper>
         <ButtonText {...{ hasFlipArrow }}>{children}</ButtonText>
-        
+
           {hasFlipArrow && <FlipArrowContainer><Icon icon={isOpen ? 'Up' : 'Down'} size={6} color='grey-11' /></FlipArrowContainer>}
-        
+
       </InnerContainer>
     </StyledButton>
   );

--- a/packages/ui-lib/src/Filters/atoms/ToggleButton.tsx
+++ b/packages/ui-lib/src/Filters/atoms/ToggleButton.tsx
@@ -1,0 +1,29 @@
+import React, { useCallback } from 'react';
+import { IToggleOption } from '../FilterTypes';
+import FilterButton from './FilterButton';
+
+type IToggleButton = {
+  options: IToggleOption[]
+  categoryLabel: String
+  selectedIndex: number
+  onToggle: (index: number, value: string | number) => void
+}
+
+const ToggleButton: React.FC<IToggleButton> = ({ options, categoryLabel, selectedIndex, onToggle, ...props }) => {
+
+  const onToggleCallback = useCallback((currentIndex: number) => {
+    const selected = currentIndex === 1 ? 0 : 1;
+    onToggle(selected, options[selected].value);
+
+  }, [onToggle, options]);
+
+  if (selectedIndex !== 0 && selectedIndex !== 1) return null;
+
+  return (
+    <FilterButton icon={options[selectedIndex].icon} onClick={() => onToggleCallback(selectedIndex)}{...props}>
+      {`${categoryLabel} : ${options[selectedIndex].text}`}
+    </FilterButton>
+  );
+};
+
+export default ToggleButton;

--- a/packages/ui-lib/src/Filters/index.ts
+++ b/packages/ui-lib/src/Filters/index.ts
@@ -7,6 +7,8 @@ import FilterLayout from './molecules/FilterLayout';
 import FilterInputs, { IFilterInputs } from './molecules/FilterInputs';
 import FiltersResults, { IFilterLabel } from './molecules/FiltersResults';
 import FilterBar from './organisms/FilterBar';
+import ToggleButton from './atoms/ToggleButton';
+
 import {
   IFilterType,
   IFilterItem,
@@ -17,6 +19,7 @@ import {
   IFilterDropdownConfig,
   IFilterDatePicker,
   isFilterItem,
+  IToggleOption,
 } from './FilterTypes';
 
 export {
@@ -31,6 +34,7 @@ export {
   FilterBar,
   isFilterItem,
   isDateInterval,
+  ToggleButton
 };
 
 type FilterButtonDesign = 'default' | 'basic'
@@ -47,5 +51,6 @@ export type {
   IFilterValue,
   DateInterval,
   IFilterDatePicker,
-  FilterButtonDesign
+  FilterButtonDesign,
+  IToggleOption
 };

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -75,7 +75,9 @@ import {
   IFilterValue,
   IFilterResult,
   isFilterItem,
-  FilterButtonDesign
+  FilterButtonDesign,
+  ToggleButton,
+  IToggleOption
 } from './Filters';
 
 import Icon, { IconSVGs } from './Icons/Icon';
@@ -278,6 +280,7 @@ export {
   FilterInputs,
   FiltersResults,
   FilterBar,
+  ToggleButton,
   isFilterItem,
   isDateInterval,
 
@@ -417,5 +420,6 @@ export type {
   ISplitLayoutHandles,
   AlertType,
   ITooltipType,
-  FilterButtonDesign
+  FilterButtonDesign,
+  IToggleOption
 };


### PR DESCRIPTION
### Description

This PR is a request to have a button with 2 states with the  design of the filter button.

```
This is primarily for the use of alternating between grid and list views using the button in filter bar pattern. As it often just changes between one of two values, it is quicker instead to toggle instead of opening the dropdown.

We may wish to use this same button for other dual state options, such as showing annotations on thumbnails so we should have text and icons for both the A and B states.
```

 ### Considerations on Implementation

This ToggleButton is just a wrapper of the FilterButton using the IToggleOption[] values to create it.

 ### Reviewing/Testing steps
Review on Storybook on Filters -> Atoms -> FilterButton

<img width="816" alt="Screenshot 2024-11-11 at 15 04 00" src="https://github.com/user-attachments/assets/fe2a66bc-a637-4167-b0cf-f375e5c09e32"> 

<img width="1290" alt="Screenshot 2024-11-11 at 15 03 25" src="https://github.com/user-attachments/assets/ea782f0b-dfb1-4aa8-bee1-c878e609f1ca">
