### PR TITLE
UtilityHeader label props and refactor

### DIFF
--- a/packages/example/src/pages/Layouts.tsx
+++ b/packages/example/src/pages/Layouts.tsx
@@ -21,11 +21,10 @@ const Layouts: FC = () => {
 
   const ExampleContent : IHeaderContent = {
     UtilityHeaderOptions: {
-      backLink: '/',
+      back: { label: "Back", link: "/" },
       breadcrumbs: [{text:'Examples', href:'/'},{text:'Two', href:'#2'},{text:'Three', href:'#3'},{text:'Four', href:'#4'},{text:'Five', href:'#5'}],
       showBreadcrumbs: true,
-      showShareLink: true,
-      shareLink: 'http://www.example.com/'
+      share: { show: true, label: "Share", link: "https://www.example.com", copiedLabel: "Copied" }
     },
     PageHeaderArea: <PageHeader
     title='Welcome'

--- a/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -70,11 +70,10 @@ const buttonList : IButtonStack[] = [
 
 const ExampleContent : IHeaderContent = {
   UtilityHeaderOptions: {
-    backLink: '/',
+    back: { label: "Back", link: "/" },
     breadcrumbs: [{text:'Examples', href:'/'},{text:'Two', href:'#2'},{text:'Three', href:'#3'},{text:'Four', href:'#4'},{text:'Five', href:'#5'}],
     showBreadcrumbs: true,
-    showShareLink: true,
-    shareLink: 'http://www.example.com/'
+    share: { show: true, label: "Share", link: "https://www.example.com", copiedLabel: "Copied" }
   },
   PageHeaderArea: <PageHeader
     title='Welcome'

--- a/packages/storybook/src/stories/Global/molecules/UtilityHeader.stories.tsx
+++ b/packages/storybook/src/stories/Global/molecules/UtilityHeader.stories.tsx
@@ -4,7 +4,7 @@ import {
 } from 'scorer-ui-kit';
 
 import styled from 'styled-components';
-import { text, object, boolean } from '@storybook/addon-knobs';
+import { object, boolean } from '@storybook/addon-knobs';
 
 export default {
   title: 'Global/molecules',
@@ -25,8 +25,7 @@ const Container = styled.div`
 `;
 
 export const _UtilityHeader = () => {
-  
-  const backLink = text("Back Link", "/");
+  const backLink = object("Back Link", { label: "Back", link: "/" });
   const showBreadcrumbs = boolean("Show Breadcrumbs", true);
   const showHomeIcon = boolean("Show Home Icon", true);
   const breadcrumbs = object("breadcrumbs", [
@@ -51,18 +50,16 @@ export const _UtilityHeader = () => {
       href:'#5'
     }
   ]);
-  const showShareLink = boolean("Show Share Link", true);
-  const shareLink = text("Share Link", "http://www.example.com/");
+  const shareLink = object("Share Link", { show: true, label: "Share", link: "https://www.example.com", copiedLabel: "Copied" });
   
   return (
     <Container>
       <UtilityHeader 
-        backLink={backLink}
+        back={backLink}
         showBreadcrumbs={showBreadcrumbs}
         breadcrumbs={breadcrumbs}
         showHomeIcon={showHomeIcon}
-        showShareLink={showShareLink}
-        shareLink={shareLink}
+        share={shareLink}
       />
     </Container>
   )

--- a/packages/storybook/src/stories/Global/organisms/ContentLayout.stories.tsx
+++ b/packages/storybook/src/stories/Global/organisms/ContentLayout.stories.tsx
@@ -31,11 +31,10 @@ const Container = styled.div`
 
 const ExampleContent : IHeaderContent = {
   UtilityHeaderOptions: {
-    backLink: '/',
+    back: { label: "Back", link: "/" },
     breadcrumbs: [{text:'Examples', href:'/'},{text:'Two', href:'#2'},{text:'Three', href:'#3'},{text:'Four', href:'#4'},{text:'Five', href:'#5'}],
     showBreadcrumbs: true,
-    showShareLink: true,
-    shareLink: 'http://www.example.com/'
+    share: { show: true, label: "Share", link: "https://www.example.com", copiedLabel: "Copied" }
   },
   PageHeaderArea: <PageHeader
     title='Welcome'

--- a/packages/ui-lib/src/Layouts/atoms/UtilityHeaderBack.tsx
+++ b/packages/ui-lib/src/Layouts/atoms/UtilityHeaderBack.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import styled, { css } from "styled-components";
+import {Link} from 'react-router-dom';
+import Icon from "../../Icons/Icon";
+import { IUtilityHeaderLinkBack } from "..";
+
+const BackLinkIcon = styled.div`
+  display: flex;
+  width: 16px;
+  height: 16px;
+  justify-content: center;
+  align-items: center;
+  flex: 1;  
+  > div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
+const BackLink = styled(Link)<{iconInGutter: boolean, showDivider: boolean}>`
+  position: relative;
+  display: flex;
+  padding: 0;
+  align-items: center;
+  gap: 8px;
+  color: var(--grey-10);
+  text-align: center;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  border: none;
+  background: none;
+  text-decoration: none;
+  transition: color 0.25s ease;
+  margin-left: ${props => props.iconInGutter ? '-24px' : '0' };
+
+  ${BackLinkIcon}{
+    svg * {
+      transition: stroke 0.25s ease;
+    }
+  }
+  
+  &:hover {
+    color: var(--grey-12);
+    ${BackLinkIcon}{
+      svg * {
+        stroke: var(--grey-12);
+      }
+    }
+  }
+
+  ${({showDivider}) => showDivider && css`
+    &::after {
+      content: '';
+      display: inline-block;
+      height: 12px;
+      width: 1px;
+      padding-left: 8px;
+      border-right: 1px solid var(--grey-10);
+    }
+  `}
+`;
+
+interface IUtilityHeaderLinkBackInstance extends IUtilityHeaderLinkBack {
+  iconInGutter: boolean;
+  showDivider: boolean;
+}
+
+const UtilityHeaderBack : React.FC<IUtilityHeaderLinkBackInstance> = ({show = true, link, label = 'Back', showDivider, iconInGutter}) => {
+  if(!show){ return null; }
+
+  return (
+    <BackLink to={link} {...{showDivider, iconInGutter}}>
+      <BackLinkIcon>
+        <Icon icon="Back" size={16} color="grey-10" />
+      </BackLinkIcon>
+      {label}
+    </BackLink>
+  );
+};
+
+export default UtilityHeaderBack;

--- a/packages/ui-lib/src/Layouts/atoms/UtilityHeaderBack.tsx
+++ b/packages/ui-lib/src/Layouts/atoms/UtilityHeaderBack.tsx
@@ -18,7 +18,7 @@ const BackLinkIcon = styled.div`
   }
 `;
 
-const BackLink = styled(Link)<{iconInGutter: boolean, showDivider: boolean}>`
+const BackLink = styled(Link)<{$iconInGutter: boolean, showDivider: boolean}>`
   position: relative;
   display: flex;
   padding: 0;
@@ -35,7 +35,7 @@ const BackLink = styled(Link)<{iconInGutter: boolean, showDivider: boolean}>`
   background: none;
   text-decoration: none;
   transition: color 0.25s ease;
-  margin-left: ${props => props.iconInGutter ? '-24px' : '0' };
+  margin-left: ${props => props.$iconInGutter ? '-24px' : '0' };
 
   ${BackLinkIcon}{
     svg * {
@@ -65,15 +65,15 @@ const BackLink = styled(Link)<{iconInGutter: boolean, showDivider: boolean}>`
 `;
 
 interface IUtilityHeaderLinkBackInstance extends IUtilityHeaderLinkBack {
-  iconInGutter: boolean;
+  $iconInGutter: boolean;
   showDivider: boolean;
 }
 
-const UtilityHeaderBack : React.FC<IUtilityHeaderLinkBackInstance> = ({show = true, link, label = 'Back', showDivider, iconInGutter}) => {
+const UtilityHeaderBack : React.FC<IUtilityHeaderLinkBackInstance> = ({show = true, link, label = 'Back', showDivider, $iconInGutter}) => {
   if(!show){ return null; }
 
   return (
-    <BackLink to={link} {...{showDivider, iconInGutter}}>
+    <BackLink to={link} {...{showDivider, $iconInGutter}}>
       <BackLinkIcon>
         <Icon icon="Back" size={16} color="grey-10" />
       </BackLinkIcon>

--- a/packages/ui-lib/src/Layouts/atoms/UtilityHeaderBack.tsx
+++ b/packages/ui-lib/src/Layouts/atoms/UtilityHeaderBack.tsx
@@ -10,7 +10,7 @@ const BackLinkIcon = styled.div`
   height: 16px;
   justify-content: center;
   align-items: center;
-  flex: 1;  
+  flex: 1;
   > div {
     display: flex;
     justify-content: center;
@@ -18,7 +18,7 @@ const BackLinkIcon = styled.div`
   }
 `;
 
-const BackLink = styled(Link)<{$iconInGutter: boolean, showDivider: boolean}>`
+const BackLink = styled(Link)<{$iconInGutter: boolean, $showDivider: boolean}>`
   position: relative;
   display: flex;
   padding: 0;
@@ -42,7 +42,7 @@ const BackLink = styled(Link)<{$iconInGutter: boolean, showDivider: boolean}>`
       transition: stroke 0.25s ease;
     }
   }
-  
+
   &:hover {
     color: var(--grey-12);
     ${BackLinkIcon}{
@@ -52,7 +52,7 @@ const BackLink = styled(Link)<{$iconInGutter: boolean, showDivider: boolean}>`
     }
   }
 
-  ${({showDivider}) => showDivider && css`
+  ${({$showDivider}) => $showDivider && css`
     &::after {
       content: '';
       display: inline-block;
@@ -66,14 +66,14 @@ const BackLink = styled(Link)<{$iconInGutter: boolean, showDivider: boolean}>`
 
 interface IUtilityHeaderLinkBackInstance extends IUtilityHeaderLinkBack {
   $iconInGutter: boolean;
-  showDivider: boolean;
+  $showDivider: boolean;
 }
 
-const UtilityHeaderBack : React.FC<IUtilityHeaderLinkBackInstance> = ({show = true, link, label = 'Back', showDivider, $iconInGutter}) => {
+const UtilityHeaderBack : React.FC<IUtilityHeaderLinkBackInstance> = ({show = true, link, label = 'Back', $showDivider, $iconInGutter}) => {
   if(!show){ return null; }
 
   return (
-    <BackLink to={link} {...{showDivider, $iconInGutter}}>
+    <BackLink to={link} {...{$showDivider, $iconInGutter}}>
       <BackLinkIcon>
         <Icon icon="Back" size={16} color="grey-10" />
       </BackLinkIcon>

--- a/packages/ui-lib/src/Layouts/atoms/UtilityHeaderShare.tsx
+++ b/packages/ui-lib/src/Layouts/atoms/UtilityHeaderShare.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useCallback, useEffect } from "react";
+import styled from "styled-components";
+
+import Icon from "../../Icons/Icon";
+import { IUtilityHeaderLinkShare } from "..";
+import { useCopyToClipboard } from "../../hooks";
+
+
+const ExtraActionIcon = styled.div`
+  display: flex;
+  width: 16px;
+  height: 16px;
+  justify-content: center;
+  align-items: center;
+`;
+const ExtraAction = styled.button`
+  position: relative;
+  display: flex;
+  padding: 0;
+  align-items: center;
+  gap: 8px;
+  color: var(--grey-10);
+  text-align: center;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  border: none;
+  background: none;
+  text-decoration: none;
+  transition: color 0.25s ease;
+  cursor: pointer;
+
+  ${ExtraActionIcon}{
+    svg * {
+      transition: stroke 0.25s ease;
+    }
+  }
+  
+  &:hover {
+    color: var(--grey-12);
+    ${ExtraActionIcon}{
+      svg * {
+        stroke: var(--grey-12);
+      }
+    }
+  }
+
+`;
+
+const UtilityHeaderShare : React.FC<IUtilityHeaderLinkShare> = ({show, link, label = 'Share', copiedLabel = 'Copied'}) => {
+  
+  const [ copyActionText, setCopyActionText ] = useState<string>(label);
+  const {copyToClipboard} = useCopyToClipboard();
+  
+  const clickHandlerShareLink = useCallback(() => {
+    // Copy to clip board and change UI for short period.
+    copyToClipboard( link ? link : window.location.href);
+    setCopyActionText(copiedLabel);
+    setTimeout(() => setCopyActionText(copyActionText), 2000);
+  }, [link, copiedLabel, copyActionText, copyToClipboard]);
+
+  useEffect(() => {
+    // Update the label if prop is updated.
+    setCopyActionText(label);
+  }, [label]);
+  
+  if(!show){ return null; }
+  
+  return(
+    <ExtraAction onClick={ clickHandlerShareLink }>
+      <ExtraActionIcon>
+        <Icon icon="Link" size={16} color="grey-10" />
+      </ExtraActionIcon>
+      {copyActionText}
+    </ExtraAction>
+  );
+  
+};
+
+export default UtilityHeaderShare;

--- a/packages/ui-lib/src/Layouts/index.ts
+++ b/packages/ui-lib/src/Layouts/index.ts
@@ -23,7 +23,7 @@ export interface IUtilityHeaderLinkShare {
 }
 
 export interface IUtilityHeader {
-  $iconInGutter?: boolean;
+  iconInGutter?: boolean;
   showBreadcrumbs?: boolean;
   showHomeIcon?: boolean;
   breadcrumbs?: IBreadcrumb[];

--- a/packages/ui-lib/src/Layouts/index.ts
+++ b/packages/ui-lib/src/Layouts/index.ts
@@ -9,13 +9,16 @@ interface IBreadcrumb {
   href: string;
 }
 
-export interface IUtilityHeaderLink {
+export interface IUtilityHeaderLinkBack {
   show?: boolean;
-  link?: string;
+  link: string;
   label?: string;
 }
 
-export interface IUtilityHeaderLinkShare extends IUtilityHeaderLink {
+export interface IUtilityHeaderLinkShare {
+  show?: boolean;
+  link?: string;
+  label?: string;
   copiedLabel?: string;
 }
 
@@ -24,7 +27,7 @@ export interface IUtilityHeader {
   showBreadcrumbs?: boolean;
   showHomeIcon?: boolean;
   breadcrumbs?: IBreadcrumb[];
-  back?: IUtilityHeaderLink;
+  back?: IUtilityHeaderLinkBack;
   share?: IUtilityHeaderLinkShare;
 }
 

--- a/packages/ui-lib/src/Layouts/index.ts
+++ b/packages/ui-lib/src/Layouts/index.ts
@@ -9,14 +9,23 @@ interface IBreadcrumb {
   href: string;
 }
 
+export interface IUtilityHeaderLink {
+  show?: boolean;
+  link?: string;
+  label?: string;
+}
+
+export interface IUtilityHeaderLinkShare extends IUtilityHeaderLink {
+  copiedLabel?: string;
+}
+
 export interface IUtilityHeader {
   $iconInGutter?: boolean;
-  backLink?: string;
   showBreadcrumbs?: boolean;
-  breadcrumbs?: IBreadcrumb[];
   showHomeIcon?: boolean;
-  showShareLink?: boolean;
-  shareLink?: string;
+  breadcrumbs?: IBreadcrumb[];
+  back?: IUtilityHeaderLink;
+  share?: IUtilityHeaderLinkShare;
 }
 
 export interface IHeaderContent {

--- a/packages/ui-lib/src/Layouts/index.ts
+++ b/packages/ui-lib/src/Layouts/index.ts
@@ -23,7 +23,7 @@ export interface IUtilityHeaderLinkShare {
 }
 
 export interface IUtilityHeader {
-  iconInGutter?: boolean;
+  $iconInGutter?: boolean;
   showBreadcrumbs?: boolean;
   showHomeIcon?: boolean;
   breadcrumbs?: IBreadcrumb[];

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import styled, { css } from "styled-components";
 import {Link} from 'react-router-dom';
 
 import Icon from "../../Icons/Icon";
-import { IUtilityHeader, IUtilityHeaderLink, IUtilityHeaderLinkShare } from "..";
+import { IUtilityHeader, IUtilityHeaderLinkBack, IUtilityHeaderLinkShare } from "..";
 import { useCopyToClipboard } from "../../hooks";
 
 const Container = styled.div`
@@ -190,27 +190,45 @@ const shareDefaults : IUtilityHeaderLinkShare = {
   label: "Share",
   copiedLabel: "Copied"
 };
-const backDefaults : IUtilityHeaderLink = {
-  show: true
+const backDefaults : IUtilityHeaderLinkBack = {
+  show: true,
+  link: '/'
 };
 
+const UtilityHeaderShare : React.FC<IUtilityHeaderLinkShare> = ({show, link, label = 'Share', copiedLabel = 'Copied'}) => {
+  
+  const [ copyActionText, setCopyActionText ] = useState<string>(label);
+  const {copyToClipboard} = useCopyToClipboard();
+  
+  const clickHandlerShareLink = useCallback(() => {
+    copyToClipboard( link ? link : window.location.href);
+    setCopyActionText(copiedLabel);
+    setTimeout(() => setCopyActionText(copyActionText), 2000);
+  }, [link, copiedLabel, copyActionText, copyToClipboard]);
 
-const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back = {}, share = {},  $iconInGutter = true }) => {
+  useEffect(() => {
+    setCopyActionText(label);
+  }, [label]);
+  
+  if(!show){ return null; }
+  
+  return(
+    <ExtraAction onClick={ clickHandlerShareLink }>
+      <ExtraActionIcon>
+        <Icon icon="Link" size={16} color="grey-10" />
+      </ExtraActionIcon>
+      {copyActionText}
+    </ExtraAction>
+  );
+  
+};
+
+const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back = {}, share,  $iconInGutter = true }) => {
 
   // Set defaults and override from props.
   back = Object.assign(backDefaults, back);
-  share = Object.assign(shareDefaults, share);
-
-  const [ copyActionText, setCopyActionText ] = useState<string|undefined>(share.label);
-  const {copyToClipboard} = useCopyToClipboard();
 
   const hasBreadcrumbs = showBreadcrumbs && breadcrumbs.length > 0;
-
-  const clickHandlerShareLink = useCallback(() => {
-    copyToClipboard( share.link ? share.link : window.location.href);
-    setCopyActionText(share.copiedLabel);
-    setTimeout(() => setCopyActionText("Share"), 2000);
-  }, [share.link, share.copiedLabel, copyToClipboard]);
 
   return (
     <Container>
@@ -246,14 +264,7 @@ const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, brea
       : null }
     </LeftArea>
     <RightArea>
-        {share.show ?
-          <ExtraAction onClick={ clickHandlerShareLink }>
-            <ExtraActionIcon>
-              <Icon icon="Link" size={16} color="grey-10" />
-            </ExtraActionIcon>
-            {copyActionText}
-          </ExtraAction> 
-        : null }
+       <UtilityHeaderShare {...share} />
     </RightArea>
     </Container>
   );

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -86,14 +86,14 @@ const RightArea = styled.div`
 `;
 
 
-const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share, iconInGutter = true }) => {
+const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share, $iconInGutter = true }) => {
 
   const hasBreadcrumbs = showBreadcrumbs && breadcrumbs.length > 0;
 
   return (
     <Container>
     <LeftArea>
-      {back && <UtilityHeaderBack showDivider={hasBreadcrumbs} {...{iconInGutter}} {...back} />}
+      {back && <UtilityHeaderBack showDivider={hasBreadcrumbs} {...{$iconInGutter}} {...back} />}
       {hasBreadcrumbs ?
         <Breadcrumbs>
           { breadcrumbs.map((breadcrumb, index) => {

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -195,7 +195,7 @@ const backDefaults : IUtilityHeaderLink = {
 };
 
 
-const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share,  $iconInGutter = true }) => {
+const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back = {}, share = {},  $iconInGutter = true }) => {
 
   // Set defaults and override from props.
   back = Object.assign(backDefaults, back);
@@ -208,14 +208,14 @@ const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, brea
 
   const clickHandlerShareLink = useCallback(() => {
     copyToClipboard( share.link ? share.link : window.location.href);
-    setCopyActionText(share.copiedLabel || '');
+    setCopyActionText(share.copiedLabel);
     setTimeout(() => setCopyActionText("Share"), 2000);
   }, [share.link, share.copiedLabel, copyToClipboard]);
 
   return (
     <Container>
     <LeftArea>
-      {back.link ?
+      {back.show && back.link ?
         <BackLink to={back.link} $showDivider={hasBreadcrumbs} {...{$iconInGutter}}>
           <BackLinkIcon>
             <Icon icon="Back" size={16} color="grey-10" />

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useCallback } from "react";
 import styled, { css } from "styled-components";
-import Icon from "../../Icons/Icon";
 import {Link} from 'react-router-dom';
-import { IUtilityHeader } from "..";
+
+import Icon from "../../Icons/Icon";
+import { IUtilityHeader, IUtilityHeaderLink, IUtilityHeaderLinkShare } from "..";
 import { useCopyToClipboard } from "../../hooks";
 
 const Container = styled.div`
@@ -184,31 +185,42 @@ const RightArea = styled.div`
   justify-content: right;
 `;
 
+const shareDefaults : IUtilityHeaderLinkShare = {
+  show: true,
+  label: "Share",
+  copiedLabel: "Copied"
+};
+const backDefaults : IUtilityHeaderLink = {
+  show: true
+};
 
 
+const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share,  $iconInGutter = true }) => {
 
-const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, backLink, $iconInGutter = true, showShareLink = false, shareLink }) => {
+  // Set defaults and override from props.
+  back = Object.assign(backDefaults, back);
+  share = Object.assign(shareDefaults, share);
 
-  const [ copyActionText, setCopyActionText ] = useState<string>("Share");
+  const [ copyActionText, setCopyActionText ] = useState<string|undefined>(share.label);
   const {copyToClipboard} = useCopyToClipboard();
 
   const hasBreadcrumbs = showBreadcrumbs && breadcrumbs.length > 0;
 
   const clickHandlerShareLink = useCallback(() => {
-    copyToClipboard( shareLink ? shareLink : window.location.href);
-    setCopyActionText("Copied");
+    copyToClipboard( share.link ? share.link : window.location.href);
+    setCopyActionText(share.copiedLabel || '');
     setTimeout(() => setCopyActionText("Share"), 2000);
-  }, [shareLink, copyToClipboard]);
+  }, [share.link, share.copiedLabel, copyToClipboard]);
 
   return (
     <Container>
     <LeftArea>
-      {backLink ?
-        <BackLink to={backLink} $showDivider={hasBreadcrumbs} {...{$iconInGutter}}>
+      {back.link ?
+        <BackLink to={back.link} $showDivider={hasBreadcrumbs} {...{$iconInGutter}}>
           <BackLinkIcon>
             <Icon icon="Back" size={16} color="grey-10" />
           </BackLinkIcon>
-          Back
+          {back.label}
         </BackLink>
       : null }
       {hasBreadcrumbs ?
@@ -234,7 +246,7 @@ const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, brea
       : null }
     </LeftArea>
     <RightArea>
-        {showShareLink ?
+        {share.show ?
           <ExtraAction onClick={ clickHandlerShareLink }>
             <ExtraActionIcon>
               <Icon icon="Link" size={16} color="grey-10" />

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React from "react";
 import styled, { css } from "styled-components";
 import {Link} from 'react-router-dom';
 
 import Icon from "../../Icons/Icon";
-import { IUtilityHeader, IUtilityHeaderLinkBack, IUtilityHeaderLinkShare } from "..";
-import { useCopyToClipboard } from "../../hooks";
+import { IUtilityHeader, IUtilityHeaderLinkBack } from "..";
+import UtilityHeaderShare from "../atoms/UtilityHeaderShare";
 
 const Container = styled.div`
   max-width: var(--max-content-width);
@@ -80,49 +80,6 @@ const BackLink = styled(Link)<{iconInGutter: boolean, showDivider: boolean}>`
   `}
 `;
 
-const ExtraActionIcon = styled.div`
-  display: flex;
-  width: 16px;
-  height: 16px;
-  justify-content: center;
-  align-items: center;
-`;
-const ExtraAction = styled.button`
-  position: relative;
-  display: flex;
-  padding: 0;
-  align-items: center;
-  gap: 8px;
-  color: var(--grey-10);
-  text-align: center;
-  font-family: var(--font-ui);
-  font-size: 12px;
-  font-style: normal;
-  font-weight: 600;
-  line-height: normal;
-  border: none;
-  background: none;
-  text-decoration: none;
-  transition: color 0.25s ease;
-  cursor: pointer;
-
-  ${ExtraActionIcon}{
-    svg * {
-      transition: stroke 0.25s ease;
-    }
-  }
-  
-  &:hover {
-    color: var(--grey-12);
-    ${ExtraActionIcon}{
-      svg * {
-        stroke: var(--grey-12);
-      }
-    }
-  }
-
-`;
-
 const Breadcrumbs = styled.div`
   display: inline-flex;
   align-items: center;
@@ -185,33 +142,7 @@ const RightArea = styled.div`
   justify-content: right;
 `;
 
-const UtilityHeaderShare : React.FC<IUtilityHeaderLinkShare> = ({show, link, label = 'Share', copiedLabel = 'Copied'}) => {
-  
-  const [ copyActionText, setCopyActionText ] = useState<string>(label);
-  const {copyToClipboard} = useCopyToClipboard();
-  
-  const clickHandlerShareLink = useCallback(() => {
-    copyToClipboard( link ? link : window.location.href);
-    setCopyActionText(copiedLabel);
-    setTimeout(() => setCopyActionText(copyActionText), 2000);
-  }, [link, copiedLabel, copyActionText, copyToClipboard]);
 
-  useEffect(() => {
-    setCopyActionText(label);
-  }, [label]);
-  
-  if(!show){ return null; }
-  
-  return(
-    <ExtraAction onClick={ clickHandlerShareLink }>
-      <ExtraActionIcon>
-        <Icon icon="Link" size={16} color="grey-10" />
-      </ExtraActionIcon>
-      {copyActionText}
-    </ExtraAction>
-  );
-  
-};
 
 interface IUtilityHeaderLinkBackInstance extends IUtilityHeaderLinkBack {
   iconInGutter: boolean;

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -93,7 +93,7 @@ const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, brea
   return (
     <Container>
     <LeftArea>
-      {back && <UtilityHeaderBack showDivider={hasBreadcrumbs} {...{$iconInGutter}} {...back} />}
+      {back && <UtilityHeaderBack $showDivider={hasBreadcrumbs} {...{$iconInGutter}} {...back} />}
       {hasBreadcrumbs ?
         <Breadcrumbs>
           { breadcrumbs.map((breadcrumb, index) => {

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -34,7 +34,7 @@ const BackLinkIcon = styled.div`
     align-items: center;
   }
 `;
-const BackLink = styled(Link)<{$iconInGutter: boolean, $showDivider: boolean}>`
+const BackLink = styled(Link)<{iconInGutter: boolean, showDivider: boolean}>`
   position: relative;
   display: flex;
   padding: 0;
@@ -51,7 +51,7 @@ const BackLink = styled(Link)<{$iconInGutter: boolean, $showDivider: boolean}>`
   background: none;
   text-decoration: none;
   transition: color 0.25s ease;
-  margin-left: ${props => props.$iconInGutter ? '-24px' : '0' };
+  margin-left: ${props => props.iconInGutter ? '-24px' : '0' };
 
   ${BackLinkIcon}{
     svg * {
@@ -68,7 +68,7 @@ const BackLink = styled(Link)<{$iconInGutter: boolean, $showDivider: boolean}>`
     }
   }
 
-  ${({$showDivider}) => $showDivider && css`
+  ${({showDivider}) => showDivider && css`
     &::after {
       content: '';
       display: inline-block;
@@ -185,16 +185,6 @@ const RightArea = styled.div`
   justify-content: right;
 `;
 
-const shareDefaults : IUtilityHeaderLinkShare = {
-  show: true,
-  label: "Share",
-  copiedLabel: "Copied"
-};
-const backDefaults : IUtilityHeaderLinkBack = {
-  show: true,
-  link: '/'
-};
-
 const UtilityHeaderShare : React.FC<IUtilityHeaderLinkShare> = ({show, link, label = 'Share', copiedLabel = 'Copied'}) => {
   
   const [ copyActionText, setCopyActionText ] = useState<string>(label);
@@ -223,24 +213,32 @@ const UtilityHeaderShare : React.FC<IUtilityHeaderLinkShare> = ({show, link, lab
   
 };
 
-const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back = {}, share,  $iconInGutter = true }) => {
+interface IUtilityHeaderLinkBackInstance extends IUtilityHeaderLinkBack {
+  iconInGutter: boolean;
+  showDivider: boolean;
+}
 
-  // Set defaults and override from props.
-  back = Object.assign(backDefaults, back);
+const UtilityHeaderBack : React.FC<IUtilityHeaderLinkBackInstance> = ({show, link, label = 'Back', showDivider, iconInGutter}) => {
+  if(!show){ return null; }
+
+  return (
+    <BackLink to={link} {...{showDivider, iconInGutter}}>
+      <BackLinkIcon>
+        <Icon icon="Back" size={16} color="grey-10" />
+      </BackLinkIcon>
+      {label}
+    </BackLink>
+  );
+};
+
+const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share, iconInGutter = true }) => {
 
   const hasBreadcrumbs = showBreadcrumbs && breadcrumbs.length > 0;
 
   return (
     <Container>
     <LeftArea>
-      {back.show && back.link ?
-        <BackLink to={back.link} $showDivider={hasBreadcrumbs} {...{$iconInGutter}}>
-          <BackLinkIcon>
-            <Icon icon="Back" size={16} color="grey-10" />
-          </BackLinkIcon>
-          {back.label}
-        </BackLink>
-      : null }
+      {back && <UtilityHeaderBack showDivider={hasBreadcrumbs} {...{iconInGutter}} {...back} />}
       {hasBreadcrumbs ?
         <Breadcrumbs>
           { breadcrumbs.map((breadcrumb, index) => {
@@ -264,7 +262,7 @@ const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, brea
       : null }
     </LeftArea>
     <RightArea>
-       <UtilityHeaderShare {...share} />
+      <UtilityHeaderShare {...share} />
     </RightArea>
     </Container>
   );

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import {Link} from 'react-router-dom';
 
+import { IUtilityHeader } from "..";
 import Icon from "../../Icons/Icon";
-import { IUtilityHeader, IUtilityHeaderLinkBack } from "..";
 import UtilityHeaderShare from "../atoms/UtilityHeaderShare";
+import UtilityHeaderBack from "../atoms/UtilityHeaderBack";
 
 const Container = styled.div`
   max-width: var(--max-content-width);
@@ -20,64 +21,6 @@ const LeftArea = styled.div`
   align-items: center;
   gap: var(--columnPadding, 16px);
   flex: 1 0 0;
-`;
-const BackLinkIcon = styled.div`
-  display: flex;
-  width: 16px;
-  height: 16px;
-  justify-content: center;
-  align-items: center;
-  flex: 1;  
-  > div {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-`;
-const BackLink = styled(Link)<{iconInGutter: boolean, showDivider: boolean}>`
-  position: relative;
-  display: flex;
-  padding: 0;
-  align-items: center;
-  gap: 8px;
-  color: var(--grey-10);
-  text-align: center;
-  font-family: var(--font-ui);
-  font-size: 12px;
-  font-style: normal;
-  font-weight: 600;
-  line-height: normal;
-  border: none;
-  background: none;
-  text-decoration: none;
-  transition: color 0.25s ease;
-  margin-left: ${props => props.iconInGutter ? '-24px' : '0' };
-
-  ${BackLinkIcon}{
-    svg * {
-      transition: stroke 0.25s ease;
-    }
-  }
-  
-  &:hover {
-    color: var(--grey-12);
-    ${BackLinkIcon}{
-      svg * {
-        stroke: var(--grey-12);
-      }
-    }
-  }
-
-  ${({showDivider}) => showDivider && css`
-    &::after {
-      content: '';
-      display: inline-block;
-      height: 12px;
-      width: 1px;
-      padding-left: 8px;
-      border-right: 1px solid var(--grey-10);
-    }
-  `}
 `;
 
 const Breadcrumbs = styled.div`
@@ -142,25 +85,6 @@ const RightArea = styled.div`
   justify-content: right;
 `;
 
-
-
-interface IUtilityHeaderLinkBackInstance extends IUtilityHeaderLinkBack {
-  iconInGutter: boolean;
-  showDivider: boolean;
-}
-
-const UtilityHeaderBack : React.FC<IUtilityHeaderLinkBackInstance> = ({show, link, label = 'Back', showDivider, iconInGutter}) => {
-  if(!show){ return null; }
-
-  return (
-    <BackLink to={link} {...{showDivider, iconInGutter}}>
-      <BackLinkIcon>
-        <Icon icon="Back" size={16} color="grey-10" />
-      </BackLinkIcon>
-      {label}
-    </BackLink>
-  );
-};
 
 const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share, iconInGutter = true }) => {
 


### PR DESCRIPTION
This iteration was made to allow the labels for the back and share buttons to be overridden. Whilst doing this and adding to the story I realised we quickly began to overload the props we were sending and things were getting messy. This becomes more problematic, the deeper that components are nested. For this reason I decided to refactor this early while it is only being used in one project and we can limit the impact of breaking changes.

## How to Update to New Props
The following props have been removed and will need to be changed: `backLink`, `showShareLink` and `shareLink`

They have been replaced with two new object props: `back` and `share` which contain everything that is needed.

Instead of `backLink`, use:
```
back = {
  link: '/example',   // This replaces backLink
  label: 'Back'       // Optional but intended for localisation overrides
}
```

Instead of `shareLink` and `showShareLink` you can do the follow. Not that `showShareLink` is not required as it is optional and will default to `true`.

```
share = {
  link: true,             // This replaces shareLink
  label: 'Back'           // Optional but intended for localisation overrides
  copiedLabel: 'Copied.'  // Shown after is clicked. Optional but intended for localisation overrides
}
```

Both of these new props also have a `show` property you can set. As these are defaulted to `true` by default, they are not needed and mostly intended for use if you need to disable and or conditionally disable the parts more conveniently. 

The back button will also not show if the `link` property is missing.