### PR TITLE
Fix to have colon conditional in Toggle Button

### DIFF
--- a/packages/storybook/src/stories/Filters/atoms/ToggleButton.stories.tsx
+++ b/packages/storybook/src/stories/Filters/atoms/ToggleButton.stories.tsx
@@ -52,7 +52,7 @@ export const _ToggleButton = () => {
 
   const disabled = boolean('Disabled', false);
   const design = select('Design type', { Default: 'default', Basic: 'basic' }, 'basic');
-  const categoryLabel = text('Category Label', 'Layout:');
+  const categoryLabel = text('Category Label', 'Layout');
   const options = object('Options', layoutOptions);
   const showToggleValue = action('Button Value: ');
 

--- a/packages/ui-lib/src/Filters/atoms/ToggleButton.tsx
+++ b/packages/ui-lib/src/Filters/atoms/ToggleButton.tsx
@@ -23,7 +23,8 @@ const ToggleButton: React.FC<IToggleButton> = ({ options, categoryLabel, selecte
 
   return (
     <FilterButton icon={options[selectedIndex].icon} onClick={() => onToggleCallback(selectedIndex)} {...{design}} {...props}>
-      {`${categoryLabel} : ${options[selectedIndex].text}`}
+      { categoryLabel && `${categoryLabel} : `}
+      {`${options[selectedIndex].text}`}
     </FilterButton>
   );
 };


### PR DESCRIPTION
### Description

 This is a fix update for Toggle button, that will make `:` sign conditional to receiving category label.

Fixes #539

Screenshoot
<img width="742" alt="Screenshot 2025-01-09 at 21 57 47" src="https://github.com/user-attachments/assets/add53a7b-1063-4b61-aee2-e397f6362846" />

<img width="694" alt="Screenshot 2025-01-09 at 21 57 55" src="https://github.com/user-attachments/assets/5885593f-891b-4c68-944f-36707d50b188" />



