### PR TITLE
Datepicker Dot Markers

### DIFF
--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { boolean, object, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { DatePicker, FilterDropdownContainer } from 'scorer-ui-kit';
+import { dataContentDays, datesRange, InitialSelectedDate } from '../../helpers/datePicker_sample';
 
 const Container = styled.div`
   margin: 20px;
@@ -24,31 +25,9 @@ const exampleCallback = <T extends Function>(fn: T): T => {
   return fn;
 };
 
-const START_RANGE: Date = new Date();
-START_RANGE.setDate(0);
-START_RANGE.setDate(START_RANGE.getDate() - 20);
-const END_RANGE: Date = new Date();
-END_RANGE.setDate(1);
-END_RANGE.setDate(END_RANGE.getDate() + 60);
-
-
-const TODAY: Date = new Date();
-const TWO_WEEKS_BEFORE: Date = new Date();
-TWO_WEEKS_BEFORE.setDate(TODAY.getDate() - 15);
-
-
-const initialValue = {
-  start: TWO_WEEKS_BEFORE,
-  end: TODAY
-}
-const datesRange = {
-  start: START_RANGE,
-  end: END_RANGE
-}
-
 export const _DatePicker = () => {
   const language = select('Language', { English: 'en', Japanese: 'ja' }, 'ja');
-  const initialValueObj = object('Initial Value', initialValue);
+  const initialValueObj = object('Initial Value', InitialSelectedDate);
   const dateMode = select('Date Mode', { single: 'single', interval: 'interval' }, 'interval');
   const timeMode = select('Time Mode', { off: 'off', single: 'single', interval: 'interval' }, 'interval');
   const dateTimeTextUpper = text('Date Time Text Upper', 'From');
@@ -58,6 +37,8 @@ export const _DatePicker = () => {
   const updateCallback = action('Date / Time Updated');
   const sendRange = boolean('Send Available Range', true);
   const availableRangeDates = object('Available Range', datesRange);
+  const contentDaysObj = object('Content Days', dataContentDays);
+  const showContentDays = boolean('Show Content Days', true)
 
   return (
     <Container>
@@ -74,6 +55,7 @@ export const _DatePicker = () => {
           lang={language}
           initialValue={initialValueObj}
           availableRange={sendRange ? availableRangeDates : undefined}
+          contentDays={showContentDays ? contentDaysObj : undefined}
         />
       </FilterDropdownContainer>
     </Container>);

--- a/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
+++ b/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
@@ -11,7 +11,6 @@ import {
   IFilterResult,
   IFilterDatePicker,
   isFilterItem,
-  DateInterval,
 } from 'scorer-ui-kit'
 
 import {
@@ -47,6 +46,7 @@ import {
   filterByCreationDatePicker
 } from '../../helpers/sample_table_helpers';
 import { ITypeTableData } from 'scorer-ui-kit/dist/Tables';
+import { dataContentDays, datesRange, InitialSelectedDate } from '../../helpers/datePicker_sample';
 
 export default {
   title: 'Filters/Organism',
@@ -194,31 +194,6 @@ export const _FilterBar = () => {
     }
   ]
 
-
-  const TODAY: Date = new Date();
-  const TWO_WEEKS_BEFORE: Date = new Date();
-  TWO_WEEKS_BEFORE.setDate(TODAY.getDate() - 15);
-
-
-  // Selected example
-  const myDate: DateInterval = {
-  start: TWO_WEEKS_BEFORE,
-  end: TODAY
-  }
-
-  const START_RANGE: Date = new Date();
-  START_RANGE.setDate(0);
-  START_RANGE.setDate(START_RANGE.getDate() - 20);
-  const END_RANGE: Date = new Date();
-  END_RANGE.setDate(1);
-  END_RANGE.setDate(END_RANGE.getDate() + 60);
-
-  const datesRange = {
-  start: START_RANGE,
-  end: END_RANGE
-}
-
-
   const datePickers: IFilterDatePicker[] = [
     {
       id: 'datePickerForRuntime',
@@ -229,8 +204,9 @@ export const _FilterBar = () => {
       dateTimeTextLower: language === 'english' ? 'To' : 'まで',
       timeZoneTitle: language === 'english' ? 'Timezone' : '時間帯',
       lang: language === 'english' ? 'en' : 'ja',
-      selected: myDate,
+      selected: InitialSelectedDate,
       availableRange: datesRange,
+      contentDays: dataContentDays
     }
   ]
 

--- a/packages/storybook/src/stories/helpers/datePicker_sample.ts
+++ b/packages/storybook/src/stories/helpers/datePicker_sample.ts
@@ -1,13 +1,15 @@
 import { DateInterval } from "scorer-ui-kit";
 
 const TODAY: Date = new Date();
+const TOMORROW: Date = new Date();
+TOMORROW.setDate(TODAY.getDate() +1);
 const TWO_WEEKS_BEFORE: Date = new Date();
 TWO_WEEKS_BEFORE.setDate(TODAY.getDate() - 15);
 
 // Selected example
 const InitialSelectedDate: DateInterval = {
   start: TWO_WEEKS_BEFORE,
-  end: TODAY
+  end: TOMORROW
 }
 
 const START_RANGE: Date = new Date();

--- a/packages/storybook/src/stories/helpers/datePicker_sample.ts
+++ b/packages/storybook/src/stories/helpers/datePicker_sample.ts
@@ -1,0 +1,47 @@
+import { DateInterval } from "scorer-ui-kit";
+
+const TODAY: Date = new Date();
+const TWO_WEEKS_BEFORE: Date = new Date();
+TWO_WEEKS_BEFORE.setDate(TODAY.getDate() - 15);
+
+// Selected example
+const InitialSelectedDate: DateInterval = {
+  start: TWO_WEEKS_BEFORE,
+  end: TODAY
+}
+
+const START_RANGE: Date = new Date();
+START_RANGE.setDate(0);
+START_RANGE.setDate(START_RANGE.getDate() - 20);
+const END_RANGE: Date = new Date();
+END_RANGE.setDate(1);
+END_RANGE.setDate(END_RANGE.getDate() + 60);
+
+const datesRange = {
+  start: START_RANGE,
+  end: END_RANGE
+}
+
+const getContentDays = (): Date[] => {
+  const contentDayArray: Date[] = [];
+  const CONTENT_TODAY: Date = new Date();
+
+  for (let index = 0; index < 30; index++) {
+    if (index % 3 !== 0 && index <= 24) continue; // Skip non-content days
+
+    const dayContent = new Date(CONTENT_TODAY);
+    dayContent.setDate(CONTENT_TODAY.getDate() - 24 + index);
+
+    contentDayArray.push(dayContent);
+  }
+
+  return contentDayArray;
+};
+
+const dataContentDays: Date[] = getContentDays();
+
+export {
+  InitialSelectedDate,
+  datesRange,
+  dataContentDays,
+}

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -530,16 +530,19 @@ const DatePicker: React.FC<IDatePicker> = ({
             return (
               <CalRow key={index}>
                 {days.map((day, index) => {
+                  const dayState = cellState(day, selectedRange);
+                  const isTodayValue = isToday(day);
+
                   return (
                     <CalCellB
                       key={index}
                       disabled={isDayOutOfRange(day, availableRange)}
                       onClick={() => onCellClick(day)}
-                      state={cellState(day, selectedRange)}
+                      state={dayState}
                       thisMonth={isSameMonth(day, focusedMonth)}
-                      isToday={isToday(day)}>
+                      isToday={isTodayValue}>
                       {format(day, "d")}
-                      <ContentDot hasContent={dayHasContent(day, contentDays)} state={cellState(day, selectedRange)} isToday={isToday(day)}/>
+                      <ContentDot hasContent={dayHasContent(day, contentDays)} state={dayState} isToday={isTodayValue}/>
                     </CalCellB>
                   );
                 })}

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -195,6 +195,24 @@ const CalHCell = styled(CalCell)`
   color: var(--grey-a11);
 `;
 
+const ContentDot = styled.div<{ hasContent: boolean }>`
+  ${({ hasContent }) => hasContent ?
+    `
+      position: absolute;
+      left: 18px;
+      bottom: 5px;
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background-color: var(--info-10);
+    `
+    :
+    `
+      display: none;
+    `
+  }
+`;
+
 const CalCellB = styled(CalCell) <{ thisMonth?: boolean, isToday?: boolean, state?: CellStates }>`
   cursor: pointer;
   position: relative;
@@ -325,6 +343,7 @@ export interface IDatePicker {
   timeZoneTitle?: string
   timeZoneValueTitle?: string
   availableRange?: DateRange
+  contentDays?: Date[]
   updateCallback?: (data: DateInterval | Date) => void
   lang?: 'en' | 'ja'
 }
@@ -340,6 +359,7 @@ const DatePicker: React.FC<IDatePicker> = ({
   updateCallback = () => { },
   initialValue,
   availableRange,
+  contentDays,
   lang = 'en'
 }) => {
 
@@ -508,7 +528,9 @@ const DatePicker: React.FC<IDatePicker> = ({
                       onClick={() => onCellClick(day)}
                       state={cellState(day, selectedRange)}
                       thisMonth={isSameMonth(day, focusedMonth)}
-                      isToday={isToday(day)}>{format(day, "d")}
+                      isToday={isToday(day)}>
+                      {format(day, "d")}
+                      <ContentDot hasContent={dayHasContent(day, contentDays)} />
                     </CalCellB>
                   );
                 })}
@@ -643,4 +665,10 @@ const isDayOutOfRange = (currentDay: Date, availableRange?: DateRange): boolean 
   }
 
   return false;
+};
+
+const dayHasContent = (currentDay: Date, contentDays?: Date[]): boolean => {
+  if (!contentDays) return false;
+
+  return contentDays.some(day => isSameDay(currentDay,day));
 };

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -222,6 +222,10 @@ const ContentDot = styled.div<{ hasContent: boolean, state?: CellStates, isToday
   `}
 `;
 
+const DayText = styled.span`
+  transform: translateY(-1px);
+`;
+
 const CalCellB = styled(CalCell) <{ thisMonth?: boolean, isToday?: boolean, state?: CellStates }>`
   cursor: pointer;
   position: relative;
@@ -541,7 +545,9 @@ const DatePicker: React.FC<IDatePicker> = ({
                       state={dayState}
                       thisMonth={isSameMonth(day, focusedMonth)}
                       isToday={isTodayValue}>
-                      {format(day, "d")}
+                      <DayText>
+                        {format(day, "d")}
+                      </DayText>
                       <ContentDot hasContent={dayHasContent(day, contentDays)} state={dayState} isToday={isTodayValue}/>
                     </CalCellB>
                   );

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -202,10 +202,14 @@ const ContentDot = styled.div<{ hasContent: boolean, state?: CellStates, isToday
   width: 4px;
   height: 4px;
   border-radius: 50%;
-  background-color: var(--info-10);
+  background-color: var(--primary-11);
 
-  ${({ state }) => (state === 'single' || state === 'start' || state === 'end' || state === 'inside') && css`
+  ${({ state }) => (state === 'single' || state === 'start' || state === 'end') && css`
     background-color: var(--white-12);`
+  }
+
+  ${({ state }) => (state === 'inside') && css`
+    background-color: var(--primary-12);`
   }
 
   ${({ isToday }) => isToday && css`

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -195,22 +195,27 @@ const CalHCell = styled(CalCell)`
   color: var(--grey-a11);
 `;
 
-const ContentDot = styled.div<{ hasContent: boolean }>`
-  ${({ hasContent }) => hasContent ?
-    `
-      position: absolute;
-      left: 18px;
-      bottom: 5px;
-      width: 4px;
-      height: 4px;
-      border-radius: 50%;
-      background-color: var(--info-10);
-    `
-    :
-    `
-      display: none;
-    `
+const ContentDot = styled.div<{ hasContent: boolean, state?: CellStates, isToday?: boolean, }>`
+  position: absolute;
+  left: 18px;
+  bottom: 5px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background-color: var(--info-10);
+
+  ${({ state }) => (state === 'single' || state === 'start' || state === 'end' || state === 'inside') && css`
+    background-color: var(--white-12);`
   }
+
+  ${({ isToday }) => isToday && css`
+    left: 16px;
+    bottom: 3px;
+  `}
+
+  ${({ hasContent }) => !hasContent && css`
+    display: none;
+  `}
 `;
 
 const CalCellB = styled(CalCell) <{ thisMonth?: boolean, isToday?: boolean, state?: CellStates }>`
@@ -530,7 +535,7 @@ const DatePicker: React.FC<IDatePicker> = ({
                       thisMonth={isSameMonth(day, focusedMonth)}
                       isToday={isToday(day)}>
                       {format(day, "d")}
-                      <ContentDot hasContent={dayHasContent(day, contentDays)} />
+                      <ContentDot hasContent={dayHasContent(day, contentDays)} state={cellState(day, selectedRange)} isToday={isToday(day)}/>
                     </CalCellB>
                   );
                 })}

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -39,6 +39,7 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
   lang,
   hasEmptyValue,
   availableRange,
+  contentDays,
   onCloseCallback = () => { },
   onUpdateCallback = () => { },
   onToggleCallback = () => { },
@@ -109,7 +110,8 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
                 timeZoneTitle,
                 timeZoneValueTitle,
                 lang,
-                availableRange
+                availableRange,
+                contentDays,
               }}
               updateCallback={handleUpdateCallback}
               hasEmptyValue


### PR DESCRIPTION
### Description

This is a new Feature request for the Datepicker

`
A new date picker feature where a list of dates or date ranges can be provided which will then place a dot on the date picker to signify, for example, that there is content available to view within that range.
`

 ### Considerations on Implementation
Moved examples data to new data helper file for DatePicker examples.
I decided to add go with the dates array for content.

 ### Reviewing/Testing steps
Test in Storybook

Filters -> Molecules -> DatePicker


<img width="610" alt="Screenshot 2024-12-05 at 13 48 13" src="https://github.com/user-attachments/assets/b738d963-eadf-41d2-b4dd-47828d37acb6">

Filters -> Organism -> FilterBar

<img width="975" alt="Screenshot 2024-12-05 at 13 48 43" src="https://github.com/user-attachments/assets/c3ea9106-7b5c-4472-8a1a-e7faf987131f">
