### PR TITLE
Fix for missing Date Ranges in filterBar

### DIFF
--- a/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
+++ b/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
@@ -11,7 +11,7 @@ import {
   IFilterResult,
   IFilterDatePicker,
   isFilterItem,
-  // DateInterval,
+  DateInterval,
 } from 'scorer-ui-kit'
 
 import {
@@ -194,11 +194,31 @@ export const _FilterBar = () => {
     }
   ]
 
+
+  const TODAY: Date = new Date();
+  const TWO_WEEKS_BEFORE: Date = new Date();
+  TWO_WEEKS_BEFORE.setDate(TODAY.getDate() - 15);
+
+
   // Selected example
-  // const myDate: DateInterval = {
-  //   start: before,
-  //   end: today,
-  // }
+  const myDate: DateInterval = {
+  start: TWO_WEEKS_BEFORE,
+  end: TODAY
+  }
+
+  const START_RANGE: Date = new Date();
+  START_RANGE.setDate(0);
+  START_RANGE.setDate(START_RANGE.getDate() - 20);
+  const END_RANGE: Date = new Date();
+  END_RANGE.setDate(1);
+  END_RANGE.setDate(END_RANGE.getDate() + 60);
+
+  const datesRange = {
+  start: START_RANGE,
+  end: END_RANGE
+}
+
+
   const datePickers: IFilterDatePicker[] = [
     {
       id: 'datePickerForRuntime',
@@ -208,8 +228,9 @@ export const _FilterBar = () => {
       dateTimeTextUpper: language === 'english' ? 'From' : 'から',
       dateTimeTextLower: language === 'english' ? 'To' : 'まで',
       timeZoneTitle: language === 'english' ? 'Timezone' : '時間帯',
-      lang: language === 'english' ? 'en' : 'ja'
-      // selected: myDate,
+      lang: language === 'english' ? 'en' : 'ja',
+      selected: myDate,
+      availableRange: datesRange,
     }
   ]
 

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -37,6 +37,8 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
   timeZoneTitle,
   timeZoneValueTitle,
   lang,
+  hasEmptyValue,
+  availableRange,
   onCloseCallback = () => { },
   onUpdateCallback = () => { },
   onToggleCallback = () => { },
@@ -106,7 +108,8 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
                 dateTimeTextLower,
                 timeZoneTitle,
                 timeZoneValueTitle,
-                lang
+                lang,
+                availableRange
               }}
               updateCallback={handleUpdateCallback}
               hasEmptyValue


### PR DESCRIPTION

### Description

This is fix of a missing prop `availableRange` prop in `DropdownDatePicker` that prevents `FilterBar` to pass DatePickers configuration correctly.


Reported Error
`
I have used the availableRange prop within the datePickersConfig of the FilterBar component. However, it doesn't seem to have any effect on the DatePicker within the FilterBar component, even though it works perfectly with the standalone DatePicker component.
`

 ### Considerations on Implementation
- Added also missing hasEmptyValue.
- Added DateRanges to FilterBar Story, Unfortunately for the way the Language is handle in stories the object of knobs can not be used directly without losing the ability to switch Languages. I think this is something that will also be improve with by making a substitution to Controls.

I did a local test to verify the Out of range functionality is intact in FilterBars.
 
<img width="948" alt="Screenshot 2024-11-29 at 15 11 21" src="https://github.com/user-attachments/assets/39361c84-929a-4283-a398-b9e5d8a07fa8">


 ### Reviewing/Testing steps
Run Storybook  and navigate Filters > Organisms > FilterBar

Lower range
<img width="997" alt="Screenshot 2024-11-29 at 14 54 42" src="https://github.com/user-attachments/assets/43f0e869-ab0e-40fd-8ba8-fb7d2dc50ab6">

Within Range
<img width="851" alt="Screenshot 2024-11-29 at 14 54 49" src="https://github.com/user-attachments/assets/b4632028-b200-44a8-9875-ec54edfdb62f">

Upper Range
<img width="917" alt="Screenshot 2024-11-29 at 14 54 54" src="https://github.com/user-attachments/assets/a97f4ae9-ed81-4bbc-9d04-b4deeedba5a0">


