### PR TITLE
Use Case's update for controlled and uncontrolled scenarios

### DIFF
--- a/packages/storybook/src/stories/Form/Switch.stories.tsx
+++ b/packages/storybook/src/stories/Form/Switch.stories.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { text, select, boolean } from "@storybook/addon-knobs";
-import {Switch} from 'scorer-ui-kit';
+import {Switch, TypeSwitchState} from 'scorer-ui-kit';
+import { sleep } from '../helpers';
 
 export default {
   title: 'Form/atoms',
@@ -11,12 +12,34 @@ export default {
 
 export const _Switch = () => {
 
+  const [checkValue, setCheckValue] = useState(false);
+  const [switchState, setSwitchState] = useState<TypeSwitchState>('default');
+
   const labelText = text("Label Text", "The Label");
-  const checked = boolean("Default Checked", true)
-  const state = select("State", { Default: "default", Disabled: "disabled", Locked: "locked", Loading: "loading", Failure: "failure" }, "default");
+  const knobCheck = boolean("Check", false)
+  const knobState = select("State", { Default: "default", Disabled: "disabled", Locked: "locked", Loading: "loading", Failure: "failure"}, "default") as TypeSwitchState;
   const leftTheme = select("Left Theme", { Off: "off", On: "on", Danger: "danger" }, "off");
   const rightTheme = select("Right Theme", { Off: "off", On: "on", Danger: "danger" }, "on");
   const onChangeCallback = action('value-changed');
+  const uncontrolled = boolean('Work as self controlled Component', true);
 
-  return <Switch {...{state, leftTheme, rightTheme, labelText, checked, onChangeCallback}} />;
-};
+  const failProcessTest = useCallback(async (value) => {
+    console.log('This test is meant to fail, input should be check false');
+    console.log('Switch input value', value);
+    setSwitchState('loading');
+    await sleep(1200);
+    setCheckValue(false);
+    setSwitchState('default');
+    onChangeCallback(value);
+  },[onChangeCallback]);
+
+  useEffect(() => {
+    setCheckValue(knobCheck);
+  },[knobCheck])
+
+  useEffect(() => {
+    setSwitchState(knobState);
+  },[knobState])
+
+  return <Switch {...{state: switchState, leftTheme, rightTheme, labelText, onChangeCallback: uncontrolled ? onChangeCallback : failProcessTest, checked: uncontrolled ? undefined : checkValue}} />;
+}

--- a/packages/ui-lib/src/Form/atoms/Switch.tsx
+++ b/packages/ui-lib/src/Form/atoms/Switch.tsx
@@ -54,8 +54,8 @@ const SwitchOuter = styled.div`
     right: calc(var(--switch-border-width) * -1);
     pointer-events: none;
     border-radius: 12px;
-    box-shadow: 
-      0px 2px 2px 0px var(--grey-a4) inset, 
+    box-shadow:
+      0px 2px 2px 0px var(--grey-a4) inset,
       0px -8px 8px 0px var(--grey-a2) inset,
       0px 2px 4px var(--black-a4),
       0px -2px 4px var(--white-a4);
@@ -72,17 +72,17 @@ const SwitchInner = styled.div<{ position: PositionKey}>`
   position: absolute;
   top: var(--offset);
   left: ${({position}) => position && `var(--position-${position})`};
-  
+
   box-sizing: border-box;
   height: var(--switch-inner-size);
   width: var(--switch-inner-size);
   border-radius: calc(var(--switch-inner-size) / 2);
-  
+
   background-color: var(--switch-default-off-background);
 
-  box-shadow: 
+  box-shadow:
     0px 2px 4px 0px var(--black-a8),
-    0px 1px 2px 0px var(--white-a5) inset, 
+    0px 1px 2px 0px var(--white-a5) inset,
     0px -1px 1px 0px var(--black-a5) inset;
 `;
 
@@ -106,13 +106,13 @@ const Container = styled(StyledLabel)<{activeTheming: string, $loading: boolean,
   display: inline-flex;
   gap: 8px;
   align-items: center;
-  
+
   ${SwitchOuter}{
     ${({activeTheming, themeState}) => css`
       border-color: var(--switch-${themeState}-${activeTheming}-border);
       background-color: var(--switch-${themeState}-${activeTheming}-background);
     `};
-  
+
     ${({ activeTheming }) => activeTheming === 'locked' && css`
       background-color: var(--switch-special-locked-background);
       border-color: var(--switch-special-locked-border);
@@ -158,12 +158,12 @@ const Container = styled(StyledLabel)<{activeTheming: string, $loading: boolean,
       border-color: var(--switch-default-${activeTheming}-inner);
       box-shadow: none;
     `};
-    
+
   }
 
   &:hover {
     ${SwitchInner}{
-      left: ${({useIntent, position}) => 
+      left: ${({useIntent, position}) =>
         useIntent && position === SwitchPosition.Off && 'calc(var(--position-off) + var(--switch-intent-offset))' ||
         useIntent && position === SwitchPosition.On && 'calc(var(--position-on) - var(--switch-intent-offset))'
       };
@@ -171,7 +171,7 @@ const Container = styled(StyledLabel)<{activeTheming: string, $loading: boolean,
   }
 `;
 
-type TypeSwitchState = 'default' | 'loading' | 'locked' | 'disabled' | 'failure';
+export type TypeSwitchState = 'default' | 'loading' | 'locked' | 'disabled' | 'failure';
 
 const isTypeSwitchState = (value: string): value is TypeSwitchState => {
   return (
@@ -270,7 +270,7 @@ const Switch : React.FC<IProps> = ({ state = 'default', leftTheme = 'off', right
     }
   }, [innerRef]);
 
-  
+
   return (
     <Container onChange={customOnChange} onMouseLeave={ () => setJustUpdated(false) } activeTheming={activeTheming} $loading={state === 'loading'} useIntent={ !justUpdated && (state === 'default' || state === 'failure')} themeState={switchState} position={position} checked={inputRef.current?.checked}>
       <SwitchOuter>

--- a/packages/ui-lib/src/Form/index.ts
+++ b/packages/ui-lib/src/Form/index.ts
@@ -6,7 +6,7 @@ import ActionButtons from './molecules/ActionButtons';
 import Input from './atoms/Input';
 import SmallInput from './atoms/SmallInput';
 import Label from './atoms/Label';
-import Switch from './atoms/Switch';
+import Switch, {TypeSwitchState} from './atoms/Switch';
 import Checkbox from './atoms/Checkbox';
 import RadioButton from './atoms/RadioButton';
 import TextArea from './atoms/TextArea';
@@ -74,4 +74,4 @@ interface ButtonProps {
 
 export type IButtonProps = ButtonProps & ButtonHTMLAttributes<HTMLButtonElement>
 
-export type { IconButtonData, ISliderMark, ISplitButtonProps, IButtonsStack, IButtonStack};
+export type { IconButtonData, ISliderMark, ISplitButtonProps, IButtonsStack, IButtonStack, TypeSwitchState};

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -49,7 +49,8 @@ import {
   ISplitButtonProps,
   ButtonsStack,
   IButtonsStack,
-  IButtonStack
+  IButtonStack,
+  TypeSwitchState
 } from './Form';
 
 // Components - Filter
@@ -423,5 +424,6 @@ export type {
   ITooltipType,
   FilterButtonDesign,
   IToggleOption,
-  DateRange
+  DateRange,
+  TypeSwitchState
 };


### PR DESCRIPTION

### Description

This is a update suggestion for [PR 562](https://github.com/future-standard/scorer-ui-kit/pull/562)
With this update, you can see that both existing solutions contain errors, and a different approach needs to be implemented.

 ### Considerations on Implementation
 
Attached is a video demonstrating the test case using either the `inputRef.current?.defaultChecked` or the `inputRef.current?.checked`  attributes of the input. 

- Using `defaultChecked`: The change updates the theme but does not affect the actual input value, and will break the code for self controlled cases.
- Using `checked (current production implementation)`:  The implementation behaves only as self-controlled component and does not update when the checked prop value changes. 

[video of test](https://drive.google.com/file/d/1RZgpMue6-PqimAjrXmfrUMi0Ai6LqObB/view?usp=drive_link) 

In the code there is also the export of the TypeSwitchState that is required to prevent typescript  waring errors. 