### PR TITLE
Add SideArea initial State and callbacks

### DIFF
--- a/packages/example/src/pages/SplitLayout.tsx
+++ b/packages/example/src/pages/SplitLayout.tsx
@@ -12,11 +12,11 @@ const SplitLayouts: FC = () => {
 
 
   const sideStateCallback = useCallback((currentState) => {
-    console.log(`Side Area Current State ${currentState}`);
+    console.log(`Side Area Current State: ${currentState}`);
   },[]);
 
-  const areaAContent = <FlexContentPlaceholder title='Area A' />;
-  const areaBContent = <FlexContentPlaceholder title='Area B' />;
+  const areaAContent = <FlexContentPlaceholder title='Main Area' />;
+  const areaBContent = <FlexContentPlaceholder title='Side Area' />;
 
   return (
       <ThemeProvider theme={defaultTheme}>

--- a/packages/example/src/pages/SplitLayout.tsx
+++ b/packages/example/src/pages/SplitLayout.tsx
@@ -206,7 +206,7 @@ const SplitLayouts: FC = () => {
               persistenceKey='my_unique_key'
               reverse={reverse}
               mainArea={{ content: areaAContent, minSize: 120 }}
-              sideArea={{ content: areaBContent, collapsable: true, minSize: 200, initialSideAreaState: 'collapsed' , onSideAreaStateChange: sideStateCallback,  }} />
+              sideArea={{ content: areaBContent, collapsable: true, minSize: 200, defaultCollapsed: true , onSideAreaStateChange: sideStateCallback,  }} />
           </ContentLayout>
 
         </GlobalUI>

--- a/packages/example/src/pages/SplitLayout.tsx
+++ b/packages/example/src/pages/SplitLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC, useCallback, useState } from "react";
 import { ThemeProvider } from 'styled-components';
 import { GlobalUI, defaultTheme, useThemeToggle, ContentLayout, SplitLayout, FlexContentPlaceholder } from "scorer-ui-kit";
 import ExamplesFilename from '../components/ExamplesFilename';
@@ -6,10 +6,15 @@ import ExamplesFilename from '../components/ExamplesFilename';
 const SplitLayouts: FC = () => {
 
   const {onThemeToggle, isLightMode} = useThemeToggle();
-  
+
   const [layout] = useState<'horizontal'|'vertical'>('horizontal');
   const [reverse] = useState<boolean>(false);
-  
+
+
+  const sideStateCallback = useCallback((currentState) => {
+    console.log(`Side Area Current State ${currentState}`);
+  },[]);
+
   const areaAContent = <FlexContentPlaceholder title='Area A' />;
   const areaBContent = <FlexContentPlaceholder title='Area B' />;
 
@@ -193,15 +198,15 @@ const SplitLayouts: FC = () => {
             },
           ]}
         >
-          
+
           <ContentLayout layout="dashboard">
-            <SplitLayout 
+            <SplitLayout
               layout={layout}
-              persist 
+              persist
               persistenceKey='my_unique_key'
-              reverse={reverse} 
-              mainArea={{ content: areaAContent, minSize: 120 }} 
-              sideArea={{ content: areaBContent, collapsable: true, minSize: 200 }} />
+              reverse={reverse}
+              mainArea={{ content: areaAContent, minSize: 120 }}
+              sideArea={{ content: areaBContent, collapsable: true, minSize: 200, initialSideAreaState: 'collapsed' , onSideAreaStateChange: sideStateCallback,  }} />
           </ContentLayout>
 
         </GlobalUI>

--- a/packages/storybook/src/stories/Global/organisms/NestedSplitLayout.stories.tsx
+++ b/packages/storybook/src/stories/Global/organisms/NestedSplitLayout.stories.tsx
@@ -1,3 +1,5 @@
+import { action } from '@storybook/addon-actions';
+import { select } from '@storybook/addon-knobs';
 import React from 'react';
 import {
   GlobalUI,
@@ -28,6 +30,10 @@ const Container = styled.div`
 export const _SplitLayoutNested = () => {
 
   const reverse = false;
+  const initialVerticalState = select("Vertical Side - Initial State", {Open: "open", Collapsing: 'collapsing', Collapsed: 'collapsed', Peeking: 'peeking', Opening: 'opening' }, 'collapsed');
+  const onVerticalNestedChange = action('Vertical State');
+  const initialHorizontalState = select("Horizontal Side - Initial State", {Open: "open", Collapsing: 'collapsing', Collapsed: 'collapsed', Peeking: 'peeking', Opening: 'opening' }, 'collapsed');
+  const onHorizontalNestedChange = action('Horizontal State');
 
   const nestedSplitChild = <SplitLayout
     layout='vertical'
@@ -35,7 +41,7 @@ export const _SplitLayoutNested = () => {
     persistenceKey='my_nested_key'
     reverse={reverse}
     mainArea={{ content: <FlexContentPlaceholder title='Area A' />, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200 }} />;
+    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onVerticalNestedChange, initialSideAreaState: initialVerticalState }} />;
 
   const nestedSplitLayout = <SplitLayout
     layout='horizontal'
@@ -43,7 +49,7 @@ export const _SplitLayoutNested = () => {
     persistenceKey='my_unique_layout_key'
     reverse={reverse}
     mainArea={{ content: nestedSplitChild, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200 }} />
+    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onHorizontalNestedChange, initialSideAreaState: initialHorizontalState }} />
 
   return (
     <Container>

--- a/packages/storybook/src/stories/Global/organisms/NestedSplitLayout.stories.tsx
+++ b/packages/storybook/src/stories/Global/organisms/NestedSplitLayout.stories.tsx
@@ -30,18 +30,18 @@ const Container = styled.div`
 export const _SplitLayoutNested = () => {
 
   const reverse = false;
-  const defaultVerticalState = boolean("Vertical Side - defaultCollapsed", false)
-  const onVerticalNestedChange = action('Vertical State');
-  const defaultHorizontalState = boolean("Horizontal Side - defaultCollapsed", false)
-    const onHorizontalNestedChange = action('Horizontal State');
+  const defaultSideAState = boolean("Side Area A - Default Collapsed", false);
+  const onSideAreaAChange = action('Side Area A State');
+  const defaultSideBState = boolean("Side Area B - Default Collapsed", false);
+    const onSideAreaBChange = action('Side Area B State');
 
   const nestedSplitChild = <SplitLayout
     layout='vertical'
     persist
     persistenceKey='my_nested_key'
     reverse={reverse}
-    mainArea={{ content: <FlexContentPlaceholder title='Area A' />, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onVerticalNestedChange, defaultCollapsed: defaultVerticalState }} />;
+    mainArea={{ content: <FlexContentPlaceholder title='Main Area' />, minSize: 120 }}
+    sideArea={{ content: <FlexContentPlaceholder title='Side Area A' />, collapsable: true, minSize: 200, onSideAreaStateChange: onSideAreaAChange, defaultCollapsed: defaultSideAState }} />;
 
   const nestedSplitLayout = <SplitLayout
     layout='horizontal'
@@ -49,7 +49,7 @@ export const _SplitLayoutNested = () => {
     persistenceKey='my_unique_layout_key'
     reverse={reverse}
     mainArea={{ content: nestedSplitChild, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onHorizontalNestedChange, defaultCollapsed: defaultHorizontalState }} />
+    sideArea={{ content: <FlexContentPlaceholder title='Side Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onSideAreaBChange, defaultCollapsed: defaultSideBState }} />
 
   return (
     <Container>

--- a/packages/storybook/src/stories/Global/organisms/NestedSplitLayout.stories.tsx
+++ b/packages/storybook/src/stories/Global/organisms/NestedSplitLayout.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { select } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import React from 'react';
 import {
   GlobalUI,
@@ -30,10 +30,10 @@ const Container = styled.div`
 export const _SplitLayoutNested = () => {
 
   const reverse = false;
-  const initialVerticalState = select("Vertical Side - Initial State", {Open: "open", Collapsing: 'collapsing', Collapsed: 'collapsed', Peeking: 'peeking', Opening: 'opening' }, 'collapsed');
+  const defaultVerticalState = boolean("Vertical Side - defaultCollapsed", false)
   const onVerticalNestedChange = action('Vertical State');
-  const initialHorizontalState = select("Horizontal Side - Initial State", {Open: "open", Collapsing: 'collapsing', Collapsed: 'collapsed', Peeking: 'peeking', Opening: 'opening' }, 'collapsed');
-  const onHorizontalNestedChange = action('Horizontal State');
+  const defaultHorizontalState = boolean("Horizontal Side - defaultCollapsed", false)
+    const onHorizontalNestedChange = action('Horizontal State');
 
   const nestedSplitChild = <SplitLayout
     layout='vertical'
@@ -41,7 +41,7 @@ export const _SplitLayoutNested = () => {
     persistenceKey='my_nested_key'
     reverse={reverse}
     mainArea={{ content: <FlexContentPlaceholder title='Area A' />, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onVerticalNestedChange, initialSideAreaState: initialVerticalState }} />;
+    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onVerticalNestedChange, defaultCollapsed: defaultVerticalState }} />;
 
   const nestedSplitLayout = <SplitLayout
     layout='horizontal'
@@ -49,7 +49,7 @@ export const _SplitLayoutNested = () => {
     persistenceKey='my_unique_layout_key'
     reverse={reverse}
     mainArea={{ content: nestedSplitChild, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onHorizontalNestedChange, initialSideAreaState: initialHorizontalState }} />
+    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200, onSideAreaStateChange: onHorizontalNestedChange, defaultCollapsed: defaultHorizontalState }} />
 
   return (
     <Container>

--- a/packages/storybook/src/stories/Global/organisms/SplitLayout.stories.tsx
+++ b/packages/storybook/src/stories/Global/organisms/SplitLayout.stories.tsx
@@ -36,16 +36,16 @@ export const _SplitLayout = () => {
     persist
     persistenceKey='my_unique_layout_key'
     reverse={reverse}
-    mainArea={{ content: <FlexContentPlaceholder title='Area A' />, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200 }} />
+    mainArea={{ content: <FlexContentPlaceholder title='Main Area' />, minSize: 120 }}
+    sideArea={{ content: <FlexContentPlaceholder title='Side Area A' />, collapsable: true, minSize: 200 }} />
 
   const nestedSplitChild = <SplitLayout
     layout='vertical'
     persist
     persistenceKey='my_nested_key'
     reverse={reverse}
-    mainArea={{ content: <FlexContentPlaceholder title='Area A' />, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200 }} />;
+    mainArea={{ content: <FlexContentPlaceholder title='Main Area' />, minSize: 120 }}
+    sideArea={{ content: <FlexContentPlaceholder title='Side Area A' />, collapsable: true, minSize: 200 }} />;
 
   const nestedSplitLayout = <SplitLayout
     layout='horizontal'
@@ -53,7 +53,7 @@ export const _SplitLayout = () => {
     persistenceKey='my_unique_layout_key'
     reverse={reverse}
     mainArea={{ content: nestedSplitChild, minSize: 120 }}
-    sideArea={{ content: <FlexContentPlaceholder title='Area B' />, collapsable: true, minSize: 200 }} />
+    sideArea={{ content: <FlexContentPlaceholder title='Side Area B' />, collapsable: true, minSize: 200 }} />
 
   return (
     <Container>

--- a/packages/ui-lib/src/Layouts/index.ts
+++ b/packages/ui-lib/src/Layouts/index.ts
@@ -42,12 +42,21 @@ export interface IMainArea {
   minSize?: number;
 }
 
+// 1. open - the side area is open and in normal resize range.
+// 2. collapsing - has been in an open state but is now in an area that will close it on release.
+// 3. collapsed - it's hidden!
+// 4. peeking - Has been closed but now dragging might re-open it.
+// 5. opening - We have restored it to a width that appears open. On release, we will set to open.
+export type ISideAreaState = 'open' | 'collapsing' | 'collapsed' | 'peeking' | 'opening';
+
 export interface ISideArea {
   content: ReactElement;
   defaultSize?: number;
   minSize?: number;
   maxSize?: number;
   collapsable?: boolean;
+  initialSideAreaState?: ISideAreaState
+  onSideAreaStateChange?: (sideAreaState: ISideAreaState) => void
 }
 
 export interface ISplitLayoutProps {

--- a/packages/ui-lib/src/Layouts/index.ts
+++ b/packages/ui-lib/src/Layouts/index.ts
@@ -55,7 +55,7 @@ export interface ISideArea {
   minSize?: number;
   maxSize?: number;
   collapsable?: boolean;
-  initialSideAreaState?: ISideAreaState
+  defaultCollapsed?: boolean;
   onSideAreaStateChange?: (sideAreaState: ISideAreaState) => void
 }
 

--- a/packages/ui-lib/src/Layouts/molecules/SplitLayout.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/SplitLayout.tsx
@@ -181,7 +181,7 @@ const SplitLayout = forwardRef<ISplitLayoutHandles, ISplitLayoutProps>(({ mainAr
   const [mousePosDiff, setMousePosDiff] = useState<IPosition>();
   const [resizing, setResizing] = useState<boolean>();
 
-  const [sideAreaState, setSideAreaState] = useState<ISideAreaState>( sideArea.initialSideAreaState|| 'open');
+  const [sideAreaState, setSideAreaState] = useState<ISideAreaState>( sideArea.defaultCollapsed ? 'collapsed' : 'open');
   const [sideAreaBasis, setSideAreaBasis] = useState<number>(sideDefaultSize);
   const [sideAreaStartBasis, setSideAreaStartBasis] = useState<number>(sideDefaultSize);
   const [lastOpenSize, setLastOpenSize] = useState<number>(sideDefaultSize);


### PR DESCRIPTION
### Description

This PR is related to the request of [Enhance SplitLayout for better code integration related to open state](#538)
 

 ### Considerations on Implementation
 
 New `onSideAreaStateChange` for sideAreaState Changes:
A callback is now triggered every time the sideAreaState changes, allowing developers to monitor and respond to state transitions. 

New `defaultCollapsed` Prop added to sideArea prop:
A defaultCollapsed prop has been added to allow the side area to start in a collapsed state. This is particularly useful for scenarios where no stream data is available.

Behavior:
The defaultCollapse prop serves as an initial state only. If a localStorage variable for the side area exists (e.g., from previous interactions), its value takes precedence over defaultCollapse. As such, if the side area was last left open by the user, it will open again by default, ensuring the previous behavior remains unchanged.


 ### Reviewing/Testing steps
 
 I have added the callback and defaultCollapse prop to Examples and to Storybook.
 However currently the Storybook knobs crashes on selection :( ... this might be fixed with the update that is about to be merged. However I didn't tested this yet due time.
 
Due this the way to  review this is in Storybook (Global UI -> Organisms -> SplitLayout -> Nested) the callback functionality and review the defaultCollapse functionality in examples
 
 
<img width="1169" alt="Screenshot 2025-01-20 at 21 59 52" src="https://github.com/user-attachments/assets/bc9da2cd-b179-471a-8499-95a6ef07caf4" />

[Video Examples](https://drive.google.com/file/d/1K0BxetzlqZHK4oumgTu9Mj9uEwWNwmRa/view?usp=drive_link)
[Video Storybook](https://drive.google.com/file/d/1ST0V-mK1g113WNr4DY9yJ38RrfkUvuyh/view?usp=drive_link)
  