### PR TITLE
Margin Modal FIX

### DIFF
--- a/packages/ui-lib/src/Modals/ConfirmationModal.tsx
+++ b/packages/ui-lib/src/Modals/ConfirmationModal.tsx
@@ -31,6 +31,8 @@ const StyledButton = styled(Button)`
 
 const ButtonsGroup = styled.div`
   text-align: right;
+  display: flex;
+  justify-content: flex-end;
 `;
 
 

--- a/packages/ui-lib/src/Modals/ConfirmationModal.tsx
+++ b/packages/ui-lib/src/Modals/ConfirmationModal.tsx
@@ -7,11 +7,21 @@ import { useModal } from '../hooks';
 const Container = styled.div``;
 
 const Title = styled.div`
-  ${({theme: { typography }}) => typography.modal.title};
+  font-size: 20px;
+  font-weight: 400;
+  text-align: left;
+  text-shadow: 0px 0px 10px var(--white-a5);
+  text-decoration: none;
+  color: var(--grey-11);
 `;
 
 const MessageBox = styled.div`
-  ${({theme: { typography }}) => typography.modal.basicContent};
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 25px;
+  text-align: left;
+  text-decoration: none;
+  color: var(--grey-11);
   margin: 28px 0;
 `;
 

--- a/packages/ui-lib/src/Modals/Modal.tsx
+++ b/packages/ui-lib/src/Modals/Modal.tsx
@@ -65,9 +65,9 @@ const CloseButton = styled.button<{ selected?: boolean }>`
   }
 `;
 
-const LightBox = styled.div<{ padding?: boolean, width?: string}>`
+const LightBox = styled.div<{ padding?: boolean, width?: string, isCloseEnable?: boolean}>`
   position: relative;
-  margin: 27px 0 0;
+  margin: ${({ isCloseEnable }) => isCloseEnable ? `27px 0 0` : `0`};
   z-index: 9999;
   width: ${({ width }) => width ? width : `580px`};
   padding: ${({ padding }) => padding ? `30px 40px` : `0`};
@@ -119,7 +119,7 @@ const Modal: React.FC<IModalProps> = ({
   return (isOpen
     ? ReactDom.createPortal(
       <Container>
-        <LightBox ref={lightBoxRef} width={width} padding={padding}>
+        <LightBox ref={lightBoxRef} width={width} padding={padding} isCloseEnable={isCloseEnable}>
           {isCloseEnable
             ?
               <CloseButton onClick={() => dismiss()}>

--- a/packages/ui-lib/src/Modals/Modal.tsx
+++ b/packages/ui-lib/src/Modals/Modal.tsx
@@ -19,10 +19,8 @@ const Container = styled.div`
   -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
   z-index: 999;
-  ${({theme}) => theme && css``}
-
-  font-family: ${({ theme }) => theme.fontFamily.ui};
-  ${({ theme }) => theme.styles.modal.overlay};
+  font-family: var(--font-ui);
+  background-color: var(--grey-a3);
 `;
 
 const CloseIcon = styled(Icon)``;
@@ -51,10 +49,8 @@ const CloseButton = styled.button<{ selected?: boolean }>`
   }
 
   &:hover:enabled {
-    ${({ theme }) => theme && css`
-      opacity: .8;
-      transition: transform ${theme.animation.speed.normal} ${theme.animation.easing.primary.inOut};
-    `}
+    opacity: .8;
+    transition: transform var(--speed-normal) var(--easing-primary-in-out);
   }
 
   &:active:enabled {
@@ -72,7 +68,9 @@ const LightBox = styled.div<{ padding?: boolean, width?: string, isCloseEnable?:
   width: ${({ width }) => width ? width : `580px`};
   padding: ${({ padding }) => padding ? `30px 40px` : `0`};
   border-radius: 5px;
-  ${({ theme }) => theme.styles.modal.container};
+  box-shadow: 0px 10px 15px 0px var(--primary-a1);
+  background-color: var(--grey-1);
+  border: var(--grey-6) 1px solid;
 `;
 
 export interface IModalProps {
@@ -124,7 +122,7 @@ const Modal: React.FC<IModalProps> = ({
             ?
               <CloseButton onClick={() => dismiss()}>
                 {closeText ? closeText : 'CLOSE'}
-                <CloseIcon icon='CloseCompact' size={15} color='mono' weight='regular' />
+                <CloseIcon icon='CloseCompact' size={15} color='grey-12' weight='regular' />
               </CloseButton>
             : null}
           {customComponent}

--- a/packages/ui-lib/src/theme/legacy/styles.ts
+++ b/packages/ui-lib/src/theme/legacy/styles.ts
@@ -487,16 +487,5 @@ export const styles = {
             "borderColor": "var(--primary-7)",
             "border": "var(--primary-7) 1px solid"
         }
-    },
-    "modal": {
-        "overlay": {
-            "backgroundColor": "var(--grey-a3)"
-        },
-        "container": {
-            "boxShadow": "0px 10px 15px 0px var(--primary-a1)",
-            "backgroundColor": "var(--grey-1)",
-            "borderColor": "var(--grey-6)",
-            "border": "var(--grey-6) 1px solid"
-        }
     }
 };

--- a/packages/ui-lib/src/theme/legacy/typography.ts
+++ b/packages/ui-lib/src/theme/legacy/typography.ts
@@ -681,23 +681,5 @@ export const typography = {
           "textDecoration": "none",
           "color": "var(--grey-a11)"
       }
-  },
-  "modal": {
-      "title": {
-          "textAlign": "left",
-          "fontSize": "20px",
-          "fontWeight": 400,
-          "textShadow": "0px 0px 10px var(--white-a5)",
-          "textDecoration": "none",
-          "color": "var(--grey-11)"
-      },
-      "basicContent": {
-          "textAlign": "left",
-          "fontSize": "14px",
-          "fontWeight": 400,
-          "lineHeight": "25px",
-          "textDecoration": "none",
-          "color": "var(--grey-11)"
-      }
   }
 };


### PR DESCRIPTION
### Description

This PR addresses a request regarding the modal margin interfering with its vertical alignment.

 ### Considerations on Implementation

- A conditional margin has been added when the isCloseEnable prop is set to false.
- Additionally, this PR includes a couple of small improvements:
  - Fixed an issue where buttons in the confirmation modal were stacked instead of appearing in the same line.
  - Replaced outdated theme variables with new style variables.

 ### Reviewing/Testing steps

Storybook - Alerts -> Modals -> Basic

Before
![Screenshot 2025-02-19 at 14 08 51](https://github.com/user-attachments/assets/a80674c1-3d8a-4936-bf0f-80dc022cb389)


After
![Screenshot 2025-02-19 at 14 08 19](https://github.com/user-attachments/assets/4124553f-b9e5-45d9-a62e-6c4c4d41834e)



**Storybook -> Alerts -> Modals -> Confirmation Template

Before**
![Screenshot 2025-02-19 at 13 50 56](https://github.com/user-attachments/assets/ed352cff-2f8d-4de5-b25a-e7e4c010b45f)

**After**


![Screenshot 2025-02-19 at 13 50 44](https://github.com/user-attachments/assets/45fb9cfa-81da-40f8-b7a6-32314892e049)



