### PR TITLE
Bump for release 2.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "2.8.2",
+      "version": "2.8.3",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -37847,7 +37847,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "2.8.2",
+      "version": "2.8.3",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
### Description


**Release 2.8.3**

**Features**
- **UtilityHeader**: Updated the left alignment of the `Breadcrumbs` component on small devices. This behavior can be overridden by passing the `$iconInGutter` boolean prop.

**Fixes**
- **Filters:** Prevents text wrapping in labels when using Japanese. (Issue identified in filter options and buttons within `SortDropdown`)