### PR TITLE
Add useLanguageAttribute hook with example in Layouts

### DIFF
--- a/packages/example/src/pages/Layouts.tsx
+++ b/packages/example/src/pages/Layouts.tsx
@@ -1,7 +1,24 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 import { ThemeProvider } from 'styled-components';
-import { GlobalUI, defaultTheme, PageHeader, useThemeToggle, ContentLayout, Tab, TabList, TabContent, Label, Button, TextField, FullWidthContentBlock, IHeaderContent, ButtonsStack, IButtonStack } from "scorer-ui-kit";
+import {
+  GlobalUI,
+  defaultTheme,
+  PageHeader,
+  useThemeToggle,
+  ContentLayout,
+  Tab,
+  TabList,
+  TabContent,
+  Label,
+  Button,
+  TextField,
+  FullWidthContentBlock,
+  IHeaderContent,
+  ButtonsStack,
+  IButtonStack,
+  useLanguageAttribute
+} from "scorer-ui-kit";
 import ExamplesFilename from "../components/ExamplesFilename";
 
 const FullWidthExampleContent = styled.div`
@@ -14,6 +31,11 @@ const FullWidthExampleContent = styled.div`
 const Layouts: FC = () => {
 
   const {onThemeToggle, isLightMode} = useThemeToggle();
+  const {onLanguageAttributeToggle} = useLanguageAttribute([]);
+
+  const onLanguageToggle = () => {
+    onLanguageAttributeToggle();
+  };
 
   const defaultBtn : IButtonStack[] = [
     {id:'primaryBase0', buttonType: 'default', text:'Example Action 1'},
@@ -52,7 +74,8 @@ const Layouts: FC = () => {
           switchThemeText='SWITCH THEME'
           selectedThemeText={isLightMode ? 'LIGHT MODE' : 'DARK MODE' }
           onThemeToggle={onThemeToggle}
-          badge={{ 
+          onLanguageToggle={onLanguageToggle}
+          badge={{
             text: 'Guest',
             color: 'primary',
             linkTo: '#',

--- a/packages/example/src/pages/Layouts.tsx
+++ b/packages/example/src/pages/Layouts.tsx
@@ -31,7 +31,7 @@ const FullWidthExampleContent = styled.div`
 const Layouts: FC = () => {
 
   const {onThemeToggle, isLightMode} = useThemeToggle();
-  const {onLanguageAttributeToggle} = useLanguageAttribute([]);
+  const {onLanguageAttributeToggle} = useLanguageAttribute(['en','ja']);
 
   const onLanguageToggle = () => {
     onLanguageAttributeToggle();

--- a/packages/storybook/src/stories/Misc/atoms/useLanguageAttributeHook.stories.tsx
+++ b/packages/storybook/src/stories/Misc/atoms/useLanguageAttributeHook.stories.tsx
@@ -1,0 +1,41 @@
+import {useLanguageAttribute, IntroductionText, Button } from "scorer-ui-kit";
+import React, { useCallback, useState } from "react";
+import styled from "styled-components";
+export default {
+  title: 'Hooks',
+  component: useLanguageAttribute,
+  decorators: []
+};
+
+const Container = styled.div`
+  margin: 100px;
+`;
+
+const Title = styled.h2`
+  color: var(--gray-2);
+  &:lang(ja) {
+    color: red;
+  }
+`;
+
+export const _useLanguageAttribute = () => {
+
+  const {onLanguageAttributeToggle} = useLanguageAttribute(['en','ja'], 'ja');
+  const [selectedLang, setSelectedLang] = useState('japanese');
+
+  const title = selectedLang === 'english' ? 'Welcome' : 'ようこそ';
+  const buttonText = selectedLang === 'english' ? 'Language Toggle': '言語トグル'
+  const introductionText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam sodales non mauris sed fermentum. Proin non elit at lectus semper lacinia a sed nisi. Sed nibh neque, sagittis at laoreet non, sodales non nisl. Nam nec lectus erat. Etiam bibendum tristique ipsum eu dictum. Nam egestas felis in mauris molestie tristique.";
+
+  const onLanguageToggle = useCallback(() => {
+    const updatedLanguage = selectedLang === 'english' ? 'japanese' : 'english';
+    setSelectedLang(updatedLanguage);
+    onLanguageAttributeToggle();
+  },[onLanguageAttributeToggle, selectedLang]);
+
+  return <Container>
+    <Title >{title}</Title>
+    <IntroductionText>{introductionText}</IntroductionText>
+    <Button onClick={onLanguageToggle}>{buttonText}</Button>
+  </Container>;
+};

--- a/packages/ui-lib/src/hooks/index.ts
+++ b/packages/ui-lib/src/hooks/index.ts
@@ -11,6 +11,7 @@ import useBreakpoints from './useBreakpoints';
 import useMediaQuery from './useMediaQuery';
 import { useMediaModal } from './useMediaModal';
 import useThemeToggle from './useThemeToggle';
+import useLanguageAttribute from './useLanguageAttribute';
 
 export {
   useInterval,
@@ -25,7 +26,8 @@ export {
   useBreakpoints,
   useMediaModal,
   useThemeToggle,
-  useLocalStorage
+  useLocalStorage,
+  useLanguageAttribute
 };
 
 export type { IModal };

--- a/packages/ui-lib/src/hooks/useLanguageAttribute.tsx
+++ b/packages/ui-lib/src/hooks/useLanguageAttribute.tsx
@@ -1,8 +1,13 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
-const setInitialLanguage = (defaultLanguages: string[]) => {
+const setInitialLanguage = (defaultLanguages: string[], initLanguage?: string) => {
   if (defaultLanguages.length === 0) {
     console.warn("defaultLanguages array is empty. Unable to set a language.");
+    return;
+  }
+
+  if (initLanguage && defaultLanguages.includes(initLanguage)) {
+    document.documentElement.setAttribute("lang", initLanguage);
     return;
   }
 
@@ -23,8 +28,10 @@ const setInitialLanguage = (defaultLanguages: string[]) => {
   }
 };
 
-const useLanguageAttribute = (languageList: string[]) => {
-  // Toggles between the first two languages in the list
+const useLanguageAttribute = (languageList: string[], initLanguage?: string) => {
+
+  const isInitialMount = useRef(true);
+
   const onLanguageAttributeToggle = useCallback(() => {
     if (languageList.length < 2) {
       console.warn("Insufficient languages in the list for toggling.");
@@ -42,8 +49,13 @@ const useLanguageAttribute = (languageList: string[]) => {
       console.warn("languageList is empty. Unable to initialize language attribute.");
       return;
     }
-    setInitialLanguage(languageList);
-  }, [languageList]);
+
+    if (isInitialMount.current) {
+      setInitialLanguage(languageList, initLanguage);
+      isInitialMount.current = false;
+    }
+
+  }, [initLanguage, languageList]);
 
   return {
     onLanguageAttributeToggle,

--- a/packages/ui-lib/src/hooks/useLanguageAttribute.tsx
+++ b/packages/ui-lib/src/hooks/useLanguageAttribute.tsx
@@ -1,0 +1,53 @@
+import { useCallback, useEffect } from "react";
+
+const setInitialLanguage = (defaultLanguages: string[]) => {
+  if (defaultLanguages.length === 0) {
+    console.warn("defaultLanguages array is empty. Unable to set a language.");
+    return;
+  }
+
+  const browserLang = navigator.language.split("-")[0];
+  const htmlLang = document.documentElement.lang;
+
+  let langToSet = defaultLanguages[0]; // Default to the first language in the list
+
+  if (!htmlLang && defaultLanguages.includes(browserLang)) {
+    langToSet = browserLang;
+
+  } else if (defaultLanguages.includes(htmlLang)) {
+    langToSet = htmlLang;
+  }
+
+  if (document.documentElement.lang !== langToSet) {
+    document.documentElement.setAttribute("lang", langToSet);
+  }
+};
+
+const useLanguageAttribute = (languageList: string[]) => {
+  // Toggles between the first two languages in the list
+  const onLanguageAttributeToggle = useCallback(() => {
+    if (languageList.length < 2) {
+      console.warn("Insufficient languages in the list for toggling.");
+      return;
+    }
+
+    const currentLang = document.documentElement.lang;
+    const newLang = currentLang === languageList[0] ? languageList[1] : languageList[0];
+    document.documentElement.setAttribute("lang", newLang);
+  }, [languageList]);
+
+  // Initialize the lang attribute on mount
+  useEffect(() => {
+    if (languageList.length === 0) {
+      console.warn("languageList is empty. Unable to initialize language attribute.");
+      return;
+    }
+    setInitialLanguage(languageList);
+  }, [languageList]);
+
+  return {
+    onLanguageAttributeToggle,
+  };
+};
+
+export default useLanguageAttribute;

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -161,7 +161,8 @@ import {
   useMediaModal,
   IModal,
   usePoll,
-  useThemeToggle
+  useThemeToggle,
+  useLanguageAttribute,
 } from './hooks';
 
 import {
@@ -319,6 +320,7 @@ export {
   usePoll,
   useMediaModal,
   useThemeToggle,
+  useLanguageAttribute,
   resetButtonStyles,
   FlexContentPlaceholder,
   Spinner,


### PR DESCRIPTION
### Description

Request to use css to manage css lang attribute
```
With switching between English and Japanese, we have some issues with things like line-height which can cause some minor issues in the layout and make things look untidy. 

We need a way easily set differing CSS within a component based on the language, ideally using CSS selectors and in a way where the language is still managed by our selector conveniently
```

 ### Considerations on Implementation
This hook useLanguageAttribute can be added to the onLanguageChange function that developers use.
I hesitated on adding a state or a localStorage since the value itself is saved in the html.
Currently the projects use localStorage to keep the current language in addition of using the i18n library

```
  const onLanguageChange = useCallback(() => {
    const language = i18n.language === 'ja' ? 'en' : 'ja';
    i18n.changeLanguage(language);
    localStorage.setItem('language', language);
  },[]);
 ```
 
It's important to prevent mismatch of values and consistent implementations. I have added the `initLanguage` prop to the hook with that in mind so the developer can initialize a language that was saved ins storage.
Please review this approach I have implemented and provide feedback having this in mind.

 ### Reviewing/ Testing Steps
I updated Layouts.tsx to use the useLanguageAttribute.
Testing can be done by running local examples and looking at GlobalUI Layouts.tsx example and using the language in the menu. The update can be seen in the html tag.

In this example in local I have updated the Title to use  red color when Japanese is used, but this is not committed code

<img width="504" alt="Screenshot 2024-12-19 at 0 01 23" src="https://github.com/user-attachments/assets/cb6d3296-d7f4-4d47-a35f-f3d55b721c02" />

**English**
<img width="1195" alt="Screenshot 2024-12-19 at 0 00 54" src="https://github.com/user-attachments/assets/e2856abe-0a0e-4af3-b8a8-1e3b86ad8173" />

**Japanese**

<img width="1169" alt="Screenshot 2024-12-19 at 0 00 45" src="https://github.com/user-attachments/assets/9341d0a5-cfd2-42d3-9d67-5b0b8800342c" />

I have added an Story to use the toggle function.

**English**
I'm using a button instead of the knob control to prevent mismatch errors with knobs.
<img width="1278" alt="Screenshot 2024-12-19 at 20 14 37" src="https://github.com/user-attachments/assets/cd9fcb22-7e87-4d28-a046-83badf3b85b6" />

**Japanese**
<img width="1286" alt="Screenshot 2024-12-19 at 20 14 54" src="https://github.com/user-attachments/assets/d9d3a8d5-8847-41df-8433-bc916dcf8b35" />



