### PR TITLE
Added rules for spacing require dot (Fixes #531)

### DIFF
--- a/packages/ui-lib/src/Form/atoms/Label.tsx
+++ b/packages/ui-lib/src/Form/atoms/Label.tsx
@@ -3,6 +3,11 @@ import styled, { css } from 'styled-components';
 import { TypeLabelDirection } from '..';
 
 const LabelText = styled.span<{ required?: boolean }>`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 8px;
+  
   ${({required}) => required && css`
     &::after {
       content: '';


### PR DESCRIPTION
After the label refactor, the new required dot lost its spacing as reported here #531. It's been restored here:

Before:
![image](https://github.com/user-attachments/assets/965a1638-f5eb-48ed-9df4-ed0b8ed984b9)

After:
![image](https://github.com/user-attachments/assets/cf2e73b3-945a-4074-a371-1c2f762513af)

I checked various implementations of Label after doing this and noticed no regression or errors in things like Pagination. However, if these can be double checked it would be highly appreciated.