### PR TITLE
Bump for release 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -37847,7 +37847,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
### Description

**Features**
- **UtilityHeader:** Developers can now set custom labels for the back and share buttons.
The following props have been removed and need to be replaced:

  - backLink
  - showShareLink
  - shareLink

  These have been replaced with two new object props: back and share, as detailed below:

    Back button configuration:
    Replace backLink with the back object:
  
```ts
   back = {  
    link: '/example',   // Replaces backLink  
    label: 'Back'       // Optional, useful for localization overrides  
   }
```

      Share button configuration:
      Replace `shareLink` with the `share` object:

```ts
share = {  
  link: true,              // Replaces shareLink  
  label: 'Share'           // Optional, useful for localization overrides  
  copiedLabel: 'Copied.'   // Shown after clicking, optional for localization overrides  
}
```

For more details, see the [PR #530](https://github.com/future-standard/scorer-ui-kit/pull/530).


- Icons
  - GroupCollapse
  - GroupExpand
