### PR TITLE
Temporary fix for having jsx in Storybook8 with one man army package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4206,6 +4206,12 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "node_modules/@mihkeleidast/storybook-addon-source": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mihkeleidast/storybook-addon-source/-/storybook-addon-source-1.0.1.tgz",
+      "integrity": "sha512-/TRoq62doDiSmtp6pNiSgngZ9tjNAWMN117M8GBz2uvgYJOIU2Zk4WH8kaEUy4TYr+S35lvmuXzZKRa5KRJpng==",
+      "dev": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -27037,6 +27043,7 @@
         "typescript": "^4.7.4"
       },
       "devDependencies": {
+        "@mihkeleidast/storybook-addon-source": "^1.0.1",
         "@storybook/addon-actions": "8.4.4",
         "@storybook/addon-knobs": "8.0.1",
         "@storybook/addon-links": "8.4.4",
@@ -30772,6 +30779,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "@mihkeleidast/storybook-addon-source": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mihkeleidast/storybook-addon-source/-/storybook-addon-source-1.0.1.tgz",
+      "integrity": "sha512-/TRoq62doDiSmtp6pNiSgngZ9tjNAWMN117M8GBz2uvgYJOIU2Zk4WH8kaEUy4TYr+S35lvmuXzZKRa5KRJpng==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -45565,6 +45578,7 @@
       "version": "file:packages/storybook",
       "requires": {
         "@future-standard/icons": "^2.0.0",
+        "@mihkeleidast/storybook-addon-source": "^1.0.1",
         "@storybook/addon-actions": "8.4.4",
         "@storybook/addon-knobs": "8.0.1",
         "@storybook/addon-links": "8.4.4",

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -1,5 +1,3 @@
-/**Updated version with migration guide https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#new-framework-api */
-
 module.exports = {
   framework: {
     name: "@storybook/react-webpack5",
@@ -14,6 +12,7 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-knobs',
     'storybook-dark-mode',
-    'storybook-addon-jsx/register',
+    // '@mihkeleidast/storybook-addon-source' is a temporary replacement for 'storybook-addon-jsx',
+    '@mihkeleidast/storybook-addon-source' /// https://github.com/dhis2/ui/pull/1607
   ]
 }

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -8,6 +8,7 @@ import { MemoryRouter as Router } from 'react-router-dom';
 import { defaultTheme, ThemeVariables } from 'scorer-ui-kit';
 import Fonts from '../src/fonts';
 import Style from '../src/style';
+const { withJsx } = require('@mihkeleidast/storybook-addon-source')
 
 // const { addDecorator } = require('@storybook/react'); // Has been deprecated, need alternative
 // import { jsxDecorator } from 'storybook-addon-jsx';
@@ -53,8 +54,9 @@ const preview: Preview = {
       dark: { ...themes.dark, appBg: '#252626' },
       light: { ...themes.normal, appBg: '#efeff3' },
     },
+    jsx: { skip: 1 }
   },
-  decorators: [withKnobs, ThemeDecorator, RouterDecorator],
+  decorators: [withJsx, withKnobs, ThemeDecorator, RouterDecorator],
 };
 
 export default preview;

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -18,15 +18,16 @@
     "typescript": "^4.7.4"
   },
   "devDependencies": {
+    "@mihkeleidast/storybook-addon-source": "^1.0.1",
     "@storybook/addon-actions": "8.4.4",
     "@storybook/addon-knobs": "8.0.1",
     "@storybook/addon-links": "8.4.4",
-    "@storybook/manager-api": "8.4.4",
-    "@storybook/preview-api": "8.4.4",
     "@storybook/addons": "7.6.17",
-    "@storybook/react-webpack5":"^8.4.4",
+    "@storybook/manager-api": "8.4.4",
     "@storybook/preset-create-react-app": "8.4.4",
+    "@storybook/preview-api": "8.4.4",
     "@storybook/react": "8.4.4",
+    "@storybook/react-webpack5": "^8.4.4",
     "storybook-addon-jsx": "^7.3.14",
     "storybook-dark-mode": "^4.0.2"
   },

--- a/packages/storybook/src/stories/Alerts/AlertBar.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/AlertBar.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import {text, select, boolean } from "@storybook/addon-knobs";
 
 import {AlertBar} from 'scorer-ui-kit';
 
@@ -9,15 +8,44 @@ const Container = styled.div`
 `;
 
 export default {
-  title: 'Alerts/atoms',
-  component: AlertBar
-};
+  component: AlertBar,
+  title: 'Alerts/atoms'
+}
 
-export const _AlertBar = () => {
-  const message = text("Message", 'Look Out!');
-  const type = select("Type", { Error: 'error', Warning: 'warning', Info: 'info', Success:'success', Neutral:'neutral'}, 'error');
-  const hideCloseButton = boolean('Hide close icon', false);
+export const _AlertBar = (args: any) => {
 
-  return <Container><AlertBar {...{message, type, hideCloseButton}} ></AlertBar></Container>;
+    return <Container><AlertBar {...args} ></AlertBar></Container>;
 
-};
+}
+
+_AlertBar.argTypes = {
+  message: {name:'Message', control: 'text' , defaultValue: 'Look Out!'},
+  type: {
+    name: 'Type',
+    options: ['error', 'warning','info', 'success', 'neutral'],
+    mapping: {
+      error: 'error',
+      warning: 'warning',
+      info: 'info',
+      success:'success',
+      neutral:'neutral'
+    },
+    control: {
+      type: 'select',
+      labels: {
+        error: 'Error',
+        warning: 'Warning',
+        info: 'Info',
+        success:'Success',
+        neutral:'Neutral'
+      }
+    }
+  },
+  hideCloseButton: false
+}
+
+_AlertBar.args = {
+  message: 'Look Out!',
+  type: 'warning',
+  hideCloseButton: false
+}


### PR DESCRIPTION
### Description

This is a potential temporary fix for the Storybook update to support JSX code in stories.

Since addDecorator was deprecated and the [JSX addon does not work without it](https://github.com/storybookjs/addon-jsx), this branch implements an alternative solution using a third-party addon: [storybook-addon-source](https://github.com/mihkeleidast/storybook-addon-source).

 ### Considerations on Implementation
- The current example only showcases Alert Bars because this JSX addon only works with controls. As a result, the Alert Bars story has been updated to use controls.
- To fully adopt this addon, all component stories will need to be upgraded to use controls.

 ### Reviewing/Testing steps
Run Storybook with Node 18 or above.
Verify that the Alert Bars story displays correctly with Source informamtion

<img width="861" alt="Screenshot 2024-11-20 at 1 13 46" src="https://github.com/user-attachments/assets/cac845a5-6f34-4ad0-ab82-3b763000a710">


