### PR TITLE
Bump for release v2.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "2.6.5",
+      "version": "2.6.6",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -37847,7 +37847,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "2.6.5",
+      "version": "2.6.6",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
### Description


Release 2.6.6

**Components**
- **ToggleButton:** A new component that alternates the icon and text of the FilterButton. It can be used to toggle between two states, such as [switching between two layout types.](https://future-standard.github.io/scorer-ui-kit/storybook/?path=/story/filters-atoms--toggle-button)

**Features**
- **UtilityHeader:** Added a home icon to the top level of the breadcrumb. The icon can be removed by setting the showHomeIcon prop to false.
