### PR TITLE
Select component - Refactor and icon

### DIFF
--- a/packages/storybook/src/stories/Form/SelectField.stories.tsx
+++ b/packages/storybook/src/stories/Form/SelectField.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import { text, object, boolean } from "@storybook/addon-knobs";
+import { text, select, object, boolean } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
-import { SelectField, PageHeader, SelectWrapper} from 'scorer-ui-kit';
+import { SelectField, SelectWrapper} from 'scorer-ui-kit';
+import { generateIconList } from '../helpers';
 
 export default {
   title: 'Form/atoms',
@@ -12,6 +13,9 @@ export default {
 
 const Container = styled.div`
   margin: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 `;
 
 const FixedSelect = styled.div<{ width?: string }>`
@@ -20,20 +24,35 @@ const FixedSelect = styled.div<{ width?: string }>`
   }
 `;
 
-export const _SelectField = () => {
+const Subsection = styled.div`
+  flex: 1;
+`;
 
+const Title = styled.h1`
+  font-family: var(--font-title);
+  font-size: 24px;
+  color: var(--grey-12);
+  font-weight: 500;
+`;
+
+export const _SelectField = () => {
+  const iconList = generateIconList();
+  
   const isCompact = boolean('isCompact', false);
-  const placeholder = text('Placeholder free width', 'Choose an option...');
-  const defaultValue = text('Default Value free width','option3');
   const disabled = boolean('Disabled', false);
+  const fieldState = select("State", { Default: "default",  Disabled: 'disabled', Required: 'required',  Valid: 'valid',  Invalid: 'invalid', Processing: 'processing' }, "default");
+  const placeholder = text('Placeholder (Free Width)', 'Choose an option...');
+  const defaultValue = text('Default Value (Free Width)', '');
   const freeSelectValue = action('Free select value');
   const fixedSelectValue = action('Free select value');
+  const icon = select("Icon", iconList, Object.keys(iconList)[0]);
 
-  const selectWidth = text('Fix width', '60px');
+  const selectWidth = text('Fix width', '80px');
   const label = object('Free Select Label', {
     htmlFor: 'free_select',
     text: 'Field Label'
   })
+
   const fixLabel = object('Fix Select Label', {
     htmlFor: 'fix_select',
     text: 'Page',
@@ -47,44 +66,69 @@ export const _SelectField = () => {
   const fixSelectOnChange = (value: string) => {
     fixedSelectValue(value);
   }
+  
   return (
     <Container>
-      <PageHeader
-        title='Select free width'
-      />
-      <SelectField
-        {...{
-          isCompact,
-          placeholder,
-          label,
-          selectWidth,
-          disabled,
-          defaultValue
-        }}
-        changeCallback={freeOnChange}
-      >
-        <option value="option1">Example Option 1</option>
-        <option value="option2">Example Option 2</option>
-        <option value="option3">Example Option 3</option>
-        <option value="option4">Example Option 4</option>
-      </SelectField>
-      <PageHeader
-        title='Select fixed width'
-      />
-      <FixedSelect width={selectWidth}>
+      <Subsection>
+        <Title>Select (Free Width)</Title>
         <SelectField
-          {...{ isCompact, disabled }}
-          label={fixLabel}
-          defaultValue={1}
-          changeCallback={fixSelectOnChange}
+          {...{
+            isCompact,
+            placeholder,
+            label,
+            selectWidth,
+            disabled,
+            defaultValue,
+            fieldState
+          }}
+          changeCallback={freeOnChange}
         >
-          <option value={1}>1</option>
-          <option value={5}>5</option>
-          <option value={10}>10</option>
-          <option value={15}>15</option>
-          <option value={20}>20</option>
+          <option value="option1">Example Option 1</option>
+          <option value="option2">Example Option 2</option>
+          <option value="option3">Example Option 3</option>
+          <option value="option4">Example Option 4</option>
         </SelectField>
-      </FixedSelect>
+      </Subsection>
+          
+      <Subsection>
+        <Title>Select (Fixed Width)</Title>
+        <FixedSelect width={selectWidth}>
+          <SelectField
+            {...{ isCompact, disabled, fieldState }}
+            label={fixLabel}
+            defaultValue={1}
+            changeCallback={fixSelectOnChange}
+            >
+            <option value={1}>1</option>
+            <option value={5}>5</option>
+            <option value={10}>10</option>
+            <option value={15}>15</option>
+            <option value={20}>20</option>
+          </SelectField>
+        </FixedSelect>
+      </Subsection>
+        
+      <Subsection>
+        <Title>Select (With Icon)</Title>
+        <SelectField
+          {...{
+            isCompact,
+            placeholder,
+            label,
+            selectWidth,
+            disabled,
+            defaultValue,
+            fieldState,
+            icon
+          }}
+          changeCallback={freeOnChange}
+          >
+          <option value="option1">Example Option 1</option>
+          <option value="option2">Example Option 2</option>
+          <option value="option3">Example Option 3</option>
+          <option value="option4">Example Option 4</option>
+        </SelectField>
+      </Subsection>
     </Container>
   );
 }

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -41,7 +41,12 @@ const StyledSelect = styled.select<{ fieldState: TypeFieldState, withIcon?: bool
   border-radius: 3px;
   color: var(--input-color-default);
   font-size: 14px;
+  cursor: pointer;
 
+  transition: 
+    border var(--speed-fast) var(--easing-primary-out),
+    background-color var(--speed-fast) var(--easing-primary-out),
+    box-shadow var(--speed-fast) var(--easing-primary-out);
 
   ${({fieldState}) => css`
     border: 1px solid var(--input-${fieldState}-border-color);
@@ -61,13 +66,6 @@ const StyledSelect = styled.select<{ fieldState: TypeFieldState, withIcon?: bool
     height: var(--input-height);
     padding: 0 16px 1px ${withIcon ? '36px' : '12px'};
   `};
-
-  transition: 
-    border var(--speed-fast) var(--easing-primary-out),
-    background-color var(--speed-fast) var(--easing-primary-out),
-    box-shadow var(--speed-fast) var(--easing-primary-out);
-
-  cursor: pointer;
 
   &:disabled {
     opacity: 1;
@@ -142,9 +140,17 @@ const SelectField: React.FC<ISelect> = ({
     changeCallback(value);
   }, [changeCallback]);
 
+  const iconColor = () => {
+    if(props.disabled || fieldState === 'disabled'){
+      return 'input-disabled-lead-icon';
+    } else {
+      return 'input-lead-icon';
+    }
+  };
+
   const renderSelect = useCallback((htmlFor?: string) => (
     <SelectWrapper>
-      {icon && <SubjectIcon {...{isCompact}}><Icon icon={icon} size={isCompact ? 12 : 12 } weight='regular' color={ activePlaceholder ? 'grey-10' : 'grey-12' } /></SubjectIcon>}
+      {icon && <SubjectIcon {...{isCompact}}><Icon icon={icon} color={iconColor()} size={isCompact ? 12 : 12 } weight='regular' /></SubjectIcon>}
       <StyledSelect
         withIcon={ icon ? true : false }
         id={htmlFor}
@@ -156,7 +162,7 @@ const SelectField: React.FC<ISelect> = ({
         {!defaultValue && <option value='' disabled hidden>{placeholder}</option>}
         {children}
       </StyledSelect>
-      <OpenIcon {...{isCompact}}><Icon icon='Down' color='grey-12' weight='regular' size={isCompact ? 8 : 10 } /></OpenIcon>
+      <OpenIcon {...{isCompact}}><Icon icon='Down' color={iconColor()} weight='regular' size={isCompact ? 8 : 10 } /></OpenIcon>
     </SelectWrapper>
   ), [children, defaultValue, handleOnChange, placeholder, props]);
 

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -140,13 +140,13 @@ const SelectField: React.FC<ISelect> = ({
     changeCallback(value);
   }, [changeCallback]);
 
-  const iconColor = () => {
+  const iconColor = useCallback(() => {
     if(props.disabled || fieldState === 'disabled'){
       return 'input-disabled-lead-icon';
     } else {
       return 'input-lead-icon';
     }
-  };
+  }, [fieldState, props.disabled]);
 
   const renderSelect = useCallback((htmlFor?: string) => (
     <SelectWrapper>
@@ -164,7 +164,7 @@ const SelectField: React.FC<ISelect> = ({
       </StyledSelect>
       <OpenIcon {...{isCompact}}><Icon icon='Down' color={iconColor()} weight='regular' size={isCompact ? 8 : 10 } /></OpenIcon>
     </SelectWrapper>
-  ), [children, defaultValue, handleOnChange, placeholder, props]);
+  ), [children, defaultValue, handleOnChange, placeholder, props, fieldState, icon, iconColor, isCompact]);
 
   return (
     <Container {...{ isCompact, activePlaceholder }} isLabelSameRow={label?.isSameRow}>

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -1,41 +1,81 @@
 import React, { useCallback, useState, SelectHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
-import Label, { StyledLabel } from './Label';
-import Icon, { IconWrapper } from '../../Icons/Icon';
+import Label from './Label';
+import Icon from '../../Icons/Icon';
+import { TypeFieldState } from '..';
 
 
 export const SelectWrapper = styled.div`
   position: relative;
   display: flex;
   width: 100%;
-
-  ${IconWrapper} {
-    position: absolute;
-    top: calc(50% - 7px);
-    right: 10px;
-    pointer-events: none;
-  }
 `;
 
-const StyledSelect = styled.select`
+const OpenIcon =  styled.div<{ isCompact?: boolean }>`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  right: ${({isCompact}) => isCompact ? '14px' : '16px'};
+  pointer-events: none;
+`;
+
+const SubjectIcon = styled.div<{ isCompact?: boolean }>`
+  position: absolute;
+  left: ${({isCompact}) => isCompact ? '10px' : '12px'};
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+`;
+
+const StyledSelect = styled.select<{ fieldState: TypeFieldState, withIcon?: boolean, isCompact?: boolean }>`
   box-sizing: border-box;
   outline: none;
   border-radius: 3px;
-  height: 40px;
-  padding: 0 25px 0 15px;
   appearance: none;
-  line-height: 1.56;
+  font-family: var(--font-data);
+  height: var(--input-height);
   width: 100%;
+  border-radius: 3px;
+  color: var(--input-color-default);
+  font-size: 14px;
+
+
+  ${({fieldState}) => css`
+    border: 1px solid var(--input-${fieldState}-border-color);
+    background: var(--input-${fieldState}-background-color);
+    box-shadow: var(--input-box-shadow-x) var(--input-box-shadow-y) var(--input-box-shadow-blur) var(--input-box-shadow-spread)  var(--input-${fieldState}-shadow-color, transparent);
+  `};
+
+
+  ${({ isCompact, withIcon }) => isCompact ? css`
+    height: var(--input-compact-height);
+    padding: 0 16px 1px ${withIcon ? '30px' : '8px'};
+
+    ${OpenIcon}{
+      right: 14px;
+    }
+  ` : css`
+    height: var(--input-height);
+    padding: 0 16px 1px ${withIcon ? '36px' : '12px'};
+  `};
+
+  transition: 
+    border var(--speed-fast) var(--easing-primary-out),
+    background-color var(--speed-fast) var(--easing-primary-out),
+    box-shadow var(--speed-fast) var(--easing-primary-out);
+
   cursor: pointer;
-  ${({theme: {styles}}) => css`
-    ${styles.form.input.default.normal};
-  `}
 
   &:disabled {
-    ${({theme: {styles}}) => css`
-      ${styles.form.input.disabled.normal};
-    `}
+    opacity: 1;
     cursor: not-allowed;
+    color: var(--input-disabled-color-default);
+    border: 1px solid var(--input-disabled-border-color);
+    background: var(--input-disabled-background-color);
+    box-shadow: var(--input-box-shadow-x) var(--input-box-shadow-y) var(--input-box-shadow-blur) var(--input-box-shadow-spread)  var(--input-disabled-shadow-color, transparent);
   }
 
   &::-ms-expand {
@@ -45,57 +85,19 @@ const StyledSelect = styled.select`
 
 const Container = styled.div<{ isCompact?: boolean, activePlaceholder: boolean, isLabelSameRow?: boolean }>`
 
-${({ isCompact }) => isCompact && css`
-  ${StyledLabel} {
-      span {
-        margin-bottom: 6px;
-      }
-    }
-  `}
-
-${({ isLabelSameRow }) => isLabelSameRow && css`
-  ${StyledLabel} {
-    display: flex;
-    align-items: center;
-    span {
-      margin: 0 10px 0 0;
-    }
+  span {
+    margin-bottom: 8px;
   }
-`};
 
-  ${StyledSelect} {
-    ${({ theme }) => css`
-      border: 1px solid ${theme.styles.form.input.default.normal.borderColor};
-      font-family: ${theme.fontFamily.data};
-      ${theme.typography.form.input.value.normal};
-    `};
-
-    ${({ theme: { typography }, isCompact }) => isCompact && css`
-      height: 30px;
-      padding: 0 25px 0 10px;
-      ${typography.form.input.value.compact};
-    `};
-
-    ${({ theme, activePlaceholder }) => activePlaceholder && css`
-      ${theme.typography.form.input.placeholder.normal};
-    `};
-
-    ${({ theme, isCompact, activePlaceholder }) => isCompact && activePlaceholder && css`
-      ${theme.typography.form.input.placeholder.compact};
-    `};
-
-    option {
-      font-style: normal;
-      ${({ theme }) => css`
-        ${theme.typography.form.input.value.normal};
-      `};
-
-      ${({ theme: { typography }, isCompact }) => isCompact && css`
-        ${typography.form.input.value.compact};
-      `};
+  ${({activePlaceholder}) => activePlaceholder && css`
+    ${StyledSelect} {
+      font-family: var(--font-data);
+      color: var(--input-color-placeholder);
+      font-style: italic;
+      font-weight: 400;
     }
-    font-weight: 400;
-  }
+  `};
+
 `;
 
 interface ILabel {
@@ -105,17 +107,21 @@ interface ILabel {
 }
 
 interface OwnProps {
+  fieldState?: TypeFieldState
   label?: ILabel
   isCompact?: boolean
   placeholder?: string
+  icon?: string
   changeCallback?: (value: string) => void
 }
 
 type ISelect = OwnProps & SelectHTMLAttributes<HTMLSelectElement>
 
 const SelectField: React.FC<ISelect> = ({
+  fieldState = 'default',
   placeholder,
   label,
+  icon,
   isCompact,
   defaultValue,
   changeCallback = () => { },
@@ -138,8 +144,11 @@ const SelectField: React.FC<ISelect> = ({
 
   const renderSelect = useCallback((htmlFor?: string) => (
     <SelectWrapper>
+      {icon && <SubjectIcon {...{isCompact}}><Icon icon={icon} size={isCompact ? 12 : 12 } weight='regular' color={ activePlaceholder ? 'grey-10' : 'grey-12' } /></SubjectIcon>}
       <StyledSelect
+        withIcon={ icon ? true : false }
         id={htmlFor}
+        {...{fieldState, isCompact}}
         {...props}
         defaultValue={defaultValue ? defaultValue : ''}
         onChange={handleOnChange}
@@ -147,7 +156,7 @@ const SelectField: React.FC<ISelect> = ({
         {!defaultValue && <option value='' disabled hidden>{placeholder}</option>}
         {children}
       </StyledSelect>
-      <Icon icon='Down' color='dimmed' size={11} />
+      <OpenIcon {...{isCompact}}><Icon icon='Down' color='grey-12' weight='regular' size={isCompact ? 8 : 10 } /></OpenIcon>
     </SelectWrapper>
   ), [children, defaultValue, handleOnChange, placeholder, props]);
 

--- a/packages/ui-lib/src/Form/atoms/SmallInput.tsx
+++ b/packages/ui-lib/src/Form/atoms/SmallInput.tsx
@@ -9,7 +9,7 @@ const StyledInput = styled.input<{ fieldState : TypeFieldState }>`
   ${removeAutoFillStyle};
 
   font-family: var(--font-data);
-  line-height: var(--common-height);
+  line-height: var(--input-compact-height);
 
   font-size: 14px;
   flex: 1;
@@ -33,7 +33,7 @@ const StyledInput = styled.input<{ fieldState : TypeFieldState }>`
 
 const InputContainer = styled.div<{fieldState : TypeFieldState, hasAction?: boolean}>`
   display: flex;
-  height: var(--common-height);
+  height: var(--input-compact-height);
   padding: 0 8px;
   align-items: center;
   gap: 8px;

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -6,12 +6,16 @@ import { dimensions } from '../theme/common';
 
 
 const wrapperCss = css`
+  
+  line-height: 0;
+
   svg {
     overflow: visible;
     vector-effect: non-scaling-stroke;
 
     line, path, circle, ellipse, foreignObject, polygon, polyline, rect, text, textPath, tspan {
       vector-effect: non-scaling-stroke;
+      transition: stroke var(--speed-normal) var(--easing-primary-out);
     }
   }
 `;

--- a/packages/ui-lib/src/Misc/atoms/BasicSearchInput.tsx
+++ b/packages/ui-lib/src/Misc/atoms/BasicSearchInput.tsx
@@ -12,7 +12,7 @@ const Container = styled.div<{ hasBorder: boolean, disabled: boolean, noBackgrou
   
     transition: all var(--speed-normal) var(--easing-primary-in);
     gap: 6px;
-    height: var(--common-height);
+    height: var(--input-compact-height);
     padding: 0;
     align-items: center;
     display: flex;

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -23,6 +23,7 @@ const ThemeVariables = createGlobalStyle`
     --global-menu-width-open: 280px;
 
     --input-height: 40px;
+    --input-compact-height: 32px;
     --input-required-dot-display: inline-block;
 
     --button-font-size: 14px;

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -611,6 +611,10 @@ export const colorVariables = css`
     --input-processing-focused-border-color: var(--primary-10);
     --input-processing-focused-shadow-color: var(--grey-3);
 
+    /* Input Icons */
+    --input-lead-icon: var(--grey-12);
+    --input-disabled-lead-icon: var(--grey-10);
+
     /* Checkboxes and Radio Buttons */
     --input-toggle-icon-color: var(--white-12);
     


### PR DESCRIPTION
The Select has been refactored to remove the old theming, link it to the new CSS theme and also add a new icon feature. 

- Refactored to new theme code
- Added `fieldState` to match `input`
- Slight adjustment in height
- Added new optional icon to start of select
- Updated story with new variant for the icon.

As there is a new variable for the input compact height, the `BasicSearchInput` has also been updated to use this.

This update should not create any breaking changes. If the size adjustment of the select field causes problems in existing projects, it can be fixed a custom CSS override on the `--input-height` and `--input-compact-height` variables.

Preview:
https://github.com/user-attachments/assets/f96d4330-c0b6-405e-8b79-7e800241db0a

_Note, there is a bug in the preview with icon colors on disabled. This has been fixed._