### PR TITLE
Post-Merge Label and Switch conflict fix

### DIFF
--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -15,7 +15,7 @@ const LabelText = styled.span<{ required?: boolean }>`
   `}
 `;
 
-export const StyledLabel = styled.label<{ direction: TypeLabelDirection }>`
+export const StyledLabel = styled.label<{ direction?: TypeLabelDirection }>`
   font-family: var(--font-ui);
   color: var(--grey-11);
   font-size: 14px;

--- a/packages/ui-lib/src/Misc/molecules/Pagination.tsx
+++ b/packages/ui-lib/src/Misc/molecules/Pagination.tsx
@@ -285,7 +285,7 @@ const Pagination: React.FC<IPagination> = (props) => {
       <ItemsSelectWrapper width={selectWidth}>
         <SelectField
           disabled={selectDisabled}
-          label={{ htmlFor: selectId, text: itemsText, isSameRow: true }}
+          label={{ htmlFor: selectId, text: itemsText, direction: 'row' }}
           defaultValue={itemsDefaultValue ? itemsDefaultValue : itemsOptions[0].value || 1}
           changeCallback={onItemsSelectChange}
         >


### PR DESCRIPTION
This fixes the conflict that arose with `Switch` after it was merged along with additional `Label` refactors. There are two parts.

1. Made the `direction` prop optional, as originally intended.
2. Removed the old `sameRow` implementation from `Pagination` and updated it to the new `direction` prop.