### PR TITLE
Update github workflows to have v4 for actions/cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         node-version: '18.x'
 
     - name: Cache node modules
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.0
       env:
         cache-name: cache-node-modules
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         node-version: '18.x'
 
     - name: Cache node modules
-      uses: actions/cache@v3.0.5
+      uses: actions/cache@v4.0.2
       env:
         cache-name: cache-node-modules
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: '18.x'
 
     - name: Cache node modules
-      uses: actions/cache@v3.0.5
+      uses: actions/cache@v4.0.2
       env:
         cache-name: cache-node-modules
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: '18.x'
 
     - name: Cache node modules
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.0
       env:
         cache-name: cache-node-modules
       with:


### PR DESCRIPTION
### Description


 Update of actions/cache to v4.0.2 because [actions/cache version prior v4 has been deprecated](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)