### PR TITLE
Switch Update and Refactor (with changes to Label and Spinner)

### DIFF
--- a/packages/storybook/src/stories/Indicators/Spinner.stories.tsx
+++ b/packages/storybook/src/stories/Indicators/Spinner.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {  select } from "@storybook/addon-knobs";
+import { select, text, number } from "@storybook/addon-knobs";
 import styled from 'styled-components';
 import {Spinner} from 'scorer-ui-kit';
 
@@ -9,36 +9,26 @@ export default {
   decorators: []
 };
 
-const containerBackgroundKey = (styling: string)  => {
-  switch(styling){
-    case 'primary':
-      return 'info';
-    case 'secondary':
-      return 'neutral';
-    case 'danger':
-      return 'error';
-    default:
-      return 'neutral';
-  }
-};
-
 const Container = styled.div<{styling: string}>`
-  padding: 12px 24px;
-  width: 100px;
   border-radius: 3px;
-
-  margin: 15% auto;
-  display:flex;
+  height: calc(100vh - 2rem);
+  display: flex;
   justify-content:center;
   align-items:center;
-  ${({styling}) => `background-color: var(--${containerBackgroundKey(styling)})` };
+  ${({styling}) => `background-color: var(--${styling}-9)` };
 `;
 
 export const LoadingSpinner = () => {
   const spinnerSize = select("Size", { Small: "small", Medium: "medium", Large: "large", XLarge: "xlarge" }, "medium");
-  const spinnerType = select("Style", { Primary: "primary", Secondary: "secondary", Danger: "danger" }, "primary");
+  const spinnerType = select("Style", { Primary: "primary", Secondary: "grey", Warning: "warning" }, "primary");
+  const customSize = number("Custom Size", 0);
+  const customBaseColor = text("Custom Base Color", "");
+  const customTopColor = text("Custom Top Color", "");
+
+  const baseColor = customBaseColor !== '' ? customBaseColor : undefined;
+  const topColor = customTopColor !== '' ? customTopColor : undefined;
 
   return <Container styling={spinnerType}>
-    <Spinner size={spinnerSize} styling={spinnerType} />
+    <Spinner size={spinnerSize} styling={spinnerType} custom={{ size: customSize, ...{ baseColor, topColor } }} />
   </Container>;
 };

--- a/packages/storybook/src/stories/Indicators/Spinner.stories.tsx
+++ b/packages/storybook/src/stories/Indicators/Spinner.stories.tsx
@@ -25,10 +25,14 @@ export const LoadingSpinner = () => {
   const customBaseColor = text("Custom Base Color", "");
   const customTopColor = text("Custom Top Color", "");
 
-  const baseColor = customBaseColor !== '' ? customBaseColor : undefined;
-  const topColor = customTopColor !== '' ? customTopColor : undefined;
+  let baseColor = customBaseColor !== '' ? customBaseColor : undefined;
+  let topColor = customTopColor !== '' ? customTopColor : undefined;
 
-  return <Container styling={spinnerType}>
+  // Fixes issue if story breaks when typing an open bracket for var()
+  baseColor = customBaseColor.indexOf('(') !== -1 && customBaseColor.indexOf(')') === -1 ? customBaseColor + ')' : customBaseColor;
+  topColor = customTopColor.indexOf('(') !== -1 && customTopColor.indexOf(')') === -1 ? customTopColor + ')' : customTopColor;
+
+  return <Container styling={spinnerType}>{baseColor}
     <Spinner size={spinnerSize} styling={spinnerType} custom={{ size: customSize, ...{ baseColor, topColor } }} />
   </Container>;
 };

--- a/packages/storybook/src/stories/Indicators/Spinner.stories.tsx
+++ b/packages/storybook/src/stories/Indicators/Spinner.stories.tsx
@@ -32,7 +32,7 @@ export const LoadingSpinner = () => {
   baseColor = customBaseColor.indexOf('(') !== -1 && customBaseColor.indexOf(')') === -1 ? customBaseColor + ')' : customBaseColor;
   topColor = customTopColor.indexOf('(') !== -1 && customTopColor.indexOf(')') === -1 ? customTopColor + ')' : customTopColor;
 
-  return <Container styling={spinnerType}>{baseColor}
+  return <Container styling={spinnerType}>
     <Spinner size={spinnerSize} styling={spinnerType} custom={{ size: customSize, ...{ baseColor, topColor } }} />
   </Container>;
 };

--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -1,11 +1,11 @@
 import React, { LabelHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 
-export const StyledLabel = styled.label<{ rightAlign: boolean }>`
-  font-family: ${({ theme }) => theme.fontFamily.ui};
-  color: var(--grey-11);
-  font-size: 14px;
-  font-weight: 500;
+export const StyledLabel = styled.label<{ rightAlign?: boolean }>`
+  font-family: var(--label-font);
+  color: var(--label-color);
+  font-size: var(--label-font-size);
+  font-weight: var(--label-weight);
   ${({ rightAlign }) => rightAlign
     ? `
         display: flex;

--- a/packages/ui-lib/src/Form/atoms/SplitButtonOption.tsx
+++ b/packages/ui-lib/src/Form/atoms/SplitButtonOption.tsx
@@ -1,7 +1,7 @@
-import React, { ButtonHTMLAttributes, FC, useCallback,useState } from 'react';
+import React, { ButtonHTMLAttributes, FC, useCallback, useState, useEffect, useRef } from 'react';
 import styled, { css } from 'styled-components';
 import Icon, { IconWrapper } from '../../Icons/Icon';
-import Spinner, { buttonSpinnerSize } from '../../Indicators/Spinner';
+import Spinner from '../../Indicators/Spinner';
 import { resetButtonStyles } from '../../common';
 import { TypeButtonDesigns, TypeButtonSizes } from '..';
 
@@ -131,7 +131,9 @@ const SplitButtonOption : FC<ISplitButtonOption> = ({
   ...props
 }) => {
 
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [ iconSize, setIconSize ] = useState<number>(0);
 
   const handleClick = useCallback(() => {
 
@@ -152,12 +154,16 @@ const SplitButtonOption : FC<ISplitButtonOption> = ({
 
   },[closeCallback, hasOnSelectLoading, onClickCallback]);
 
-
+  useEffect(() => {
+    if(buttonRef.current){
+      setIconSize( parseInt( getComputedStyle(buttonRef.current).getPropertyValue('--button-icon-size') ));
+    }
+  }, [buttonRef]);
 
   return(
-    <StyledButton {...{noBorderTop}} onClick={handleClick} {...props}>
+    <StyledButton ref={buttonRef} {...{noBorderTop, size}} onClick={handleClick} {...props}>
       <LeftIconWrapper isAscendingIcon={icon === 'FilterAscending'} >
-        {isLoading ? <Spinner size={buttonSpinnerSize(size)} styling={design} /> : <Icon icon={icon} />}
+        {isLoading ? <Spinner custom={{size: iconSize}} styling={design} /> : <Icon icon={icon} />}
       </LeftIconWrapper>
       <TextWrapper {...{textMaxWidth}}><OptionText>{text}</OptionText></TextWrapper>
     </StyledButton>

--- a/packages/ui-lib/src/Form/atoms/Switch.tsx
+++ b/packages/ui-lib/src/Form/atoms/Switch.tsx
@@ -3,6 +3,8 @@ import styled, { css } from 'styled-components';
 
 import Icon from '../../Icons/Icon';
 import Spinner from '../../Indicators/Spinner';
+import { StyledLabel } from './Label';
+
 
 enum SwitchPosition {
   Off = 0,
@@ -82,17 +84,7 @@ const SwitchInner = styled.div<{ position: 'off' | 'on' | 'neutral'| 'locked'}>`
     0px -1px 1px 0px var(--black-a5) inset;
 `;
 
-const LabelText = styled.span`
-  font-family: var(--font-ui);
-
-  flex: 1;
-  margin-left: 10px;
-  display: block;
-
-  line-height: ${ p => p.theme.dimensions.form.switch.outer.height };
-
-  ${ p => p.theme.typography.form.input.label };
-`;
+const LabelText = styled.span``;
 
 const IconWrapper = styled.div`
   position: absolute;
@@ -107,9 +99,11 @@ const IconWrapper = styled.div`
 `;
 const SpinnerWrapper = styled.div``;
 
-const Container = styled.label<{activeTheming: string, $loading: boolean, useIntent: boolean, themeState: string, position: SwitchPosition, checked?: boolean}>`
+const Container = styled(StyledLabel)<{activeTheming: string, $loading: boolean, useIntent: boolean, themeState: string, position: SwitchPosition, checked?: boolean}>`
   user-select: none;
-  display: flex;
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
   
   ${SwitchOuter}{
     ${({activeTheming, themeState}) => css`

--- a/packages/ui-lib/src/Form/atoms/Switch.tsx
+++ b/packages/ui-lib/src/Form/atoms/Switch.tsx
@@ -150,7 +150,6 @@ const Container = styled(StyledLabel)<{activeTheming: string, $loading: boolean,
 
     ${({ activeTheming }) => activeTheming === 'failure' && css`
       background-color: var(--switch-special-failure-inner);
-      box-shadow: none;
     `}
 
     ${({activeTheming, $loading}) => $loading && css`

--- a/packages/ui-lib/src/Form/atoms/Switch.tsx
+++ b/packages/ui-lib/src/Form/atoms/Switch.tsx
@@ -46,10 +46,10 @@ const SwitchOuter = styled.div`
     content: '';
     display: block;
     position: absolute;
-    top: -var(--switch-border-width);
-    left: -var(--switch-border-width);
-    bottom: -var(--switch-border-width);
-    right: -var(--switch-border-width);
+    top: calc(var(--switch-border-width) * -1);
+    left: calc(var(--switch-border-width) * -1);
+    bottom: calc(var(--switch-border-width) * -1);
+    right: calc(var(--switch-border-width) * -1);
     pointer-events: none;
     border-radius: 12px;
     box-shadow: 

--- a/packages/ui-lib/src/Form/atoms/Switch.tsx
+++ b/packages/ui-lib/src/Form/atoms/Switch.tsx
@@ -116,6 +116,11 @@ const Container = styled(StyledLabel)<{activeTheming: string, $loading: boolean,
       border-color: var(--switch-special-locked-border);
     `};
 
+    ${({ activeTheming }) => activeTheming === 'failure' && css`
+      background-color: var(--switch-special-failure-background);
+      border-color: var(--switch-special-failure-border);
+    `};
+
     ${({activeTheming, $loading}) => $loading && css`
       background-color: var(--switch-default-${activeTheming}-background);
       border-color: var(--switch-default-${activeTheming}-border);
@@ -141,6 +146,11 @@ const Container = styled(StyledLabel)<{activeTheming: string, $loading: boolean,
       ${IconWrapper} svg {
         transform: translateX(-1px);
       }
+    `}
+
+    ${({ activeTheming }) => activeTheming === 'failure' && css`
+      background-color: var(--switch-special-failure-inner);
+      box-shadow: none;
     `}
 
     ${({activeTheming, $loading}) => $loading && css`

--- a/packages/ui-lib/src/Form/atoms/Switch.tsx
+++ b/packages/ui-lib/src/Form/atoms/Switch.tsx
@@ -13,7 +13,9 @@ enum SwitchPosition {
   Locked = 3
 }
 
-const getPositionKey = (switchPos : SwitchPosition) => {
+type PositionKey = 'off' | 'on' | 'neutral' | 'locked';
+
+const getPositionKey = (switchPos : SwitchPosition) : PositionKey => {
   switch (switchPos) {
     case SwitchPosition.Off:
       return 'off';
@@ -60,7 +62,7 @@ const SwitchOuter = styled.div`
   }
 `;
 
-const SwitchInner = styled.div<{ position: 'off' | 'on' | 'neutral'| 'locked'}>`
+const SwitchInner = styled.div<{ position: PositionKey}>`
   --offset: calc(((var(--switch-height) - var(--switch-inner-size)) / 2) - var(--switch-border-width));
   --position-off: var(--offset);
   --position-on: calc(var(--switch-width) - var(--switch-inner-size) - (var(--switch-border-width)*2) - var(--offset));

--- a/packages/ui-lib/src/Form/atoms/Switch.tsx
+++ b/packages/ui-lib/src/Form/atoms/Switch.tsx
@@ -49,7 +49,7 @@ const SwitchInner = styled.div`
 `;
 
 const LabelText = styled.span`
-  font-family: ${({theme}) => theme.fontFamily.ui };
+  font-family: var(--font-ui);
 
   flex: 1;
   margin-left: 10px;
@@ -85,9 +85,9 @@ const Container = styled.label<{activeTheming: string, $loading: boolean, useInt
       left: ${theme.dimensions.form.switch.positions[getPositionKey(position)]};
       top: ${theme.dimensions.form.switch.positions.top};
       transition:
-        left ${theme.animation.speed.normal} ${theme.animation.easing.primary.out},
-        border ${theme.animation.speed.normal} ${theme.animation.easing.primary.out},
-        width ${theme.animation.speed.normal} ${theme.animation.easing.primary.out};
+        left var(--speed-normal) var(--easing-primary-in-out),
+        border var(--speed-normal) var(--easing-primary-in-out),
+        width var(--speed-normal) var(--easing-primary-in-out);
 
       ${theme.styles.form.switch[activeTheming][themeState].inner}
     `}

--- a/packages/ui-lib/src/Form/atoms/Switch.tsx
+++ b/packages/ui-lib/src/Form/atoms/Switch.tsx
@@ -116,6 +116,17 @@ const Container = styled.label<{activeTheming: string, $loading: boolean, useInt
       border-color: var(--switch-${themeState}-${activeTheming}-border);
       background-color: var(--switch-${themeState}-${activeTheming}-background);
     `};
+  
+    ${({ activeTheming }) => activeTheming === 'locked' && css`
+      background-color: var(--switch-special-locked-background);
+      border-color: var(--switch-special-locked-border);
+    `};
+
+    ${({activeTheming, $loading}) => $loading && css`
+      background-color: var(--switch-default-${activeTheming}-background);
+      border-color: var(--switch-default-${activeTheming}-border);
+    `};
+
   }
 
   ${SwitchInner}{
@@ -128,15 +139,21 @@ const Container = styled.label<{activeTheming: string, $loading: boolean, useInt
       border var(--speed-fast) var(--easing-primary-in-out),
       width var(--speed-fast) var(--easing-primary-in-out);
 
-    /* 
-    ${p => p.activeTheming === 'locked' && css`
-      width: calc(100% - ${parseInt(p.theme.dimensions.form.switch.positions.locked) * 2}px);
+    ${({ activeTheming }) => activeTheming === 'locked' && css`
+      width: calc(100% - var(--switch-border-width));
+      background-color: var(--switch-special-locked-inner);
+      box-shadow: none;
+
+      ${IconWrapper} svg {
+        transform: translateX(-1px);
+      }
     `}
 
-    ${p => p.$loading && css`
-      background: transparent;
-      top: 1px;
-    `} */
+    ${({activeTheming, $loading}) => $loading && css`
+      border-color: var(--switch-default-${activeTheming}-inner);
+      box-shadow: none;
+    `};
+    
   }
 
   &:hover {
@@ -181,9 +198,6 @@ const Switch : React.FC<IProps> = ({ state = 'default', leftTheme = 'off', right
   const [ switchState, setSwitchState ] = useState<TypeSwitchState>('default');
   const [ justUpdated, setJustUpdated ] = useState<boolean>(false);
   const [ innerSize, setInnerSize ] = useState<number>(0);
-
-  // innerRef.current && parseInt( getComputedStyle(innerRef.current).getPropertyValue('--switch-inner-size') );
-
 
   useEffect(() => {
     setPosition(checked ? SwitchPosition.On : SwitchPosition.Off);
@@ -252,13 +266,12 @@ const Switch : React.FC<IProps> = ({ state = 'default', leftTheme = 'off', right
   }, [innerRef]);
 
   
-
   return (
     <Container onChange={customOnChange} onMouseLeave={ () => setJustUpdated(false) } activeTheming={activeTheming} $loading={state === 'loading'} useIntent={ !justUpdated && (state === 'default' || state === 'failure')} themeState={switchState} position={position} checked={inputRef.current?.checked}>
       <SwitchOuter>
         <SwitchInner position={getPositionKey(position)} ref={innerRef}>
           {state === 'failure' ? <IconWrapper><Icon icon='Exclamation' color='danger' size={18} weight='regular' /></IconWrapper> : null}
-          {state === 'locked' ? <IconWrapper><Icon icon='Locked' color='dimmed' size={10} weight='light' /></IconWrapper> : null}
+          {state === 'locked' ? <IconWrapper><Icon icon='Locked' color='switch-special-locked-icon' size={12} weight='regular' /></IconWrapper> : null}
           {state === 'loading' && innerSize > 0 ? <SpinnerWrapper><Spinner styling='simple' custom={{ size: innerSize }} /></SpinnerWrapper> : null}
         </SwitchInner>
       </SwitchOuter>

--- a/packages/ui-lib/src/Indicators/Spinner.tsx
+++ b/packages/ui-lib/src/Indicators/Spinner.tsx
@@ -31,13 +31,13 @@ const rotate = keyframes`
   }
 `;
 
-const BaseCircle = styled.circle<{ styling: string }>`
-  stroke: ${({styling}) => `var(--spinner-${styling}, --grey-a8)` };
+const BaseCircle = styled.circle<{ styling: string, customColor?: string }>`
+  stroke: ${({styling, customColor}) => customColor ? customColor : `var(--spinner-${styling}-base, --grey-a8)` };
   fill: none;
 `;
 
-const RotatingCircle = styled.circle<{ r: number }>`
-  stroke: var(--white-1);
+const RotatingCircle = styled.circle<{ r: number, styling: string, customColor?: string }>`
+  stroke: ${({styling, customColor}) => customColor ? customColor : `var(--spinner-${styling}-top, --white-1)` };
   fill: none;
   stroke-dasharray: ${({r}) => circumference(r)};
   stroke-dashoffset: ${({r}) => 2 * 3.1416 * r / 2};
@@ -66,18 +66,17 @@ export const buttonSpinnerSize = (buttonSize: TypeButtonSizes) : SpinnerSize  =>
   }
 };
 
-export const isTypeButtonDesigns = (value: any): value is TypeButtonDesigns => {
+export const getButtonDesign = (value: string) => {
 
-  switch (value) {
-    case 'primary':
-    case 'secondary':
-    case 'danger':
-    return true;
-    break;
-
-    default:
-      return false;
+  if(value === 'primary' || value === 'secondary' || value === 'warning'){
+    return value;
+  } else if(value === 'danger'){
+    console.warn('Button.tsx - Warning, the design prop value `danger` is being deprecated. Use `warning` instead.');
+    return 'danger';
   }
+
+  return 'simple';
+
 };
 
 const sizeGuide = {
@@ -101,15 +100,16 @@ interface IProps {
   custom?: ICustomSpinner
 }
 
-const Spinner : React.FC<IProps> = ({ size = 'medium', styling = 'primary', custom }) => {
+const Spinner : React.FC<IProps> = ({ size = 'medium', styling = 'primary', custom = {} }) => {
+  const { baseColor, topColor } = custom;
   const sizeVal = custom?.size ? custom.size : sizeGuide[size];
   const strokeWidth = sizeVal / 5.333;
   const circleRadius = (sizeVal / 2) - (strokeWidth / 2);
 
   return (
     <svg viewBox={`-${sizeVal/2} -${sizeVal/2} ${sizeVal} ${sizeVal}`} width={sizeVal} height={sizeVal} xmlns='http://www.w3.org/2000/svg'>
-      <BaseCircle cx='0' cy='0' r={circleRadius} strokeWidth={strokeWidth} styling={isTypeButtonDesigns(styling) ? styling : 'simple'} />
-      <RotatingCircle cx='0' cy='0' r={circleRadius} strokeWidth={strokeWidth} />
+      <BaseCircle cx='0' cy='0' r={circleRadius} strokeWidth={strokeWidth} styling={ getButtonDesign(styling) } customColor={ baseColor } />
+      <RotatingCircle cx='0' cy='0' r={circleRadius} strokeWidth={strokeWidth} styling={ getButtonDesign(styling) } customColor={ topColor } />
     </svg>
   );
 

--- a/packages/ui-lib/src/Indicators/Spinner.tsx
+++ b/packages/ui-lib/src/Indicators/Spinner.tsx
@@ -88,13 +88,21 @@ const sizeGuide = {
   xlarge: 48
 };
 
-interface IProps {
-  size: SpinnerSize
-  styling: string
+interface ICustomSpinner {
+  size?: number;
+  baseColor?: string;
+  topColor?: string;
 }
 
-const Spinner : React.FC<IProps> = ({ size = 'medium', styling = 'primary' }) => {
-  const sizeVal = sizeGuide[size];
+interface IProps {
+  size?: SpinnerSize
+  customSize?: number
+  styling: string
+  custom?: ICustomSpinner
+}
+
+const Spinner : React.FC<IProps> = ({ size = 'medium', styling = 'primary', custom }) => {
+  const sizeVal = custom?.size ? custom.size : sizeGuide[size];
   const strokeWidth = sizeVal / 5.333;
   const circleRadius = (sizeVal / 2) - (strokeWidth / 2);
 

--- a/packages/ui-lib/src/Indicators/Spinner.tsx
+++ b/packages/ui-lib/src/Indicators/Spinner.tsx
@@ -31,12 +31,12 @@ const rotate = keyframes`
 `;
 
 const BaseCircle = styled.circle<{ styling: string, customColor?: string }>`
-  stroke: ${({styling, customColor}) => customColor ? customColor : `var(--spinner-${styling}-base, --grey-a8)` };
+  stroke: ${({styling, customColor}) => customColor ? customColor : `var(--spinner-${styling}-base, var(--grey-a8))` };
   fill: none;
 `;
 
 const RotatingCircle = styled.circle<{ r: number, styling: string, customColor?: string }>`
-  stroke: ${({styling, customColor}) => customColor ? customColor : `var(--spinner-${styling}-top, --white-1)` };
+  stroke: ${({styling, customColor}) => customColor ? customColor : `var(--spinner-${styling}-top, var(--white-1))` };
   fill: none;
   stroke-dasharray: ${({r}) => circumference(r)};
   stroke-dashoffset: ${({r}) => 2 * 3.1416 * r / 2};
@@ -77,7 +77,6 @@ interface ICustomSpinner {
 
 interface IProps {
   size?: SpinnerSize
-  customSize?: number
   styling: string
   custom?: ICustomSpinner
 }

--- a/packages/ui-lib/src/Indicators/Spinner.tsx
+++ b/packages/ui-lib/src/Indicators/Spinner.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styled, { keyframes } from 'styled-components';
-import { TypeButtonDesigns, TypeButtonSizes} from "../Form";
 
 const circumference = (radius : number) => {
   return 2 * 3.1416 * radius;
@@ -48,23 +47,6 @@ const RotatingCircle = styled.circle<{ r: number, styling: string, customColor?:
 `;
 
 export type SpinnerSize = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';
-
-
-export const buttonSpinnerSize = (buttonSize: TypeButtonSizes) : SpinnerSize  => {
-  switch (buttonSize) {
-    case 'xsmall':
-    case 'small':
-      return 'xsmall';
-      break;
-
-    case 'large':
-      return 'small';
-
-    default:
-      return 'small';
-      break;
-  }
-};
 
 export const getButtonDesign = (value: string) => {
 

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -35,7 +35,8 @@ const ThemeVariables = createGlobalStyle`
 
     --button-icon-size: 14px;
     --button-icon-h-padding: 8px;
-
+    
+    // Inputs
     --input-box-shadow-x: 0;
     --input-box-shadow-y: 0;
     --input-box-shadow-blur: 0;
@@ -46,11 +47,17 @@ const ThemeVariables = createGlobalStyle`
     --input-focused-box-shadow-blur: 3px;
     --input-focused-box-shadow-spread: 0;
 
+    // Switches
     --switch-height: 24px;
     --switch-width: 40px;
     --switch-border-width: 2px;
     --switch-inner-size: 16px;
     --switch-intent-offset: 3px;
+
+    // Labels
+    --label-font: var(--font-ui);
+    --label-font-size: 14px;
+    --label-weight: 500;
 
   }
 

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -46,6 +46,12 @@ const ThemeVariables = createGlobalStyle`
     --input-focused-box-shadow-blur: 3px;
     --input-focused-box-shadow-spread: 0;
 
+    --switch-height: 24px;
+    --switch-width: 40px;
+    --switch-border-width: 2px;
+    --switch-inner-size: 16px;
+    --switch-intent-offset: 3px;
+
   }
 
   .button-size-xsmall {

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -755,4 +755,39 @@ export const colorVariables = css`
 
   }
 
+  /* Switches */
+  .light-theme, .dark-theme {
+    // Background
+    --switch-default-off-background: var(--grey-4);
+    --switch-default-on-background: var(--primary-9);
+    --switch-default-danger-background: var(--warning-9);
+
+    --switch-disabled-off-background: var(--grey-3);
+    --switch-disabled-on-background: var(--primary-8);
+    --switch-disabled-danger-background: var(--warning-8);
+    
+    // Border
+    --switch-default-off-border: var(--grey-7);
+    --switch-default-on-border: var(--primary-9);
+    --switch-default-danger-border: var(--warning-9);
+    
+    --switch-disabled-off-border: var(--grey-6);
+    --switch-disabled-on-border: var(--primary-a6);
+    --switch-disabled-danger-border: var(--warning-a6);
+    
+    // Inner
+    --switch-default-off-inner: var(--primary-9);
+    --switch-default-on-inner: var(--white-12);
+    --switch-default-danger-inner: var(--white-12);
+    
+    --switch-disabled-off-inner: var(--grey-7);
+    --switch-disabled-on-inner: var(--primary-a9);
+    --switch-disabled-danger-inner: var(--warning-a9);
+    
+    // Special States
+    --switch-special-locked-background: var(--grey-3);
+    --switch-special-locked-border: var(--grey-11);
+    --switch-special-locked-inner: var(--grey-11);
+  }
+
 `;

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -533,12 +533,19 @@ export const colorVariables = css`
     --primary: var(--primary-9);
     --danger: var(--warning-9);
 
-
-    --spinner-danger: var(--warning-8);
-    --spinner-secondary: var(--grey-8);
-    --spinner-primary: var(--primary-6);
-    --spinner-simple: var(--grey-a8);
-
+    /* Spinner */
+    --spinner-primary-base: var(--primary-6);
+    --spinner-primary-top: var(--white-1);
+    
+    --spinner-secondary-base: var(--grey-8);
+    --spinner-secondary-top: var(--white-1);
+    
+    --spinner-simple-base: var(--grey-a8);
+    --spinner-simple-top: var(--white-1);
+    
+    --spinner-warning-base: var(--warning-8);
+    --spinner-warning-top: var(--white-1);
+    
     /* Global */
     --main-background-gradient: radial-gradient(200% 200% at 50% -10%, var(--grey-2) 0%, var(--grey-3) 100%);
     --main-background-color: var(--grey-3);

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -669,6 +669,11 @@ export const colorVariables = css`
     --filter-button-shadow-color: var(--black-a8);
   }
 
+  /* Typography */
+  .light-theme, .dark-theme {
+    --label-color: var(--grey-11);
+  }
+
   /* Buttons */
   .light-theme, .dark-theme {
     --button-background-color: var(--primary-9);

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -787,7 +787,43 @@ export const colorVariables = css`
     // Special States
     --switch-special-locked-background: var(--grey-3);
     --switch-special-locked-border: var(--grey-11);
-    --switch-special-locked-inner: var(--grey-11);
+    --switch-special-locked-inner: transparent;
+    --switch-special-locked-icon: var(--grey-11);
+  }
+
+  .light-theme {
+    // Background
+    --switch-default-off-background: var(--grey-2);
+    --switch-default-on-background: var(--primary-7);
+    --switch-default-danger-background: var(--warning-9);
+    
+    --switch-disabled-off-background: var(--grey-3);
+    --switch-disabled-on-background: var(--primary-6);
+    --switch-disabled-danger-background: var(--warning-8);
+
+    // Border
+    --switch-default-off-border: var(--grey-6);
+    --switch-default-on-border: var(--primary-7);
+    --switch-default-danger-border: var(--warning-9);
+    
+    --switch-disabled-off-border: var(--grey-6);
+    --switch-disabled-on-border: var(--primary-7);
+    --switch-disabled-danger-border: var(--warning-a5);
+    
+    // Inner
+    --switch-default-off-inner: var(--primary-9);
+    --switch-default-on-inner: var(--white-12);
+    --switch-default-danger-inner: var(--white-12);
+
+    --switch-disabled-off-inner: var(--grey-7);
+    --switch-disabled-on-inner: var(--primary-9);
+    --switch-disabled-danger-inner: var(--warning-a8);
+    
+    // Special States
+    --switch-special-locked-background: var(--grey-3);
+    --switch-special-locked-border: var(--grey-8);
+    --switch-special-locked-inner: transparent;
+    --switch-special-locked-icon: var(--grey-11);
   }
 
 `;

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -801,6 +801,12 @@ export const colorVariables = css`
     --switch-special-locked-border: var(--grey-11);
     --switch-special-locked-inner: transparent;
     --switch-special-locked-icon: var(--grey-11);
+
+    --switch-special-failure-background: var(--warning-8);
+    --switch-special-failure-border: var(--warning-9);
+    --switch-special-failure-inner: var(--white-12);
+    --switch-special-failure-icon: var(--warning-8);
+
   }
 
   .light-theme {


### PR DESCRIPTION
This PR refactors the switch to match new designs, refactor out the legacy theme code and make some general quality improvements to the interactions. As part of this, the Spinner component has also got a slight upgrade with some custom components that mean it will work correctly if the switch is resized.

Here are a list of the changes made to the `Switch`:

- The theme has been replaced to match the new style and fully integrate with the newly added CSS variables.
- Because of this, now the switches are fully light and dark mode compatible.
- It has size variables in CSS that mean it can be resized if needed. While thinking forward, this also means that for legacy projects, the previous size of the switch can be restored.
- The label now uses the Label component to ensure that it is kept in sync with everything else.
- The intention interaction, where the inner part of the switch moves slightly on hover has been refined so that once you click it, the intention interaction does not trigger again until your mouse leaves and re-enters the area.
- No changes have been made to props that should cause any breaking changes.

Other changes to `Label` and `Spinner` include:
- [Label] CSS theme integration.
- [Label] Display type updated so that the container fits the content instead of being full width. This should fix #203 
- [Spinner] Theme variables updated, renamed and a color added for the top color instead of just the base.
- [Spinner] It can now take a custom size to override the preset sizes. While preset sizes are still going to be commonly used, this will be useful in various contexts. For now, this allows the `Switch` to be resized with the CSS rules while keeping the loading state spinner the correct size for the switch.
- [Spinner] Custom colors can be given to the spinner, for better styling in differing contexts.
- [Spinner] Story has been updated to show the custom size and color overrides.
- [SplitButtonOption] The Spinner size here was updated to the new custom size pattern that extracts the css variable value to pass along as custom size.
- No breaking changes are expected from the above.

## Note: For restoring previous size on older projects
While the button styling won't remain pixel perfect, this should return the button to the correct size and any further aesthetic changes themselves are considered to be ok and exempt from "pixel perfect" requirements. 

To restore the size to previous, use this snippet as a custom variable override:
```
:root {
    --switch-height: 22px;
    --switch-width: 38px;
    --switch-border-width: 1px;
    --switch-inner-size: 14px;
}
```

## How does it all look?
https://github.com/user-attachments/assets/6f6539ac-4d1b-44d9-a68b-95f13f7a6544