### PR TITLE
Datepicker, cancel and apply buttons

### DIFF
--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { boolean, object, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
@@ -39,6 +39,12 @@ export const _DatePicker = () => {
   const availableRangeDates = object('Available Range', datesRange);
   const contentDaysObj = object('Content Days', dataContentDays);
   const showContentDays = boolean('Show Content Days', true)
+  const hasApply = boolean('Has Apply Button', false);
+  const disableApply = boolean('Disable Apply button', false);
+  const cancelText = text('Cancel Text', 'Cancel');
+  const applyText = text('Apply Text', 'Apply');
+  const applyCallback = action('Apply Button Pressed');
+  const cancelCallback = action('Cancel Button Pressed');
 
   return (
     <Container>
@@ -47,6 +53,12 @@ export const _DatePicker = () => {
           timeMode,
           dateMode,
           timeZoneValueTitle,
+          hasApply,
+          disableApply,
+          cancelText,
+          applyText,
+          applyCallback,
+          cancelCallback,
         }}
           updateCallback={exampleCallback(updateCallback)}
           dateTimeTextUpper={language === 'ja' ? 'から' : dateTimeTextUpper}

--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -39,6 +39,9 @@ export const _DatePicker = () => {
   const availableRangeDates = object('Available Range', datesRange);
   const contentDaysObj = object('Content Days', dataContentDays);
   const showContentDays = boolean('Show Content Days', true)
+  const cancelText = text('Cancel Text', 'Cancel');
+  const applyText = text('Apply Text', 'Apply');
+  const resetText = text('Reset Text', 'Reset');
 
   return (
     <Container>
@@ -47,6 +50,9 @@ export const _DatePicker = () => {
           timeMode,
           dateMode,
           timeZoneValueTitle,
+          cancelText,
+          applyText,
+          resetText
         }}
           updateCallback={exampleCallback(updateCallback)}
           dateTimeTextUpper={language === 'ja' ? 'から' : dateTimeTextUpper}

--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -39,9 +39,6 @@ export const _DatePicker = () => {
   const availableRangeDates = object('Available Range', datesRange);
   const contentDaysObj = object('Content Days', dataContentDays);
   const showContentDays = boolean('Show Content Days', true)
-  const cancelText = text('Cancel Text', 'Cancel');
-  const applyText = text('Apply Text', 'Apply');
-  const resetText = text('Reset Text', 'Reset');
 
   return (
     <Container>
@@ -50,9 +47,6 @@ export const _DatePicker = () => {
           timeMode,
           dateMode,
           timeZoneValueTitle,
-          cancelText,
-          applyText,
-          resetText
         }}
           updateCallback={exampleCallback(updateCallback)}
           dateTimeTextUpper={language === 'ja' ? 'から' : dateTimeTextUpper}

--- a/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
+++ b/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
@@ -203,6 +203,8 @@ export const _FilterBar = () => {
       dateTimeTextUpper: language === 'english' ? 'From' : 'から',
       dateTimeTextLower: language === 'english' ? 'To' : 'まで',
       timeZoneTitle: language === 'english' ? 'Timezone' : '時間帯',
+      cancelText: language === 'english' ? 'Cancel' : 'キャンセル',
+      applyText: language === 'english' ? 'Apply' : '完了',
       lang: language === 'english' ? 'en' : 'ja',
       selected: InitialSelectedDate,
       availableRange: datesRange,

--- a/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
+++ b/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
@@ -121,7 +121,7 @@ export const _FilterBar = () => {
   const hasShowMore = boolean('Has Show More', true);
   // valid formats - https://date-fns.org/v2.25.0/docs/format
   const resultsDateFormat = text('Results date format', 'yyyy-MM-dd HH:mm');
-  const datePickerHasApply = select('Datepicker has Apply', { true: true, false: false }, true);
+  const datePickerHasApply = boolean('Datepicker has Apply', true);
 
   // Sent to checkbox in TableRow via Table component.
   const selectCallback = useCallback((checked: boolean, id?: string | number) => {

--- a/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
+++ b/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
@@ -114,7 +114,6 @@ export const _FilterBar = () => {
   const [data, setData] = useState<ITableSampleData[]>(dataInitialState);
   const [rows, setRows] = useState<ITypeTableData>(rowMaker(dataInitialState));
   const [filters, setFilters] = useState<IFilterResult[]>([]);
-
   /**
  * Story interaction section
  */
@@ -122,6 +121,7 @@ export const _FilterBar = () => {
   const hasShowMore = boolean('Has Show More', true);
   // valid formats - https://date-fns.org/v2.25.0/docs/format
   const resultsDateFormat = text('Results date format', 'yyyy-MM-dd HH:mm');
+  const datePickerHasApply = select('Datepicker has Apply', { true: true, false: false }, true);
 
   // Sent to checkbox in TableRow via Table component.
   const selectCallback = useCallback((checked: boolean, id?: string | number) => {
@@ -208,7 +208,8 @@ export const _FilterBar = () => {
       lang: language === 'english' ? 'en' : 'ja',
       selected: InitialSelectedDate,
       availableRange: datesRange,
-      contentDays: dataContentDays
+      contentDays: dataContentDays,
+      hasApply: datePickerHasApply
     }
   ]
 

--- a/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
@@ -121,7 +121,7 @@ const FilterDropHandler = forwardRef<FilterDropHandlerRef, IFilterDropHandler>(
     const buttonWrapperRef = useRef<HTMLDivElement>(null);
     const mainRef = useRef<HTMLDivElement>(null);
 
-    const handleClose = useCallback(() => {
+    const clickOutsideClose = useCallback(() => {
       if(noCloseOnClickOutside) {
         return;
       }
@@ -137,7 +137,7 @@ const FilterDropHandler = forwardRef<FilterDropHandlerRef, IFilterDropHandler>(
 
     }, [noCloseOnClickOutside, onCloseCallback, openState.isOpen]);
 
-    useClickOutside(mainRef, handleClose);
+    useClickOutside(mainRef, clickOutsideClose);
 
     const handleToggleOpen = useCallback((minWidth: number, minHeight: number) => {
       if (!buttonWrapperRef.current) { return; }

--- a/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
@@ -146,7 +146,7 @@ const FilterDropHandler = forwardRef<FilterDropHandlerRef, IFilterDropHandler>(
       if (!buttonRect) { return; }
       const position: IOpenPos = getDropPosition(buttonRect, minWidth, minHeight);
 
-      onToggleOpenCallback(openState.isOpen);
+      onToggleOpenCallback(!openState.isOpen);
       setOpenState((prev) => {
         const isOpen = !prev.isOpen;
         return { ...prev, isOpen, position };

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -382,11 +382,16 @@ export interface IDatePicker {
   timeZoneValueTitle?: string
   availableRange?: DateRange
   contentDays?: Date[]
+  lang?: 'en' | 'ja'
   cancelText?: string
   applyText?: string
   resetText?: string
+  hasApply?: boolean
+  hasReset?: boolean
   updateCallback?: (data: DateInterval | Date) => void
-  lang?: 'en' | 'ja'
+  onApplyCallback?: () => void
+  onResetCallback?: () => void
+  onCancelCallback?: () => void
 }
 
 const DatePicker: React.FC<IDatePicker> = ({
@@ -404,7 +409,12 @@ const DatePicker: React.FC<IDatePicker> = ({
   lang = 'en',
   cancelText = 'Cancel',
   applyText = 'Apply',
-  resetText = 'Reset'
+  resetText = 'Reset',
+  hasApply = false,
+  hasReset = false,
+  onApplyCallback = () => {},
+  onResetCallback = () => {},
+  onCancelCallback = () => {}
 }) => {
 
   // TODO: Have a function to output tidied up data for the configuration.
@@ -588,19 +598,22 @@ const DatePicker: React.FC<IDatePicker> = ({
           })}
         </CalBody>
 
-        <CalButtons>
-          <CalLeftButton>
-            <Button design='secondary'>{resetText}</Button>
-          </CalLeftButton>
-          <CalRightButtons>
-            <Button design='secondary'>{cancelText}</Button>
-            <Button>{applyText}</Button>
-          </CalRightButtons>
-        </CalButtons>
+        {(hasReset || hasApply) && (<CalButtons>
+          {hasReset && (
+            <CalLeftButton>
+            <Button design='secondary' onClick={onResetCallback}>{resetText}</Button>
+          </CalLeftButton>)
+          }
+          {hasApply && (
+            <CalRightButtons>
+              <Button design='secondary' onClick={onCancelCallback}>{cancelText}</Button>
+              <Button onClick={onApplyCallback}>{applyText}</Button>
+            </CalRightButtons>)
+          }
+        </CalButtons>)
+        }
 
       </CalendarArea>
-
-
     </Container>
   );
 

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -607,7 +607,7 @@ const DatePicker: React.FC<IDatePicker> = ({
           {hasApply && (
             <CalRightButtons>
               <Button design='secondary' onClick={cancelCallback}>{cancelText}</Button>
-              <Button onClick={applyCallback}>{applyText}</Button>
+              <Button onClick={applyCallback} disabled={!isTimeRangeValid || selectedRange === null}>{applyText}</Button>
             </CalRightButtons>)
           }
         </CalButtons>)

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -172,14 +172,6 @@ const CalButtons = styled.div`
   border-top: 1px solid var(--grey-6);
 `;
 
-const CalLeftButton = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-  flex: 1 0 0;
-`;
-
 const CalRightButtons = styled.div`
   display: flex;
   align-items: center;

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -378,6 +378,7 @@ export interface IDatePicker {
   cancelText?: string
   applyText?: string
   hasApply?: boolean
+  disableApply?: boolean
   updateCallback?: (data: DateInterval | Date) => void
   applyCallback?: () => void
   cancelCallback?: () => void
@@ -399,6 +400,7 @@ const DatePicker: React.FC<IDatePicker> = ({
   cancelText = 'Cancel',
   applyText = 'Apply',
   hasApply = false,
+  disableApply = false,
   applyCallback = () => { },
   cancelCallback = () => { }
 }) => {
@@ -589,7 +591,7 @@ const DatePicker: React.FC<IDatePicker> = ({
             {hasApply && (
               <CalRightButtons>
                 <Button design='secondary' onClick={cancelCallback}>{cancelText}</Button>
-                <Button onClick={applyCallback} disabled={!isTimeRangeValid || selectedRange === null}>{applyText}</Button>
+                <Button onClick={applyCallback} disabled={!isTimeRangeValid || selectedRange === null || disableApply }>{applyText}</Button>
               </CalRightButtons>)
             }
           </CalButtons>)

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -385,12 +385,9 @@ export interface IDatePicker {
   lang?: 'en' | 'ja'
   cancelText?: string
   applyText?: string
-  resetText?: string
   hasApply?: boolean
-  hasReset?: boolean
   updateCallback?: (data: DateInterval | Date) => void
   applyCallback?: () => void
-  resetCallback?: () => void
   cancelCallback?: () => void
 }
 
@@ -409,12 +406,9 @@ const DatePicker: React.FC<IDatePicker> = ({
   lang = 'en',
   cancelText = 'Cancel',
   applyText = 'Apply',
-  resetText = 'Reset',
   hasApply = false,
-  hasReset = false,
-  applyCallback = () => {},
-  resetCallback = () => {},
-  cancelCallback = () => {}
+  applyCallback = () => { },
+  cancelCallback = () => { }
 }) => {
 
   // TODO: Have a function to output tidied up data for the configuration.
@@ -589,7 +583,7 @@ const DatePicker: React.FC<IDatePicker> = ({
                       <DayText>
                         {format(day, "d")}
                       </DayText>
-                      <ContentDot hasContent={dayHasContent(day, contentDays)} state={dayState} isToday={isTodayValue}/>
+                      <ContentDot hasContent={dayHasContent(day, contentDays)} state={dayState} isToday={isTodayValue} />
                     </CalCellB>
                   );
                 })}
@@ -598,19 +592,15 @@ const DatePicker: React.FC<IDatePicker> = ({
           })}
         </CalBody>
 
-        {(hasReset || hasApply) && (<CalButtons>
-          {hasReset && (
-            <CalLeftButton>
-            <Button design='secondary' onClick={resetCallback}>{resetText}</Button>
-          </CalLeftButton>)
-          }
-          {hasApply && (
-            <CalRightButtons>
-              <Button design='secondary' onClick={cancelCallback}>{cancelText}</Button>
-              <Button onClick={applyCallback} disabled={!isTimeRangeValid || selectedRange === null}>{applyText}</Button>
-            </CalRightButtons>)
-          }
-        </CalButtons>)
+        {hasApply && (
+          <CalButtons>
+            {hasApply && (
+              <CalRightButtons>
+                <Button design='secondary' onClick={cancelCallback}>{cancelText}</Button>
+                <Button onClick={applyCallback} disabled={!isTimeRangeValid || selectedRange === null}>{applyText}</Button>
+              </CalRightButtons>)
+            }
+          </CalButtons>)
         }
 
       </CalendarArea>
@@ -742,5 +732,5 @@ const isDayOutOfRange = (currentDay: Date, availableRange?: DateRange): boolean 
 const dayHasContent = (currentDay: Date, contentDays?: Date[]): boolean => {
   if (!contentDays) return false;
 
-  return contentDays.some(day => isSameDay(currentDay,day));
+  return contentDays.some(day => isSameDay(currentDay, day));
 };

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -6,6 +6,7 @@ import DateTimeBlock from '../atoms/DateTimeBlock';
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isAfter, eachWeekOfInterval, addMonths, endOfWeek, intervalToDuration, isSameMonth, isSameDay, isToday, startOfDay, endOfDay, isWithinInterval, set, add, isEqual } from 'date-fns';
 import { ja, enUS } from 'date-fns/locale';
 import { resetButtonStyles } from '../../common';
+import Button from '../../Form/atoms/Button';
 
 /**
  * Convert a single days duration to an interval.
@@ -55,7 +56,7 @@ const TimeZoneOption = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px;
+  padding: 11px;
   box-sizing: border-box;
 `;
 
@@ -159,6 +160,30 @@ const PaginateMonth = styled.button`
 
 const CalBody = styled.div`
   padding: 5px 0;
+`;
+
+const CalButtons = styled.div`
+  display: flex;
+  padding: 4px;
+  justify-content: flex-end;
+  align-items: flex-start;
+  gap: 4px;
+  align-self: stretch;
+  border-top: 1px solid var(--grey-6);
+`;
+
+const CalLeftButton = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  flex: 1 0 0;
+`;
+
+const CalRightButtons = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
 `;
 
 const CalRow = styled.div`
@@ -357,6 +382,9 @@ export interface IDatePicker {
   timeZoneValueTitle?: string
   availableRange?: DateRange
   contentDays?: Date[]
+  cancelText?: string
+  applyText?: string
+  resetText?: string
   updateCallback?: (data: DateInterval | Date) => void
   lang?: 'en' | 'ja'
 }
@@ -373,7 +401,10 @@ const DatePicker: React.FC<IDatePicker> = ({
   initialValue,
   availableRange,
   contentDays,
-  lang = 'en'
+  lang = 'en',
+  cancelText = 'Cancel',
+  applyText = 'Apply',
+  resetText = 'Reset'
 }) => {
 
   // TODO: Have a function to output tidied up data for the configuration.
@@ -556,6 +587,16 @@ const DatePicker: React.FC<IDatePicker> = ({
             );
           })}
         </CalBody>
+
+        <CalButtons>
+          <CalLeftButton>
+            <Button design='secondary'>{resetText}</Button>
+          </CalLeftButton>
+          <CalRightButtons>
+            <Button design='secondary'>{cancelText}</Button>
+            <Button>{applyText}</Button>
+          </CalRightButtons>
+        </CalButtons>
 
       </CalendarArea>
 

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -389,9 +389,9 @@ export interface IDatePicker {
   hasApply?: boolean
   hasReset?: boolean
   updateCallback?: (data: DateInterval | Date) => void
-  onApplyCallback?: () => void
-  onResetCallback?: () => void
-  onCancelCallback?: () => void
+  applyCallback?: () => void
+  resetCallback?: () => void
+  cancelCallback?: () => void
 }
 
 const DatePicker: React.FC<IDatePicker> = ({
@@ -412,9 +412,9 @@ const DatePicker: React.FC<IDatePicker> = ({
   resetText = 'Reset',
   hasApply = false,
   hasReset = false,
-  onApplyCallback = () => {},
-  onResetCallback = () => {},
-  onCancelCallback = () => {}
+  applyCallback = () => {},
+  resetCallback = () => {},
+  cancelCallback = () => {}
 }) => {
 
   // TODO: Have a function to output tidied up data for the configuration.
@@ -601,13 +601,13 @@ const DatePicker: React.FC<IDatePicker> = ({
         {(hasReset || hasApply) && (<CalButtons>
           {hasReset && (
             <CalLeftButton>
-            <Button design='secondary' onClick={onResetCallback}>{resetText}</Button>
+            <Button design='secondary' onClick={resetCallback}>{resetText}</Button>
           </CalLeftButton>)
           }
           {hasApply && (
             <CalRightButtons>
-              <Button design='secondary' onClick={onCancelCallback}>{cancelText}</Button>
-              <Button onClick={onApplyCallback}>{applyText}</Button>
+              <Button design='secondary' onClick={cancelCallback}>{cancelText}</Button>
+              <Button onClick={applyCallback}>{applyText}</Button>
             </CalRightButtons>)
           }
         </CalButtons>)

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import FilterDropdownContainer from '../atoms/FilterDropdownContainer';
 import DatePicker, { DateInterval, IDatePicker } from './DatePicker';
-import FilterDropHandler from '../atoms/FilterDropHandler';
+import FilterDropHandler, { FilterDropHandlerRef } from '../atoms/FilterDropHandler';
 
 const MIN_WIDTH = 470;
 const MIN_HEIGHT = 360;
@@ -40,9 +40,15 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
   hasEmptyValue,
   availableRange,
   contentDays,
+  cancelText = 'Cancel',
+  applyText = 'Apply',
+  resetText = 'Reset',
+  hasApply = true,
+  hasReset = true,
   onCloseCallback = () => { },
   onUpdateCallback = () => { },
   onToggleCallback = () => { },
+  onCancelCallback = () => { },
   ...props }) => {
 
   /**
@@ -52,6 +58,7 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
   const pickerValue = useRef<DateInterval | Date | null>(null);
   const [mountedPicker, setMountedPicker] = useState<IMountPicker>({ initialValue: initialValue, isMount: true });
 
+  const DropdownHandlerRef = useRef<FilterDropHandlerRef>(null);
   const handleUpdateCallback = useCallback((data: DateInterval | Date) => {
     pickerValue.current = data;
     onUpdateCallback(data);
@@ -76,6 +83,11 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
     }
   }, [mountedPicker, onToggleCallback, selected]);
 
+  const handleOnCancel = useCallback(() => {
+    onCancelCallback();
+    DropdownHandlerRef.current?.cancelClose();
+  }, [onCancelCallback]);
+
   /**
    * Caching the selected null /clear flag for this picker from parent component
    */
@@ -93,11 +105,13 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
   return (
     <Container {...props}>
       <FilterDropHandler
-        {...{ buttonIcon, buttonText, disabled }}
+        ref={DropdownHandlerRef}
         minWidth={MIN_WIDTH}
         minHeight={MIN_HEIGHT}
         onCloseCallback={handleOnClose}
         onToggleOpenCallback={handleOnToggle}
+        noCloseOnClickOutside={hasApply || hasReset}
+        {...{ buttonIcon, buttonText, disabled }}
       >
         <FilterDropdownContainer>
           {mountedPicker.isMount && (
@@ -112,8 +126,14 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
                 lang,
                 availableRange,
                 contentDays,
+                cancelText,
+                applyText,
+                resetText,
+                hasApply,
+                hasReset
               }}
               updateCallback={handleUpdateCallback}
+              onCancelCallback={handleOnCancel}
               hasEmptyValue
               initialValue={mountedPicker.initialValue}
             />)}

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -79,7 +79,6 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
 
     /** Verify if the picker needs to be mounted again to force initialValue set in Datepicker Component */
     if (isOpen && (!mountedPicker.isMount)) {
-      console.log('Toggle mount functionality was triggered');
       setMountedPicker((prev) => {
         return { ...prev, isMount: true };
       });
@@ -98,7 +97,6 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
 
 
   const handleOnApply = useCallback(() => {
-
     if (pickerValue.current && (pickerValue.current !== selected)) {
       onApplyCallback(pickerValue.current);
     }

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -89,10 +89,10 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
   }, [mountedPicker, onToggleCallback, selected]);
 
   const handleOnCancel = useCallback(() => {
-    if (selected && pickerValue.current && (pickerValue.current !== selected)) {
-      pickerValue.current = selected;
-      setMountedPicker({ initialValue: selected, isMount: false });
-      console.log('Returning value to selected before modification', selected);
+    if (pickerValue.current && (pickerValue.current !== selected)) {
+      pickerValue.current = selected === undefined ? null : selected;
+      const validInitialValue = selected === null ? undefined : selected;
+      setMountedPicker({ initialValue: validInitialValue, isMount: false });
     }
     onCancelCallback();
     DropdownHandlerRef.current?.cancelClose();
@@ -100,9 +100,11 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
 
 
   const handleOnApply = useCallback(() => {
+
     if (pickerValue.current && (pickerValue.current !== selected)) {
       onApplyCallback(pickerValue.current);
     }
+    DropdownHandlerRef.current?.cancelClose();
   },[onApplyCallback, selected]);
 
   /**

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import FilterDropdownContainer from '../atoms/FilterDropdownContainer';
 import DatePicker, { DateInterval, IDatePicker } from './DatePicker';
 import FilterDropHandler, { FilterDropHandlerRef } from '../atoms/FilterDropHandler';
+import { areDatesEqual } from '../../helpers';
 
 const MIN_WIDTH = 470;
 const MIN_HEIGHT = 360;
@@ -58,12 +59,14 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
    */
   const pickerValue = useRef<DateInterval | Date | null>(null);
   const [mountedPicker, setMountedPicker] = useState<IMountPicker>({ initialValue: initialValue, isMount: true });
+  const [disableApply, setDisableApply] = useState(false);
 
   const DropdownHandlerRef = useRef<FilterDropHandlerRef>(null);
   const handleUpdateCallback = useCallback((data: DateInterval | Date) => {
     pickerValue.current = data;
     onUpdateCallback(data);
-  }, [onUpdateCallback]);
+    setDisableApply(areDatesEqual(selected, data));
+  }, [onUpdateCallback, selected]);
 
   const handleOnClose = useCallback(() => {
     if (pickerValue.current && (pickerValue.current !== selected)) {
@@ -151,6 +154,7 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
               applyCallback={handleOnApply}
               hasEmptyValue
               initialValue={mountedPicker.initialValue}
+              disableApply={disableApply}
             />)}
         </FilterDropdownContainer>
       </FilterDropHandler>

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -44,9 +44,7 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
   contentDays,
   cancelText = 'Cancel',
   applyText = 'Apply',
-  resetText = 'Reset',
   hasApply = true,
-  hasReset = true,
   onCloseCallback = () => { },
   onUpdateCallback = () => { },
   onToggleCallback = () => { },
@@ -111,14 +109,14 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
    * Caching the selected null /clear flag for this picker from parent component
    */
   useEffect(() => {
-    let canReset = true;
+    let canUnmount = true;
 
-    if (canReset && selected === null && pickerValue.current !== null) {
+    if (canUnmount && selected === null && pickerValue.current !== null) {
       pickerValue.current = selected;
       setMountedPicker({ initialValue: undefined, isMount: false });
     }
     return () => {
-      canReset = false;
+      canUnmount = false;
     };
   }, [selected]);
 
@@ -148,9 +146,7 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
                 contentDays,
                 cancelText,
                 applyText,
-                resetText,
                 hasApply,
-                hasReset
               }}
               updateCallback={handleUpdateCallback}
               cancelCallback={handleOnCancel}

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -75,18 +75,18 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
 
   const handleOnToggle = useCallback((isOpen: boolean) => {
 
-    if (pickerValue.current && (pickerValue.current !== selected)) {
+    if (!hasApply && pickerValue.current && (pickerValue.current !== selected)) {
       onToggleCallback(pickerValue.current, isOpen);
     }
 
-    /** mounting again to force initialValue set in Datepicker Component */
+    /** Verify if the picker needs to be mounted again to force initialValue set in Datepicker Component */
     if (isOpen && (!mountedPicker.isMount)) {
       console.log('Toggle mount functionality was triggered');
       setMountedPicker((prev) => {
         return { ...prev, isMount: true };
       });
     }
-  }, [mountedPicker, onToggleCallback, selected]);
+  }, [hasApply, mountedPicker.isMount, onToggleCallback, selected]);
 
   const handleOnCancel = useCallback(() => {
     if (pickerValue.current && (pickerValue.current !== selected)) {

--- a/packages/ui-lib/src/Filters/organisms/FilterBar.tsx
+++ b/packages/ui-lib/src/Filters/organisms/FilterBar.tsx
@@ -117,7 +117,6 @@ const createDatePickers = (
     const onToggleCallback = (value: DateInterval | Date | null, isOpen: boolean) => {
       // if it was open before toggle means the user closed it and value should be updated.
       if (!isOpen) {
-        console.log(`datepicker: ${datePicker.id} toggled open: ${isOpen} value: ${value}`);
         handleDatePickers(value, datePicker.id);
       }
     };

--- a/packages/ui-lib/src/Filters/organisms/FilterBar.tsx
+++ b/packages/ui-lib/src/Filters/organisms/FilterBar.tsx
@@ -116,10 +116,16 @@ const createDatePickers = (
 
     const onToggleCallback = (value: DateInterval | Date | null, isOpen: boolean) => {
       // if it was open before toggle means the user closed it and value should be updated.
-      if (isOpen) {
+      if (!isOpen) {
+        console.log(`datepicker: ${datePicker.id} toggled open: ${isOpen} value: ${value}`);
         handleDatePickers(value, datePicker.id);
       }
     };
+
+    const onApplyCallback = (value: DateInterval | Date) => {
+      handleDatePickers(value, datePicker.id);
+    };
+
     const disabled = getDisableValue(filtersValues, singleFilter, datePicker);
     const foundPicker = filtersValues.find(filter => filter.id === datePicker.id);
     let validInitialValue: Date | DateInterval | undefined = undefined;
@@ -134,6 +140,7 @@ const createDatePickers = (
       ...datePicker,
       onCloseCallback,
       onToggleCallback,
+      onApplyCallback,
       disabled,
       selected: foundPicker && (foundPicker.selected instanceof Date || isDateInterval(foundPicker.selected)) ? foundPicker.selected : null,
       initialValue: validInitialValue,

--- a/packages/ui-lib/src/helpers/index.tsx
+++ b/packages/ui-lib/src/helpers/index.tsx
@@ -1,4 +1,5 @@
-import {ITimeUnit} from '../index';
+import { isEqual } from 'date-fns';
+import {DateInterval, isDateInterval, ITimeUnit} from '../index';
 
 const isInsideRange = (value: number, min: number, max: number) : boolean => {
   if( value < min) {return false;}
@@ -90,6 +91,26 @@ const uniqueID = () =>
     return intValue !== intValue;
   };
 
+  const areDatesEqual = (storedValue: DateInterval | Date | null | undefined, currentDisplay: DateInterval | Date | null): boolean => {
+    if (storedValue === null && currentDisplay === null) {
+      return true;
+    }
+
+    if (storedValue === undefined && currentDisplay === null) {
+      return true;
+    }
+
+    if (isDateInterval(storedValue) && isDateInterval(currentDisplay)) {
+      return isEqual(storedValue?.start, currentDisplay?.start) && isEqual(storedValue?.end, currentDisplay?.end);
+    }
+
+    if(storedValue instanceof Date && currentDisplay instanceof Date) {
+      return isEqual(storedValue, currentDisplay);
+    }
+
+    return false;
+  };
+
 export {
   clamp,
   isValidImage,
@@ -99,5 +120,6 @@ export {
   getShortTextTimeUnit,
   getTopLevelPath,
   uniqueID,
-  isNotNumber
+  isNotNumber,
+  areDatesEqual
 };


### PR DESCRIPTION
### Description

Updated the DatePicker component to include "Apply" and "Cancel" buttons.

### Considerations on Implementation

This update introduces the following new props to DatePicker:

```ts
  cancelText = 'Cancel',
  applyText = 'Apply',
  hasApply = false,
  onToggleCallback = () => { },
  onCancelCallback = () => { },
  onApplyCallback = () => { },
```

- This update is backward compatible for both `DatePicker` and `FilterBar`, meaning no changes are required unless DropdownDatePicker is used as a standalone component.

- `DatePicker` prop `hasApply` is false ensuring no UI changes for existing implementations.
- In `DropdownDatePicker`, `hasApply` defaults to true. To maintain the previous behavior, set `hasApply` to `false`. If the new behaviour is desired the developer needs to implement the `onCancelCallback` and `onApplyCallback` on their side to handle the `selected` value.

I have made a document of the use cases for Apply, Cancel and Toggle 
https://docs.google.com/spreadsheets/d/1POe9uZxKXtLhQFF6DIV-RclUp7T7oXgSeSLlbYmE38g/edit?usp=sharing

The mayor change updates were in `Toggle` and `Click Outside`

**Before:**

**Toggle Close:** will send updated value
**Click Outside:** Closes Dropdown without update

**Now**

**Toggle Close**: Does not send update and keeps the current value even if it's not apply. When reopened it will show.
**Click Outside:** Does not closes the Dropdown

### Reviewing/Testing steps
Please Review in Storybook under Filters -> Organisms -> Filterbar
[Demo Video](https://drive.google.com/file/d/11cLXMDOCOpWC0Y1O1a1EoGvID_lKynOa/view?usp=drive_link)

**Updated**
![Screenshot 2025-02-06 at 15 24 59](https://github.com/user-attachments/assets/ff403994-4990-48a3-bcaa-cff1529a199d)


**Invalid values. disabled Apply button**

![Screenshot 2025-02-06 at 15 25 09](https://github.com/user-attachments/assets/c5f3e26e-ff6d-4d83-8f6f-6c8db606b4e4)

**New selection**
![Screenshot 2025-02-06 at 15 25 16](https://github.com/user-attachments/assets/3e7db683-6bff-4df5-be0b-14098380ac14)
![Screenshot 2025-02-06 at 15 25 21](https://github.com/user-attachments/assets/9631f352-7240-46ab-a344-48b8132716b1)

No selection disabled Apply
![Screenshot 2025-02-06 at 15 25 28](https://github.com/user-attachments/assets/39684a8b-dbe7-4b33-be91-07f986b65f34)
