### PR TITLE
Responsive alignment of UtilityHeader

### DIFF
--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -4,6 +4,7 @@ import {Link} from 'react-router-dom';
 
 import { IUtilityHeader } from "..";
 import Icon from "../../Icons/Icon";
+import { useBreakpoints } from "../../hooks";
 import UtilityHeaderShare from "../atoms/UtilityHeaderShare";
 import UtilityHeaderBack from "../atoms/UtilityHeaderBack";
 
@@ -87,13 +88,14 @@ const RightArea = styled.div`
 
 
 const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share, $iconInGutter = true }) => {
-
+  
+  const { isLarge } = useBreakpoints();
   const hasBreadcrumbs = showBreadcrumbs && breadcrumbs.length > 0;
 
   return (
     <Container>
     <LeftArea>
-      {back && <UtilityHeaderBack $showDivider={hasBreadcrumbs} {...{$iconInGutter}} {...back} />}
+      {back && <UtilityHeaderBack $showDivider={hasBreadcrumbs} $iconInGutter={isLarge} {...back} />}
       {hasBreadcrumbs ?
         <Breadcrumbs>
           { breadcrumbs.map((breadcrumb, index) => {

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -87,15 +87,16 @@ const RightArea = styled.div`
 `;
 
 
-const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share, $iconInGutter = true }) => {
+const UtilityHeader : React.FC<IUtilityHeader> = ({ showBreadcrumbs = true, breadcrumbs = [], showHomeIcon = true, back, share, $iconInGutter }) => {
   
   const { isLarge } = useBreakpoints();
+  const iconInGutter = $iconInGutter !== undefined ? $iconInGutter : isLarge;
   const hasBreadcrumbs = showBreadcrumbs && breadcrumbs.length > 0;
 
   return (
     <Container>
     <LeftArea>
-      {back && <UtilityHeaderBack $showDivider={hasBreadcrumbs} $iconInGutter={isLarge} {...back} />}
+      {back && <UtilityHeaderBack $showDivider={hasBreadcrumbs} $iconInGutter={iconInGutter} {...back} />}
       {hasBreadcrumbs ?
         <Breadcrumbs>
           { breadcrumbs.map((breadcrumb, index) => {

--- a/packages/ui-lib/src/Pages/atoms/PageTitle.tsx
+++ b/packages/ui-lib/src/Pages/atoms/PageTitle.tsx
@@ -93,7 +93,7 @@ const PageTitle : React.FC<IProps> = ({title, icon, areaTitle, areaHref, updateD
   useTitle(title, hideAreaInDocTitle ? undefined : areaTitle || '', undefined, updateDocTitle);
 
   return (
-    <Container >
+    <Container>
       {icon ?
         <IconContainer ><Icon size={ICON_SIZE} color={iconColor} {...{icon}} /></IconContainer>
       : null}


### PR DESCRIPTION
Fixes issue #536 .

Previously the `$iconInGutter` was hardcoded so the `UtilityHeader` alignment didn't change on small breakpoints. This has been updated to be responsive but can be overridden by the props.

Before:
![Screenshot 2025-02-04 at 20 26 12](https://github.com/user-attachments/assets/c74e249a-9c91-4f39-9736-1ec380283bf2)

After:
![Screenshot 2025-02-04 at 20 24 55](https://github.com/user-attachments/assets/7930d117-af6c-48c3-9eb0-b28ddbb7ae51)
