### PR TITLE
Feature/css lang drawer control

### DIFF
--- a/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import {
   GlobalUI,
   PageHeader,
@@ -155,7 +155,7 @@ const Accounts = () => (
   <ExampleContentBlock>
     <h2>Example</h2>
     <p>Here is a list of accounts</p>
-  </ExampleContentBlock>  
+  </ExampleContentBlock>
 );
 
 const Billing = () => (
@@ -384,6 +384,7 @@ const customDrawer: ICustomDrawer = {
 export const _GlobalUI = () => {
 
   const {isLightMode ,  onThemeToggle} = useThemeToggle();
+  const  [attributeLanguage, setAttributeLanguage] = useState('us');
 
 
   const maxWidth = text("Max width", "1200px");
@@ -405,7 +406,6 @@ export const _GlobalUI = () => {
   const canAlwaysPin = boolean("Can Always Pin", true);
   const defaultMenuOpen = boolean("Default menu open", false);
   const hasLanguage = boolean("Has Language", true);
-  const selectedLanguageText = text("Selected Language Text", "English");
   const hasSwitchTheme = boolean("Has Switch Theme", true);
   const switchThemeText = text("Switch Theme Text", "SWITCH THEME");
   const selectedThemeText = text("Selected Theme Text", "Light/Dark Mode");
@@ -519,7 +519,11 @@ export const _GlobalUI = () => {
   const notificationsHistory = object("Notifications History", allNotifications);
 
   const onLanguageToggle = () => {
-    languageToggle();
+    setAttributeLanguage((prev:  string) => {
+      const newLang = prev === 'us'? 'ja' : 'us'
+      languageToggle(newLang);
+      return newLang;
+    })
   }
 
   const getToggleValue = (isMenuOpen: boolean) => {
@@ -560,7 +564,9 @@ export const _GlobalUI = () => {
         canAlwaysPin={canAlwaysPin}
         userDrawerMeta={userDrawerMetaConfig}
         legacyLayout={false}
-        badge={{ 
+        selectedLangAttribute={attributeLanguage}
+        selectedLanguageText={attributeLanguage === 'us'? 'ENGLISH' : '日本'}
+        badge={{
           text: badgeText,
           color: badgeColor,
           linkTo: badgeLinkTo,
@@ -569,7 +575,7 @@ export const _GlobalUI = () => {
         {...{ logoMark, logoText, supportUrl, maxWidth, paddingOverride, notificationsHistory, customDrawer}}
         {...{ loggedInUser, userSubmenu, hasSearch, hasLogout, hasNotifications, logoutLink, logoutText, searchPlaceholder, hasLanguage,
               hasCurrentUser, currentUserText, accountOptionText, userDrawerFooter, hasUserDrawerMeta, copySuccessMessage, includeCopyTitle, hasUserDrawerFooter,
-              selectedLanguageText, hasSwitchTheme, isLightMode, switchThemeText, selectedThemeText, onThemeToggle, onLanguageToggle
+              hasSwitchTheme, isLightMode, switchThemeText, selectedThemeText, onThemeToggle, onLanguageToggle
             }}
       >
         <ContentLayout layout="default" HeaderContent={ExampleContent}>

--- a/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -520,7 +520,7 @@ export const _GlobalUI = () => {
 
   const onLanguageToggle = useCallback(() => {
     setAttributeLanguage((prev:  string) => {
-      const newLang = prev === 'us'? 'ja' : 'us'
+      const newLang = prev === 'en'? 'ja' : 'en'
       languageToggle(newLang);
       return newLang;
     })
@@ -565,7 +565,7 @@ export const _GlobalUI = () => {
         userDrawerMeta={userDrawerMetaConfig}
         legacyLayout={false}
         selectedLangAttribute={attributeLanguage}
-        selectedLanguageText={attributeLanguage === 'us'? 'ENGLISH' : '日本語'}
+        selectedLanguageText={attributeLanguage === 'en'? 'ENGLISH' : '日本語'}
         badge={{
           text: badgeText,
           color: badgeColor,

--- a/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useCallback, useState } from 'react';
 import {
   GlobalUI,
   PageHeader,
@@ -518,13 +518,13 @@ export const _GlobalUI = () => {
   ])
   const notificationsHistory = object("Notifications History", allNotifications);
 
-  const onLanguageToggle = () => {
+  const onLanguageToggle = useCallback(() => {
     setAttributeLanguage((prev:  string) => {
       const newLang = prev === 'us'? 'ja' : 'us'
       languageToggle(newLang);
       return newLang;
     })
-  }
+  },[languageToggle])
 
   const getToggleValue = (isMenuOpen: boolean) => {
     console.log(isMenuOpen);
@@ -565,7 +565,7 @@ export const _GlobalUI = () => {
         userDrawerMeta={userDrawerMetaConfig}
         legacyLayout={false}
         selectedLangAttribute={attributeLanguage}
-        selectedLanguageText={attributeLanguage === 'us'? 'ENGLISH' : '日本'}
+        selectedLanguageText={attributeLanguage === 'us'? 'ENGLISH' : '日本語'}
         badge={{
           text: badgeText,
           color: badgeColor,

--- a/packages/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/packages/storybook/src/stories/Global/TopBar.stories.tsx
@@ -168,7 +168,7 @@ export const _TopBar = () => {
 
   const onLanguageToggle = useCallback(() => {
     setAttributeLanguage((prev:  string) => {
-      const newLang = prev === 'us'? 'ja' : 'us'
+      const newLang = prev === 'en'? 'ja' : 'en'
       languageToggle(newLang);
       return newLang;
     })
@@ -211,7 +211,7 @@ export const _TopBar = () => {
         userDrawerMeta={userDrawerMetaConfig}
         customDrawer={drawerProps}
         selectedLangAttribute={attributeLanguage}
-        selectedLanguageText={attributeLanguage === 'us'? 'ENGLISH' : '日本語'}
+        selectedLanguageText={attributeLanguage === 'en'? 'ENGLISH' : '日本語'}
       />
     </Container>
   );

--- a/packages/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/packages/storybook/src/stories/Global/TopBar.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { object, text, boolean, select } from "@storybook/addon-knobs";
 import { TopBar, ICustomDrawer, INotificationItem, INotificationsHistory, useThemeToggle } from 'scorer-ui-kit';
@@ -93,6 +93,7 @@ const allNotifications: INotificationsHistory = {
 
 export const _TopBar = () => {
   const {onThemeToggle, isLightMode} = useThemeToggle();
+  const  [attributeLanguage, setAttributeLanguage] = useState('us');
 
   const loggedInUser = text("Logged In User", "full.name@example.com");
 
@@ -103,7 +104,6 @@ export const _TopBar = () => {
   const logoutLink = text("Logout Url", "#")
   const searchPlaceholder = text("Search Placeholder", "Search area names, etc.")
   const hasLanguage = boolean("Has Language", true);
-  const selectedLanguageText = text("Selected Language Text", "English");
   const hasSwitchTheme = boolean("Has Switch Theme", true);
   const switchThemeText = text("Switch Theme Text", "SWITCH THEME");
   const selectedThemeText = text("Selected Theme Text", "Light/Dark Mode");
@@ -166,14 +166,18 @@ export const _TopBar = () => {
 
   // userDrawerBespoke: See examples for implementation of this prop.
 
-  const onLanguageToggle = () => {
-    languageToggle();
-  }
+  const onLanguageToggle = useCallback(() => {
+    setAttributeLanguage((prev:  string) => {
+      const newLang = prev === 'us'? 'ja' : 'us'
+      languageToggle(newLang);
+      return newLang;
+    })
+  },[languageToggle])
 
   return (
     <Container>
-      <TopBar 
-        badge={{ 
+      <TopBar
+        badge={{
           text: badgeText,
           color: badgeColor,
           linkTo: badgeLinkTo,
@@ -194,7 +198,6 @@ export const _TopBar = () => {
         notificationsHistory,
         hasSwitchTheme,
         isLightMode,
-        selectedLanguageText,
         switchThemeText,
         selectedThemeText,
         onThemeToggle,
@@ -207,6 +210,8 @@ export const _TopBar = () => {
       }}
         userDrawerMeta={userDrawerMetaConfig}
         customDrawer={drawerProps}
+        selectedLangAttribute={attributeLanguage}
+        selectedLanguageText={attributeLanguage === 'us'? 'ENGLISH' : '日本語'}
       />
     </Container>
   );

--- a/packages/ui-lib/src/Global/atoms/DrawerBottomMenu.tsx
+++ b/packages/ui-lib/src/Global/atoms/DrawerBottomMenu.tsx
@@ -33,6 +33,7 @@ const Title = styled.div`
 const SubTitle = styled.div`
   font-family: var(--font-ui);
   font-size: 10px;
+  line-height: 12px;
   font-weight: 500;
   letter-spacing: 0.29px;
   color: var(--grey-11);

--- a/packages/ui-lib/src/Global/index.ts
+++ b/packages/ui-lib/src/Global/index.ts
@@ -92,6 +92,8 @@ export interface IMenuTop {
     loggedInUser: string;
     hasLanguage?: boolean;
     selectedLanguageText?: string;
+    languageOptionsText?:string;
+    selectedLangAttribute?:string;
     hasLogout?: boolean;
     logoutText?: string;
     logoutLink?: string;

--- a/packages/ui-lib/src/Global/molecules/TopBar.tsx
+++ b/packages/ui-lib/src/Global/molecules/TopBar.tsx
@@ -60,7 +60,7 @@ const SearchInput = styled.input`
   line-height: 35px;
   border: none;
   outline: none;
-  background: transparent;  
+  background: transparent;
   color: var(--grey-10);
   font-size: 14px;
 
@@ -113,9 +113,9 @@ const DrawerToggle = styled.button.attrs({ type: 'button' }) <{ isActive: boolea
     background-color: transparent;
     border-radius: 2px 2px 0 0;
   }
-  
+
   transition: background-color var(--speed-normal) var(--easing-primary-out);
-  
+
   svg {
     transition: transform var(--speed-normal) var(--easing-primary-out);
   }
@@ -126,7 +126,7 @@ const DrawerToggle = styled.button.attrs({ type: 'button' }) <{ isActive: boolea
       background-color: var(--primary-6);
     }
   }
- 
+
   ${({ isActive }) => isActive && css`
     &, &:hover {
       border-bottom-color: var(--primary-9);
@@ -153,7 +153,7 @@ const Drawer = styled.div<{ isOpen: boolean, baseWidth?: string }>`
   bottom: 0;
   background: var(--global-element-background);
   border-left: var(--dividing-line) 1px solid;
-  
+
   width: ${({ baseWidth }) => baseWidth ? baseWidth : `200px`};
   opacity: 0;
   visibility: hidden;
@@ -190,6 +190,8 @@ const TopBar: React.FC<ITopBar> = ({
   hasNotifications = false,
   hasLanguage = false,
   selectedLanguageText = '',
+  languageOptionsText,
+  selectedLangAttribute,
   hasLogout = true,
   logoutLink = '/logout',
   logoutText = 'Logout',
@@ -281,6 +283,8 @@ const TopBar: React.FC<ITopBar> = ({
               onLogout,
               onLanguageToggle,
               selectedLanguageText,
+              languageOptionsText,
+              selectedLangAttribute,
               hasSwitchTheme,
               isLightMode,
               switchThemeText,

--- a/packages/ui-lib/src/Global/molecules/UserMenu.tsx
+++ b/packages/ui-lib/src/Global/molecules/UserMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, Fragment } from 'react';
+import React, { useCallback, Fragment, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { Link } from 'react-router-dom';
 
@@ -124,6 +124,24 @@ const FooterText = styled.div <{ icon?: string }>`
   opacity: 0.5;
 `;
 
+const updateLanguageAttribute = (initLanguage?: string) => {
+
+  if (initLanguage) {
+    document.documentElement.setAttribute("lang", initLanguage);
+    return initLanguage;
+  }
+
+  const browserLang = navigator.language.split("-")[0];
+  const htmlLang = document.documentElement.lang;
+
+  if(!htmlLang) {
+    document.documentElement.setAttribute("lang", browserLang);
+    return browserLang;
+  }
+
+  return htmlLang;
+};
+
 interface IUserMenu extends ITopBar {
   closeOnClick?: () => void
 }
@@ -131,6 +149,8 @@ interface IUserMenu extends ITopBar {
 const UserMenu: React.FC<IUserMenu> = ({
   hasLanguage = false,
   selectedLanguageText = '',
+  languageOptionsText = 'LANGUAGE / 言語',
+  selectedLangAttribute,
   hasLogout = true,
   logoutLink = '/logout',
   logoutText = 'Logout',
@@ -158,7 +178,6 @@ const UserMenu: React.FC<IUserMenu> = ({
 }) => {
 
   const {icon, title} = userDrawerFooter as IUserDrawerFooter;
-
   const logoutHandler = useCallback(async (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     e.preventDefault();
     await onLogout();
@@ -173,6 +192,10 @@ const UserMenu: React.FC<IUserMenu> = ({
       closeOnClick();
     }
   }, [closeOnClick]);
+
+  useEffect(() => {
+    updateLanguageAttribute(selectedLangAttribute);
+  },[selectedLangAttribute]);
 
   return (
     <Fragment>
@@ -226,7 +249,7 @@ const UserMenu: React.FC<IUserMenu> = ({
 
       <DrawerBottom>
         {hasSwitchTheme && <DrawerBottomMenu icon={isLightMode ? 'LightMode' : 'DarkMode'} title={switchThemeText} subTitle={selectedThemeText} onClickCallback={onThemeToggle} />}
-        {hasLanguage && <DrawerBottomMenu icon='Language' title='LANGUAGE / 言語' subTitle={selectedLanguageText} onClickCallback={onLanguageToggle} />}
+        {hasLanguage && <DrawerBottomMenu icon='Language' title={languageOptionsText} subTitle={selectedLanguageText} onClickCallback={onLanguageToggle} />}
         {(hasUserDrawerFooter) ?
           <FooterMeta title={title} icon={icon}>
             {icon ?


### PR DESCRIPTION
###Description
This is an iteration of the proposal for managing the language attribute.

###Considerations on Implementation
The previous implementation in PR [#532](https://github.com/future-standard/scorer-ui-kit/pull/532) required adding a hook to the main component and passing the available languages for toggling.

In this iteration, developers can directly provide the current language passing the `selectedLangAttribute` prop  without needing additional configuration. If no value is provided, the language attribute will default to the user's browser language preference, ensuring it is never unset.

This update is fully backward-compatible and requires no changes to existing implementations.
 ### Reviewing/Testing steps
This change can be reviewed in Storybook 
Global - Global UI and TopBar
[Video demo](https://drive.google.com/file/d/1vBjVtFPEqDrD3jJAH4GyliUgi-HCMqOx/view?usp=sharing)
