### PR TITLE
Add Template String to Duration Slider

### DIFF
--- a/packages/storybook/src/stories/Form/Input/DurationSlider.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/DurationSlider.stories.tsx
@@ -131,7 +131,7 @@ const secToMinAndHours = (seconds: number): ITimeValue => {
   }
 }
 
-const templateExampleData = {
+const timeFormatData = {
   hours: {
     min: 1,
     max: 10,
@@ -213,8 +213,8 @@ export const _DurationSlider = () => {
   const minValue2 = number('Min 2', 3);
   const defaultValue2 = number('Default value 2', defaultMixValue)
   const onlyMarkSelect = boolean('Only Mark Select', true);
-  const templateUnit = select('Template Example Unit', { Hours: 'hours', Minutes: 'minutes', Seconds: 'seconds' }, 'hours');
-  const valueTitleTemplate = text('Value Title Template', '[HR]Hr [MIN]Min [SEC]Sec');
+  const timeFormatUnit = select('Template Example Unit', { Hours: 'hours', Minutes: 'minutes', Seconds: 'seconds' }, 'seconds');
+  const timeFormat = text('Time Format', '[H]Hr [M]Min [S]Sec');
 
   const showValue2 = action('Input Callback');
   const marks2 = object('Marks 2', exampleMarks2);
@@ -230,7 +230,7 @@ export const _DurationSlider = () => {
     <Container>
       <Wrapper>
         <PageHeader
-          title='Simple example'
+          title='Simple Example'
           introductionText='Values are controlled by component'
         />
         <DurationSlider
@@ -247,7 +247,7 @@ export const _DurationSlider = () => {
       </Wrapper>
       <Wrapper>
         <PageHeader
-          title='Mixed values example'
+          title='Mixed Values Example'
           introductionText='Values are controlled from outside'
         />
         <DurationSlider
@@ -266,16 +266,17 @@ export const _DurationSlider = () => {
       </Wrapper>
       <Wrapper>
         <PageHeader
-          title='Template example'
-          introductionText='Title template is used'
+          title='Date Format Example'
+          introductionText='Date Format is used'
         />
         <DurationSlider
           title={'Custom Titles'}
-          timeUnit={templateUnit}
-          max={templateExampleData[templateUnit].max}
-          min={templateExampleData[templateUnit].min}
-          valueTitleTemplate={valueTitleTemplate}
-          marks={templateExampleData[templateUnit].marks}
+          timeUnit={timeFormatUnit}
+          max={timeFormatData[timeFormatUnit].max}
+          min={timeFormatData[timeFormatUnit].min}
+          timeFormat={timeFormat}
+          defaultValue={timeFormatData[timeFormatUnit].min}
+          marks={timeFormatData[timeFormatUnit].marks}
         />
       </Wrapper>
     </Container>

--- a/packages/storybook/src/stories/Form/Input/DurationSlider.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/DurationSlider.stories.tsx
@@ -131,6 +131,63 @@ const secToMinAndHours = (seconds: number): ITimeValue => {
   }
 }
 
+const templateExampleData = {
+  hours: {
+    min: 1,
+    max: 10,
+    marks: [
+      {
+        value: 1,
+        label: '1M',
+      },
+      {
+        value: 5,
+        label: '5H',
+      },
+      {
+        value: 10,
+        label: '10H',
+      },
+    ],
+  },
+  minutes: {
+    min: 1,
+    max: 60,
+    marks: [
+      {
+        value: 1,
+        label: '1M',
+      },
+      {
+        value: 30,
+        label: '30M',
+      },
+      {
+        value: 60,
+        label: '1H',
+      },
+    ],
+  },
+  seconds: {
+    min: 1,
+    max: 3600,
+    marks: [
+      {
+        value: 1,
+        label: '1S',
+      },
+      {
+        value: 1800,
+        label: '30M',
+      },
+      {
+        value: 3600,
+        label: '1H',
+      },
+    ],
+  },
+}
+
 export const _DurationSlider = () => {
 
   const title = text('Title', 'Duration');
@@ -156,6 +213,8 @@ export const _DurationSlider = () => {
   const minValue2 = number('Min 2', 3);
   const defaultValue2 = number('Default value 2', defaultMixValue)
   const onlyMarkSelect = boolean('Only Mark Select', true);
+  const templateUnit = select('Template Example Unit', { Hours: 'hours', Minutes: 'minutes', Seconds: 'seconds' }, 'hours');
+  const valueTitleTemplate = text('Value Title Template', '[HR]Hr [MIN]Min [SEC]Sec');
 
   const showValue2 = action('Input Callback');
   const marks2 = object('Marks 2', exampleMarks2);
@@ -203,6 +262,20 @@ export const _DurationSlider = () => {
           title={title2}
           timeUnit={value2.unit}
           onlyMarkSelect={onlyMarkSelect}
+        />
+      </Wrapper>
+      <Wrapper>
+        <PageHeader
+          title='Template example'
+          introductionText='Title template is used'
+        />
+        <DurationSlider
+          title={'Custom Titles'}
+          timeUnit={templateUnit}
+          max={templateExampleData[templateUnit].max}
+          min={templateExampleData[templateUnit].min}
+          valueTitleTemplate={valueTitleTemplate}
+          marks={templateExampleData[templateUnit].marks}
         />
       </Wrapper>
     </Container>

--- a/packages/ui-lib/src/Form/molecules/DurationSlider.tsx
+++ b/packages/ui-lib/src/Form/molecules/DurationSlider.tsx
@@ -76,9 +76,9 @@ const getTimeValues = (value: number, unit: ITimeUnit) => {
   }
 };
 
-const getValueTitle = (value: number, timeUnit: ITimeUnit | string, valueTitleTemplate?: string) => {
+const getValueTitle = (value: number, timeUnit: ITimeUnit | string, timeFormat?: string) => {
   // Handle default case
-  if (!valueTitleTemplate || !isTimeUnit(timeUnit)) {
+  if (!timeFormat || !isTimeUnit(timeUnit)) {
     const unit = isTimeUnit(timeUnit) ? getShortTextTimeUnit(value, timeUnit) : timeUnit;
     return (
       <ValueTitle>
@@ -90,20 +90,25 @@ const getValueTitle = (value: number, timeUnit: ITimeUnit | string, valueTitleTe
 
   const timeValues = getTimeValues(value, timeUnit as ITimeUnit);
 
-  const updatedTitle = valueTitleTemplate
-    .split(/(\[HR\]|\[MIN\]|\[SEC\])/)
+  const updatedTitle = timeFormat
+    .split(/(\[H+\]|\[M+\]|\[S+\])/)
     .map((part, index) => {
       switch (part) {
-        case '[HR]':
+        case '[HH]':
+          return <span key={index}>{timeValues.hours.toString().padStart(2, '0')}</span>;
+        case '[H]':
           return <span key={index}>{timeValues.hours}</span>;
-        case '[MIN]':
+        case '[MM]':
+          return <span key={index}>{timeValues.minutes.toString().padStart(2, '0')}</span>;
+        case '[M]':
           return <span key={index}>{timeValues.minutes}</span>;
-        case '[SEC]':
+        case '[SS]':
+          return <span key={index}>{timeValues.seconds.toString().padStart(2, '0')}</span>;
+        case '[S]':
           return <span key={index}>{timeValues.seconds}</span>;
         default: {
-          // Preserve whitespace by using a non-breaking space for empty strings
-          const keepSpaceInPart = part.replace(' ', '\u00A0');
-          return keepSpaceInPart;
+          const preserveSpacesInPart = part.replace(/\s+/g, '\u00A0');
+          return preserveSpacesInPart;
         }
       }
     });
@@ -119,7 +124,7 @@ interface IDurationSliderProps {
   title: string
   timeUnit: ITimeUnit | string
   controlledValue?: number
-  valueTitleTemplate?: string // [HR] [MIN] [SEC] -> [12]Hours [30]Minutes [15]Seconds OR 12:30:15
+  timeFormat?: string // [H]Hours [M]Minutes [S]Seconds -> 4Hours 10Minutes 30Seconds // [HH]時 [MM]分 [SS]秒 -> 4時 10分 30秒
 }
 
 type IDurationSlider = IDurationSliderProps & ISlider;
@@ -133,7 +138,7 @@ const DurationSlider: React.FC<IDurationSlider> = (
     timeUnit,
     controlledValue,
     inputCallback,
-    valueTitleTemplate,
+    timeFormat,
     ...props
   }
 ) => {
@@ -153,7 +158,7 @@ const DurationSlider: React.FC<IDurationSlider> = (
     <Container>
       <Headers>
         <Label htmlFor='duration-slider' labelText={title} />
-        {getValueTitle(labelValue, timeUnit, valueTitleTemplate)}
+        {getValueTitle(labelValue, timeUnit, timeFormat)}
       </Headers>
       <SliderInput
         {


### PR DESCRIPTION
### Description

This feature request enhances the Slider Duration component by providing more flexible templating options for the right side title.

Related issue: [#212](https://github.com/future-standard/scorer-ui-kit/issues/212)

 ### Considerations on Implementation

- This implementation maintains backward compatibility with the existing template.
- The new timeFormat prop allows developers to control the displayed format.
- One notable change is that the previous implementation automatically handled pluralization for hours, minutes, and seconds. If developers still require this, they will need to implement it manually on their side. They can refer to the logic in the [helpers index file](https://github.com/future-standard/scorer-ui-kit/blob/main/packages/ui-lib/src/helpers/index.tsx).

 ### Reviewing/Testing steps

Review in Storybook Form -> Input -Duration Slider

**Spread values ( Hours/min/sec) and single digit capable**
<img width="1137" alt="Screenshot 2025-02-12 at 14 44 21" src="https://github.com/user-attachments/assets/7b094cb9-aa64-4f5e-bc12-e7d0eeac2797" />


**Digital Clock with complementary text**
<img width="1159" alt="Screenshot 2025-02-12 at 14 45 14" src="https://github.com/user-attachments/assets/46fc703c-310d-4057-84e8-fb2f426cfa8c" />


**Japanese Text**
<img width="1154" alt="Screenshot 2025-02-12 at 14 45 47" src="https://github.com/user-attachments/assets/1971a1e8-3c2b-4705-9091-fd529be267d0" />


