### PR TITLE
Fix circular dependency error for  FilterButtonDesign type

### DIFF
--- a/packages/ui-lib/src/Filters/FilterTypes.ts
+++ b/packages/ui-lib/src/Filters/FilterTypes.ts
@@ -67,6 +67,8 @@ interface IFilterDropdownConfig {
   name?: string
 }
 
+type FilterButtonDesign = 'default' | 'basic'
+
 export {
   isFilterItem
 };
@@ -81,4 +83,5 @@ export type {
   IFilterDatePicker,
   IFilterDropdownConfig,
   IToggleOption,
+  FilterButtonDesign,
 };

--- a/packages/ui-lib/src/Filters/atoms/FilterButton.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterButton.tsx
@@ -3,7 +3,7 @@ import styled, { css, keyframes } from 'styled-components';
 import { resetButtonStyles } from '../../common';
 import Icon, { IconWrapper } from '../../Icons/Icon';
 import { animation } from '../../theme/common';
-import { FilterButtonDesign } from '..';
+import { FilterButtonDesign } from '../FilterTypes';
 
 const LeftIconWrapper = styled.div<{ isSortAscending: boolean }>`
   ${({ isSortAscending }) => isSortAscending && css`

--- a/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import styled, { css } from 'styled-components';
 import FilterButton from '../atoms/FilterButton';
 import { useClickOutside } from '../../hooks/useClickOutside';
-import { FilterButtonDesign } from '..';
+import { FilterButtonDesign } from '../FilterTypes';
 
 const Container = styled.div`
   position: relative;

--- a/packages/ui-lib/src/Filters/atoms/ToggleButton.tsx
+++ b/packages/ui-lib/src/Filters/atoms/ToggleButton.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { IToggleOption } from '../FilterTypes';
 import FilterButton from './FilterButton';
-import { FilterButtonDesign } from '..';
+import { FilterButtonDesign } from '../FilterTypes';
 
 type IToggleButton = {
   options: IToggleOption[]

--- a/packages/ui-lib/src/Filters/index.ts
+++ b/packages/ui-lib/src/Filters/index.ts
@@ -20,6 +20,7 @@ import {
   IFilterDatePicker,
   isFilterItem,
   IToggleOption,
+  FilterButtonDesign
 } from './FilterTypes';
 
 export {
@@ -36,8 +37,6 @@ export {
   isDateInterval,
   ToggleButton
 };
-
-type FilterButtonDesign = 'default' | 'basic'
 
 export type {
   ISearchFilter,

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -8,7 +8,7 @@ import { IFilterItem, IFilterValue, isFilterItem } from '../FilterTypes';
 import FilterDropHandler from '../atoms/FilterDropHandler';
 import FilterDropdownContainer from '../atoms/FilterDropdownContainer';
 import LoadingBox from '../atoms/LoadingBox';
-import { FilterButtonDesign } from '..';
+import { FilterButtonDesign } from '../FilterTypes';
 
 const Container = styled.div`
   display: inline-block;
@@ -303,7 +303,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
         onCloseCallback={handleClose}
         onToggleOpenCallback={handleToggleOpen}
       >
-        <FilterDropdownContainer>          
+        <FilterDropdownContainer>
           {hasOptionsFilter && (
             <SearchWrapper>
               <BasicSearchInput

--- a/packages/ui-lib/src/Filters/molecules/SortDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/SortDropdown.tsx
@@ -4,9 +4,9 @@ import Icon, { IconWrapper } from '../../Icons/Icon';
 import FilterOption from '../../Form/atoms/FilterOption';
 import FilterDropHandler from '../atoms/FilterDropHandler';
 import LoadingBox from '../atoms/LoadingBox';
-import { IFilterItem } from '../FilterTypes';
+import { IFilterItem, FilterButtonDesign } from '../FilterTypes';
 import { resetButtonStyles } from '../../common';
-import { FilterButtonDesign, FilterDropdownContainer } from '..';
+import FilterDropdownContainer from '../atoms/FilterDropdownContainer';
 
 const Container = styled.div`
   display: inline-block;


### PR DESCRIPTION
### Description

There was an error introduction when `FilterButtonDesign` type was added on the Filters index in the refactor of SortDropdown. https://github.com/future-standard/scorer-ui-kit/issues/511

`
Circular dependency: src/Filters/index.ts -> src/Filters/molecules/SortDropdown.tsx -> src/Filters/index.ts
Circular dependency: src/Filters/index.ts -> src/Filters/molecules/SortDropdown.tsx -> src/Filters/index.ts
`

 ### Considerations on Implementation

The circular dependency was fixed by moving the type from index to the Filter types files, all files that use `FilterButtonDesign` type were updated.

 ### Reviewing/Testing steps

Due the nature of the error, this can only be seen on the logs for the hot reload of ui-lib package.
Run the project on local and review the circular dependency error is not present.


![Screenshot 2024-12-09 at 11 57 55](https://github.com/user-attachments/assets/a48a3474-9a0a-4e31-a3a3-ffebca01303e)
