### PR TITLE
Bugfix/525 Pagination fix with Label refactor

### DIFF
--- a/packages/storybook/src/stories/Form/Input/RadioButton.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/RadioButton.stories.tsx
@@ -31,17 +31,17 @@ export const _RadioButton = () => {
   return (
     <Container>
       <OptionsWrapper>
-        <Label htmlFor={'option1'} labelText={'Option 1'} rightAlign>
+        <Label htmlFor={'option1'} labelText={'Option 1'} direction='row-reverse'>
           <RadioButton {...{ name, disabled, currentChecked }} id={'option1'} value='option1' onChangeCallback={handleChange} />
         </Label>
       </OptionsWrapper>
       <OptionsWrapper>
-        <Label htmlFor={'option2'} labelText={'Option 2'} rightAlign>
+        <Label htmlFor={'option2'} labelText={'Option 2'} direction='row-reverse'>
           <RadioButton {...{ name, disabled, currentChecked }} id={'option2'} value='option2' onChangeCallback={handleChange} />
         </Label>
       </OptionsWrapper>
       <OptionsWrapper>
-        <Label htmlFor={'option3'} labelText={'Option 3'} rightAlign>
+        <Label htmlFor={'option3'} labelText={'Option 3'} direction='row-reverse'>
           <RadioButton {...{ name, disabled, currentChecked }} id={'option3'} value='option3' onChangeCallback={handleChange} />
         </Label>
       </OptionsWrapper>

--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -1,41 +1,18 @@
 import React, { LabelHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 
-export const StyledLabel = styled.label<{ rightAlign: boolean }>`
-  font-family: ${({ theme }) => theme.fontFamily.ui};
+export const StyledLabel = styled.label<{  }>`
+  font-family: var(--font-ui);
   color: var(--grey-11);
   font-size: 14px;
   font-weight: 500;
-  ${({ rightAlign }) => rightAlign
-    ? `
-        display: flex;
-        align-items: center;
-        flex-direction: row-reverse;
-        justify-content: left;
-      `
-    :
-    `
-        display: block;
-        margin-bottom: 20px;
-      `
-  };
+
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 `;
 
-const LabelText = styled.span<{ rightAlign: boolean, required?: boolean }>`
-  display: flex;
-  gap: 8px;
-  align-items: center;
-
-
-  ${({ rightAlign }) => rightAlign
-      ? `
-        margin-left: 12px;
-        `
-      : `
-        margin-bottom: 10px;
-      `
-  }
-
+const LabelText = styled.span<{ required?: boolean }>`
   ${({required}) => required && css`
     &::after {
       content: '';
@@ -64,9 +41,13 @@ const Label: React.FC<Props> = ({
   children,
   ...props }) => {
 
+    if(rightAlign){
+      console.warn('Deprecation warning: `Label` is deprecating `rightAlign`, please update this to use `direction=\'column\'` instead.');
+    };
+
   return (
-    <StyledLabel {...{ htmlFor, rightAlign }} {...props}>
-      <LabelText {...{ rightAlign, required }}>{labelText}</LabelText>
+    <StyledLabel {...{ htmlFor }} {...props}>
+      <LabelText {...{ required }}>{labelText}</LabelText>
       {children}
     </StyledLabel>
   );

--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -27,6 +27,8 @@ export const StyledLabel = styled.label<{ direction: TypeLabelDirection }>`
   ${({direction}) => direction && css`
     flex-direction: ${direction};
     ${['row', 'row-reverse'].includes(direction) && css`
+      display: inline-flex;
+      
       ${LabelText}{
         align-self: center;
       }

--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -1,16 +1,6 @@
 import React, { LabelHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
-
-export const StyledLabel = styled.label<{  }>`
-  font-family: var(--font-ui);
-  color: var(--grey-11);
-  font-size: 14px;
-  font-weight: 500;
-
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;
+import { TypeLabelDirection } from '..';
 
 const LabelText = styled.span<{ required?: boolean }>`
   ${({required}) => required && css`
@@ -25,9 +15,29 @@ const LabelText = styled.span<{ required?: boolean }>`
   `}
 `;
 
+export const StyledLabel = styled.label<{ direction: TypeLabelDirection }>`
+  font-family: var(--font-ui);
+  color: var(--grey-11);
+  font-size: 14px;
+  font-weight: 500;
+
+  display: inline-flex;
+  gap: 8px;
+
+  ${({direction}) => direction && css`
+    flex-direction: ${direction};
+    ${['row', 'row-reverse'].includes(direction) && css`
+      ${LabelText}{
+        align-self: center;
+      }
+    `}
+  `}
+`;
+
 interface OwnProps {
   htmlFor: string
   labelText: string
+  direction?: TypeLabelDirection
   rightAlign?: boolean
   required?: boolean
 }
@@ -36,6 +46,7 @@ type Props = OwnProps & LabelHTMLAttributes<HTMLLabelElement>
 const Label: React.FC<Props> = ({
   htmlFor,
   labelText,
+  direction = 'column',
   rightAlign = false,
   required = false,
   children,
@@ -43,10 +54,10 @@ const Label: React.FC<Props> = ({
 
     if(rightAlign){
       console.warn('Deprecation warning: `Label` is deprecating `rightAlign`, please update this to use `direction=\'column\'` instead.');
-    };
+    }
 
   return (
-    <StyledLabel {...{ htmlFor }} {...props}>
+    <StyledLabel {...{ htmlFor, direction }} {...props}>
       <LabelText {...{ required }}>{labelText}</LabelText>
       {children}
     </StyledLabel>

--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -21,7 +21,7 @@ export const StyledLabel = styled.label<{ direction: TypeLabelDirection }>`
   font-size: 14px;
   font-weight: 500;
 
-  display: inline-flex;
+  display: flex;
   gap: 8px;
 
   ${({direction}) => direction && css`

--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -55,7 +55,8 @@ const Label: React.FC<Props> = ({
   ...props }) => {
 
     if(rightAlign){
-      console.warn('Deprecation warning: `Label` is deprecating `rightAlign`, please update this to use `direction=\'column\'` instead.');
+      console.warn('Deprecation warning: `Label` is deprecating `rightAlign`, please update this to use `direction=\'row-reverse\'` instead.');
+      direction = 'row-reverse';
     }
 
   return (

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -81,7 +81,7 @@ const StyledSelect = styled.select<{ fieldState: TypeFieldState, withIcon?: bool
   }
 `;
 
-const Container = styled.div<{ isCompact?: boolean, activePlaceholder: boolean, isLabelSameRow?: boolean }>`
+const Container = styled.div<{ isCompact?: boolean, activePlaceholder: boolean }>`
 
   ${({activePlaceholder}) => activePlaceholder && css`
     ${StyledSelect} {
@@ -124,6 +124,10 @@ const SelectField: React.FC<ISelect> = ({
   ...props
 }) => {
 
+  if(label?.isSameRow){
+    console.warn('Deprecation warning: `SelectField` is deprecating `label.isSameRow`, please update this to use `label.direction` set to `row`.');
+  }
+
   const [activePlaceholder, setPlaceholderStatus] = useState<boolean>(!defaultValue ? true : false);
 
   const handleOnChange = useCallback((e) => {
@@ -164,7 +168,7 @@ const SelectField: React.FC<ISelect> = ({
   ), [children, defaultValue, handleOnChange, placeholder, props, fieldState, icon, iconColor, isCompact]);
 
   return (
-    <Container {...{ isCompact, activePlaceholder }} isLabelSameRow={label?.isSameRow}>
+    <Container {...{ isCompact, activePlaceholder }}>
       {label
         ? (
           <Label htmlFor={label.htmlFor} labelText={label.text} direction={ label.isSameRow ? 'row' : label.direction }>

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState, SelectHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import Label from './Label';
 import Icon from '../../Icons/Icon';
-import { TypeFieldState } from '..';
+import { TypeFieldState, TypeLabelDirection } from '..';
 
 
 export const SelectWrapper = styled.div`
@@ -83,10 +83,6 @@ const StyledSelect = styled.select<{ fieldState: TypeFieldState, withIcon?: bool
 
 const Container = styled.div<{ isCompact?: boolean, activePlaceholder: boolean, isLabelSameRow?: boolean }>`
 
-  span {
-    margin-bottom: 8px;
-  }
-
   ${({activePlaceholder}) => activePlaceholder && css`
     ${StyledSelect} {
       font-family: var(--font-data);
@@ -102,6 +98,7 @@ interface ILabel {
   htmlFor: string
   text: string
   isSameRow?: boolean
+  direction?: TypeLabelDirection
 }
 
 interface OwnProps {
@@ -170,7 +167,7 @@ const SelectField: React.FC<ISelect> = ({
     <Container {...{ isCompact, activePlaceholder }} isLabelSameRow={label?.isSameRow}>
       {label
         ? (
-          <Label htmlFor={label.htmlFor} labelText={label.text}>
+          <Label htmlFor={label.htmlFor} labelText={label.text} direction={ label.isSameRow ? 'row' : label.direction }>
             {renderSelect(label.htmlFor)}
           </Label>
         )

--- a/packages/ui-lib/src/Form/index.ts
+++ b/packages/ui-lib/src/Form/index.ts
@@ -64,6 +64,9 @@ export type TypeButtonSizes = 'xsmall' | 'small' | 'normal' | 'large';
 export type ISelectSizes = 'small' | 'normal';
 export type IInputOptionsType = "text" | "checkbox" | "radio";
 
+export type TypeLabelDirection = 'column' | 'row' | 'row-reverse';
+
+
 interface ButtonProps {
   size?: TypeButtonSizes
   design?: TypeButtonDesigns

--- a/packages/ui-lib/src/Misc/molecules/Pagination.tsx
+++ b/packages/ui-lib/src/Misc/molecules/Pagination.tsx
@@ -5,7 +5,7 @@ import Icon from '../../Icons/Icon';
 import { removeAutoFillStyle, resetButtonStyles } from '../../common';
 import { isNotNumber } from '../../helpers';
 import SelectField, { SelectWrapper } from '../../Form/atoms/SelectField';
-import { StyledLabel } from  '../../Form/atoms/Label';
+import Label from  '../../Form/atoms/Label';
 
 const WIDTH_PER_NUMBER = 12;
 
@@ -19,16 +19,8 @@ const PaginationContainer = styled.div`
   height: fit-content;
   margin-right: 10px;
   white-space: nowrap;
-  gap: 0 8px;
+  gap: 40px;
   vertical-align: baseline;
-`;
-
-const PageLabel = styled.label`
-  font-family: var(--font-ui);
-  font-weight: 500px;
-  font-size: 14px;
-  color: var(--grey-10);
-  text-align: left;
 `;
 
 const StaticPageCount = styled.div`
@@ -43,9 +35,9 @@ const StaticPageCount = styled.div`
   padding-right: 1px;
 `;
 
-const StyledInput = styled.input<{ textColor: string, maxWidth?: string }>`
+const StyledInput = styled.input<{ maxWidth?: string }>`
   ${removeAutoFillStyle};
-  color: ${({ textColor }) => textColor};
+  color: var(--input-color-default);
   max-width: ${({ maxWidth }) => maxWidth ? maxWidth : '40px'};
   font-family: var(--font-data);
   height: 100%;
@@ -67,7 +59,7 @@ const shakeAnimation = keyframes`
   100% { transform: translateX(0); }
 `;
 
-const InputContainer = styled.div<{ borderColor?: string, shouldShake: boolean }>`
+const InputContainer = styled.div<{ borderColorState?: string, shouldShake: boolean }>`
   height: var(--input-height, 40px);
   animation: ${({ shouldShake }) => (shouldShake ? shakeAnimation : 'none')} 150ms 2 linear;
   flex-grow: 0;
@@ -78,7 +70,7 @@ const InputContainer = styled.div<{ borderColor?: string, shouldShake: boolean }
   padding: 0 8px;
   border-radius: 3px;
   box-shadow: 0 2px 1px 0 rgba(0, 102, 255, 0.04);
-  ${({ borderColor }) => borderColor && `border: 1px solid ${borderColor}`};
+  ${({ borderColorState }) => borderColorState && `border: 1px solid var(--input-${borderColorState}-border-color)`};
 `;
 
 const GoButton = styled(Button)`
@@ -99,7 +91,7 @@ const ArrowButton = styled.button<{ active: boolean }>`
   padding: 12px;
   border-radius: 3px;
   box-shadow: 0 4px 9px 0 rgba(152, 174, 189, 0.07);
-  border: solid 1px var(--grey-9);
+  border: solid 1px var(--input-default-border-color);
   background-color: var(grey-2);
   pointer-events: ${({ active }) => active ? 'auto' : 'none'};
   opacity: ${({ active }) => active ? '1' : '0.5'};
@@ -112,11 +104,6 @@ const ArrowButton = styled.button<{ active: boolean }>`
 const ItemsSelectWrapper = styled.div<{ width: string }>`
   ${SelectWrapper} {
     width: ${({ width }) => width ? width : `60px`};
-  }
-    margin-right: 35px;
-
-  ${StyledLabel} {
-    margin-bottom: 0;
   }
 `;
 
@@ -257,23 +244,6 @@ const Pagination: React.FC<IPagination> = (props) => {
 
   };
 
-  const getStateColor = useCallback((state: string): string => {
-
-    switch (state) {
-      case 'processing':
-        return 'var(--primary-7)';
-        break;
-
-      case 'invalid':
-        return 'var(--warning-8)';
-
-      case 'default':
-      default:
-        return 'var(--grey-9)';
-    }
-
-  }, []);
-
   const onClickGo = useCallback(() => {
 
     onPageChange(parseInt(pageValue));
@@ -326,37 +296,38 @@ const Pagination: React.FC<IPagination> = (props) => {
           </Fragment>
         </SelectField>
       </ItemsSelectWrapper>
-      <PageLabel htmlFor='goButton'>{pageText}</PageLabel>
-      <InputContainer borderColor={getStateColor(fieldState)} shouldShake={shouldShake}>
-        <StyledInput
-          ref={inputRef}
-          value={pageValue}
-          onChange={(e) => onInputChange(e)}
-          textColor={getStateColor(fieldState)}
-          onFocus={(e) => onFocus(e)}
-          onBlur={(e) => onBlur(e)}
-          onPaste={(e) => handlePaste(e)}
-          onKeyDown={handleKeyDown}
-          maxWidth={getValidWidth()}
-        />
-        <StaticPageCount>{'/' + '\u00A0' + totalPages.toString()}</StaticPageCount>
-        <GoButton id='goButton' size='small' design='primary' disabled={disableGo} onClick={onClickGo}>{buttonText}</GoButton>
-      </InputContainer>
+      <Label labelText={pageText} htmlFor='goButton' direction='row'>
+        <InputContainer borderColorState={fieldState} shouldShake={shouldShake}>
+          <StyledInput
+            ref={inputRef}
+            value={pageValue}
+            onChange={(e) => onInputChange(e)}
+            onFocus={(e) => onFocus(e)}
+            onBlur={(e) => onBlur(e)}
+            onPaste={(e) => handlePaste(e)}
+            onKeyDown={handleKeyDown}
+            maxWidth={getValidWidth()}
+          />
+          <StaticPageCount>{'/' + '\u00A0' + totalPages.toString()}</StaticPageCount>
+          <GoButton id='goButton' size='small' design='primary' disabled={disableGo} onClick={onClickGo}>{buttonText}</GoButton>
+        </InputContainer>
 
-      <ArrowWrapper>
-        <ArrowButton
-          onClick={() => handlePageChange(activePage - 1)}
-          disabled={activePage <= 1}
-          active={fieldState === 'default' && activePage > 1}>
-          <Icon icon='Left' color='dimmed' size={8} />
-        </ArrowButton>
-        <ArrowButton
-          onClick={() => handlePageChange(activePage + 1)}
-          disabled={activePage >= totalPages}
-          active={fieldState === 'default' && activePage < totalPages}>
-          <Icon icon='Right' color='dimmed' size={8} />
-        </ArrowButton>
-      </ArrowWrapper>
+        <ArrowWrapper>
+          <ArrowButton
+            onClick={() => handlePageChange(activePage - 1)}
+            disabled={activePage <= 1}
+            active={fieldState === 'default' && activePage > 1}>
+            <Icon icon='Left' color='input-lead-icon' size={8} />
+          </ArrowButton>
+          <ArrowButton
+            onClick={() => handlePageChange(activePage + 1)}
+            disabled={activePage >= totalPages}
+            active={fieldState === 'default' && activePage < totalPages}>
+            <Icon icon='Right' color='input-lead-icon' size={8} />
+          </ArrowButton>
+        </ArrowWrapper>
+      </Label>
+
     </PaginationContainer>
   );
 };


### PR DESCRIPTION
This fix was primarily to fix issue #525, however it also includes related fixes and refactoring to the `Label` component to bring that more in line with the flex approach we are taking more now. This in turn will make it more easily used among other components which should but don't yet use it.

The main change to be aware of is the addition of the new `direction` prop which will be used to handle where the label is in relation to the field is it wrapping.

`column` is the default. It is used when the label is above, such as for text inputs.
`row` is used when the label should be to the left of the input. For example, the pagination controls do this.
`row-reverse` is used when the text goes after the input, such as in the case of radio buttons.


## Deprecations and Risks
The following two props have been marked for deprecation however will default the value needed to replicate the required behaviour, along with a console warning to advise on how to fix it moving forward.

While there is no expected cases this should break, please be cautious when updating to make sure there are no unexpected errors.

As the props are fairly uniquely named, it should be easy to search your project for instances that need fixing:
`SelectField` prop `isSameRow` should be replaced by `direction='row'`
`Label` prop `rightAlign` should be replaced by `direction='row-reverse'`

## Other Changes
There have been updates to some of the colors in the `Pagination` component to bring them more in to line with recent input refactors and theming.

## Relating to 525 - Pagination Fix
Here is a screenshot of the restored and refactored Pagination component.
![image](https://github.com/user-attachments/assets/d2ef3c3d-9d78-4587-aabe-636d0c7258e6)
