### PR TITLE
Breadcrumbs have Home icon added to top level

### DIFF
--- a/packages/storybook/src/stories/Global/molecules/UtilityHeader.stories.tsx
+++ b/packages/storybook/src/stories/Global/molecules/UtilityHeader.stories.tsx
@@ -28,6 +28,7 @@ export const _UtilityHeader = () => {
   
   const backLink = text("Back Link", "/");
   const showBreadcrumbs = boolean("Show Breadcrumbs", true);
+  const showHomeIcon = boolean("Show Home Icon", true);
   const breadcrumbs = object("breadcrumbs", [
     {
       text: 'Examples', 
@@ -59,6 +60,7 @@ export const _UtilityHeader = () => {
         backLink={backLink}
         showBreadcrumbs={showBreadcrumbs}
         breadcrumbs={breadcrumbs}
+        showHomeIcon={showHomeIcon}
         showShareLink={showShareLink}
         shareLink={shareLink}
       />

--- a/packages/ui-lib/src/Layouts/index.ts
+++ b/packages/ui-lib/src/Layouts/index.ts
@@ -14,6 +14,7 @@ export interface IUtilityHeader {
   backLink?: string;
   showBreadcrumbs?: boolean;
   breadcrumbs?: IBreadcrumb[];
+  showHomeIcon?: boolean;
   showShareLink?: boolean;
   shareLink?: string;
 }

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -147,7 +147,16 @@ const BreadcrumbIcon = styled.div`
     align-items: center;
   }
 `;
+const HomeIcon = styled(BreadcrumbIcon)`
+  padding-bottom: 1px;
+  svg path {
+    transition: stroke var(--speed-normal) var(--easing-primary-out);
+  }
+`;
 const BreadcrumbLink = styled(Link)`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
   flex: 1;
   color: var(--grey-10);
   font-family: var(--font-ui);
@@ -156,9 +165,15 @@ const BreadcrumbLink = styled(Link)`
   font-style: normal;
   font-weight: 500;
   line-height: 12px; /* 100% */
-  transition: color 0.25s ease;
+  transition: color var(--speed-normal) var(--easing-primary-out);
+
   &:hover {
     color: var(--grey-12);
+    ${HomeIcon} svg {
+      path {
+        stroke: var(--grey-12);
+      }
+    }
   }
 `;
 
@@ -172,7 +187,7 @@ const RightArea = styled.div`
 
 
 
-const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], backLink, $iconInGutter = true, showShareLink = false, shareLink }) => {
+const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, backLink, $iconInGutter = true, showShareLink = false, shareLink }) => {
 
   const [ copyActionText, setCopyActionText ] = useState<string>("Share");
   const {copyToClipboard} = useCopyToClipboard();
@@ -200,12 +215,16 @@ const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, brea
         <Breadcrumbs>
           { breadcrumbs.map((breadcrumb, index) => {
             const {text, href} = breadcrumb;
+            const isFirst = index === 0;
             const isLast = index === breadcrumbs.length - 1;
 
             return (
               <React.Fragment key={index}>
                 <Breadcrumb>
-                  <BreadcrumbLink to={href}>{text}</BreadcrumbLink>
+                  <BreadcrumbLink to={href}>
+                    {isFirst && showHomeIcon ? <HomeIcon><Icon icon="Home" size={11} color='grey-10' /></HomeIcon> : null }
+                    {text}
+                  </BreadcrumbLink>
                   {!isLast ? <BreadcrumbIcon><Icon icon="Right" size={6} color='grey-8' /></BreadcrumbIcon> : null }
                 </Breadcrumb>
               </React.Fragment>


### PR DESCRIPTION
This simply adds the home icon to the top level of the breadcrumb. It is set to on by default as the top level is usually intended to be the home reference but this can be optionally switched off if the project chooses to treat this differently. This is done with the `showHomeIcon?: boolean` prop. 

At the moment no projects are known to be using this feature so this change isn't deemed to be breaking or disruptive. The first project this has been requested for will require this icon, though it is not critical.

New home icon can be seen here:
![image](https://github.com/user-attachments/assets/13296f46-8946-4259-82f0-681c593b11f2)
