### PR TITLE
Fixed incorrect wrapping of jp in SmallInput's unit label

### DIFF
--- a/packages/ui-lib/src/Form/atoms/SmallInput.tsx
+++ b/packages/ui-lib/src/Form/atoms/SmallInput.tsx
@@ -65,6 +65,7 @@ const UnitKey = styled.div`
   font-family: var(--font-ui);
   color: var(--input-color-unit);
   margin-top: 1px;
+  white-space: nowrap;
 `;
 
 const Container = styled.div<{ fieldState: string }>`


### PR DESCRIPTION
Quick fix to the unit label in `SmallInput` to stop it incorrectly line wrapping when in Japanese. Simple css fix.

Before: 
![image](https://github.com/user-attachments/assets/c4023a7d-4c36-4931-90da-91c20e459bf7)

After:
![image](https://github.com/user-attachments/assets/8ced00d8-fe02-47bb-9c81-87c677fbf182)
