### PR TITLE
Bump for release 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "2.8.3",
+      "version": "2.9.0",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -27395,7 +27395,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "2.8.3",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
### Description

Release 2.9.0

**Dependencies**
This release updates Storybook from version 6 to 8.
Storybook 8 requires `Node.js 18`. Updated instructions for running the project with Node 18 can be found in the [README](https://github.com/future-standard/scorer-ui-kit/blob/main/packages/ui-lib/README.md).

**Deprecated features and breaking changes**
The `JSX plugin` for Storybook has been removed in this version, as it is no longer supported by Storybook 8.
