### PR TITLE
Button text-only outline

### DIFF
--- a/packages/storybook/src/stories/Form/Buttons/Button.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/Button.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 export const StandardButton = () => {
   const buttonText = text("Button Text", "Example Title");
-  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only" }, "primary");
+  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only", Outline: 'outline' }, "primary");
   const buttonSize = select("Size", { Xsmall: 'xsmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonShadow = boolean("Shadow", false);

--- a/packages/storybook/src/stories/Form/Buttons/Button.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/Button.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 export const StandardButton = () => {
   const buttonText = text("Button Text", "Example Title");
-  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger" }, "primary");
+  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only" }, "primary");
   const buttonSize = select("Size", { Xsmall: 'xsmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonShadow = boolean("Shadow", false);

--- a/packages/storybook/src/stories/Form/Buttons/ButtonWithIcons.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/ButtonWithIcons.stories.tsx
@@ -14,7 +14,7 @@ export const _WithIcon = () => {
   const iconList = generateIconList();
 
   const buttonText = text("Button Text", "Example Title");
-  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger" }, "primary");
+  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only" }, "primary");
   const buttonSize = select("Size", { Xsmall: 'xsmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonIcon = select("Icon", iconList, Object.keys(iconList)[0]);

--- a/packages/storybook/src/stories/Form/Buttons/ButtonWithIcons.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/ButtonWithIcons.stories.tsx
@@ -14,7 +14,7 @@ export const _WithIcon = () => {
   const iconList = generateIconList();
 
   const buttonText = text("Button Text", "Example Title");
-  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only" }, "primary");
+  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only",  Outline: 'outline' }, "primary");
   const buttonSize = select("Size", { Xsmall: 'xsmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonIcon = select("Icon", iconList, Object.keys(iconList)[0]);

--- a/packages/storybook/src/stories/Form/Buttons/ButtonWithLoading.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/ButtonWithLoading.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 export const _WithLoading = () => {
   const buttonText = text("Button Text", "Example Title");
-  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger" }, "primary");
+  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only" }, "primary");
   const buttonSize = select("Size", { Xsmall: 'xsmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonLoading = boolean("Loading", true);

--- a/packages/storybook/src/stories/Form/Buttons/ButtonWithLoading.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/ButtonWithLoading.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 export const _WithLoading = () => {
   const buttonText = text("Button Text", "Example Title");
-  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only" }, "primary");
+  const buttonDesign = select("Design", { Primary: "primary", Secondary: "secondary", Danger: "danger", TextOnly: "text-only", Outline: 'outline' }, "primary");
   const buttonSize = select("Size", { Xsmall: 'xsmall', Small: "small", Normal: "normal", Large: "large" }, "normal");
   const buttonDisabled = boolean("Disabled", false);
   const buttonLoading = boolean("Loading", true);

--- a/packages/ui-lib/src/Form/atoms/Button.tsx
+++ b/packages/ui-lib/src/Form/atoms/Button.tsx
@@ -9,6 +9,7 @@ interface IStyledComponentProps {
   $shadow: boolean
   $noPadding?: boolean
   $loading?: boolean
+  isOutline?: boolean
 }
 
 const activeAnimation = (shadow?: boolean) => {
@@ -47,7 +48,12 @@ const StyledButton = styled.button<IStyledComponentProps>`
   color: var(--button-text-color);
   font-weight: 600;
 
-  padding: ${({ $noPadding }) => $noPadding ? 0 : `var(--button-h-padding)`};
+  ${({ $noPadding, isOutline }) => $noPadding ? css`
+      padding: 0px;
+    ` : css`
+      padding: ${isOutline ? `var(--button-h-padding-outline)` : `var(--button-h-padding)`};
+    `
+  }
 
   overflow: hidden;
   cursor: pointer;
@@ -75,7 +81,8 @@ const StyledButton = styled.button<IStyledComponentProps>`
     background-position var(--speed-normal) var(--easing-primary-out),
     background-size var(--speed-normal) var(--easing-primary-out),
     box-shadow var(--speed-normal) var(--easing-primary-out),
-    opacity var(--speed-normal) var(--easing-primary-out);
+    opacity var(--speed-normal) var(--easing-primary-out),
+    color var(--speed-normal) var(--easing-primary-in-out);
 
   &:hover:enabled {
     background-position: 1%;
@@ -135,7 +142,7 @@ type Props = OwnProps & ButtonHTMLAttributes<HTMLButtonElement>
 
 const Button : React.FC<Props> = ({ design='primary', size='normal', shadow = false, noPadding = false, loading=false, children, ...props }) => {
   design === 'danger' ? console.warn('Button.tsx - Warning, the design prop value danger is being deprecated. Use warning instead.') : null;
-  return <StyledButton type='button' className={`button-design-${design} button-size-${size}`} {...{design, size}} $noPadding={noPadding} $shadow={shadow} $loading={loading} {...props}>{children}</StyledButton>;
+  return <StyledButton type='button' isOutline={design === 'outline'} className={`button-design-${design} button-size-${size}`} {...{design, size}} $noPadding={noPadding} $shadow={shadow} $loading={loading} {...props}>{children}</StyledButton>;
 };
 
 export default Button;

--- a/packages/ui-lib/src/Form/atoms/Button.tsx
+++ b/packages/ui-lib/src/Form/atoms/Button.tsx
@@ -51,12 +51,11 @@ const StyledButton = styled.button<IStyledComponentProps>`
 
   overflow: hidden;
   cursor: pointer;
-  border-radius: 3px;
   outline: none;
   box-sizing: border-box;
 
   border-radius: 3px;
-  border: 1px solid var(--button-border-color);
+  border: var(--button-border-width) solid var(--button-border-color);
   background: linear-gradient(135deg, transparent, transparent, var(--button-gradient-start), var(--button-gradient-end));
   background-color: var(--button-background-color);
   background-size: 400%;

--- a/packages/ui-lib/src/Form/atoms/Button.tsx
+++ b/packages/ui-lib/src/Form/atoms/Button.tsx
@@ -56,7 +56,7 @@ const StyledButton = styled.button<IStyledComponentProps>`
   box-sizing: border-box;
 
   border-radius: 3px;
-  border: 1px solid transparent;
+  border: 1px solid var(--button-border-color);
   background: linear-gradient(135deg, transparent, transparent, var(--button-gradient-start), var(--button-gradient-end));
   background-color: var(--button-background-color);
   background-size: 400%;
@@ -71,7 +71,7 @@ const StyledButton = styled.button<IStyledComponentProps>`
   `}
 
   transition:
-    border-color var(--speed-slow) var(--easing-primary-in-out),
+    border-color var(--speed-normal) var(--easing-primary-in-out),
     background-color var(--speed-normal) var(--easing-primary-in-out),
     background-position var(--speed-normal) var(--easing-primary-out),
     background-size var(--speed-normal) var(--easing-primary-out),
@@ -106,14 +106,15 @@ const StyledButton = styled.button<IStyledComponentProps>`
     cursor: not-allowed;
     opacity: 50%;
     color: var(--button-disabled-text-color);
+    border-color: var(--button-disabled-border-color, transparent);
   }
 
   ${({$loading}) => $loading && css`
-      &:disabled {
-        opacity: 1;
-        cursor: wait;
-        color: var(--button-loading-text-color);
-      }
+    &:disabled {
+      opacity: 1;
+      cursor: wait;
+      color: var(--button-loading-text-color);
+    }
   `};
 
   button + button {

--- a/packages/ui-lib/src/Form/atoms/Button.tsx
+++ b/packages/ui-lib/src/Form/atoms/Button.tsx
@@ -8,24 +8,25 @@ interface IStyledComponentProps {
   design: TypeButtonDesigns
   $shadow: boolean
   $noPadding?: boolean
+  $loading?: boolean
 }
 
 const activeAnimation = (shadow?: boolean) => {
   const animation = keyframes`
     0% {
-      box-shadow: 
+      box-shadow:
         0 0px 0px var(--button-hover-inner-shadow-color) inset
         ${shadow ? ', 0 4px 8px var(--button-hover-drop-shadow-color)' : ''};
     }
 
     75% {
-      box-shadow: 
+      box-shadow:
         0 0 24px var(--button-active-inner-shadow-color) inset
         ${shadow ? ', 0 4px 6px var(--button-active-drop-shadow-color)' : ''};
     }
 
     100% {
-      box-shadow: 
+      box-shadow:
         0 0 16px var(--button-active-inner-shadow-color) inset
         ${shadow ? ', 0 4px 6px var(--button-active-drop-shadow-color)' : ''};
     }
@@ -45,7 +46,7 @@ const StyledButton = styled.button<IStyledComponentProps>`
   font-size: var(--button-font-size);
   color: var(--button-text-color);
   font-weight: 600;
-  
+
   padding: ${({ $noPadding }) => $noPadding ? 0 : `var(--button-h-padding)`};
 
   overflow: hidden;
@@ -62,13 +63,13 @@ const StyledButton = styled.button<IStyledComponentProps>`
   background-position: 99%;
 
   ${({$shadow}) => $shadow ? css`
-    box-shadow: 
+    box-shadow:
       0 2px 4px 2px var(--button-drop-shadow-color),
       0 0 0 var(--button-inner-shadow-color) inset;
   ` : css`
     box-shadow: 0 0 0 var(--button-inner-shadow-color) inset;
   `}
-  
+
   transition:
     border-color var(--speed-slow) var(--easing-primary-in-out),
     background-color var(--speed-normal) var(--easing-primary-in-out),
@@ -82,9 +83,9 @@ const StyledButton = styled.button<IStyledComponentProps>`
     background-color: var(--button-hover-background-color);
     border-color: var(--button-hover-border-color);
     color: var(--button-hover-text-color);
-    
+
     ${({$shadow}) => $shadow ? css`
-      box-shadow: 
+      box-shadow:
         0 4px 8px var(--button-hover-drop-shadow-color),
         0 0 5px var(--button-hover-inner-shadow-color) inset;
     ` : css`
@@ -104,7 +105,16 @@ const StyledButton = styled.button<IStyledComponentProps>`
   &:disabled {
     cursor: not-allowed;
     opacity: 50%;
+    color: var(--button-disabled-text-color);
   }
+
+  ${({$loading}) => $loading && css`
+      &:disabled {
+        opacity: 1;
+        cursor: wait;
+        color: var(--button-loading-text-color);
+      }
+  `};
 
   button + button {
     margin-left: 20px;
@@ -118,13 +128,14 @@ interface OwnProps {
   design?: TypeButtonDesigns
   shadow?: boolean
   noPadding?: boolean
+  loading?: boolean
 }
 
 type Props = OwnProps & ButtonHTMLAttributes<HTMLButtonElement>
 
-const Button : React.FC<Props> = ({ design='primary', size='normal', shadow = false, noPadding = false, children, ...props }) => {
+const Button : React.FC<Props> = ({ design='primary', size='normal', shadow = false, noPadding = false, loading=false, children, ...props }) => {
   design === 'danger' ? console.warn('Button.tsx - Warning, the design prop value danger is being deprecated. Use warning instead.') : null;
-  return <StyledButton type='button' className={`button-design-${design} button-size-${size}`} {...{design, size}} $noPadding={noPadding} $shadow={shadow} {...props}>{children}</StyledButton>;
+  return <StyledButton type='button' className={`button-design-${design} button-size-${size}`} {...{design, size}} $noPadding={noPadding} $shadow={shadow} $loading={loading} {...props}>{children}</StyledButton>;
 };
 
 export default Button;

--- a/packages/ui-lib/src/Form/atoms/ButtonWithIcon.tsx
+++ b/packages/ui-lib/src/Form/atoms/ButtonWithIcon.tsx
@@ -5,7 +5,7 @@ import Icon from '../../Icons/Icon';
 import Spinner from '../../Indicators/Spinner';
 import { IButtonProps, TypeButtonSizes } from '..';
 
-const Container = styled.div<{ $loading: boolean}>`
+const Container = styled.div`
   display: inline;
 `;
 
@@ -136,7 +136,7 @@ export interface IButtonWithIcon extends IButtonProps {
 
 const ButtonWithIcon : React.FC<IButtonWithIcon> = ({design = 'primary', size='normal', loading = false, shadow = false, onClick, disabled, position, icon, children, ...props}) => {
   return (
-    <Container $loading={loading}>
+    <Container>
       <Button noPadding disabled={disabled || loading} {...{ design, size, shadow, onClick, loading }} {...props}>
         <InnerContainer {...{disabled, loading}}>
           <TextContainer {...{size, position}}>{children}</TextContainer>

--- a/packages/ui-lib/src/Form/atoms/ButtonWithIcon.tsx
+++ b/packages/ui-lib/src/Form/atoms/ButtonWithIcon.tsx
@@ -5,16 +5,8 @@ import Icon from '../../Icons/Icon';
 import Spinner from '../../Indicators/Spinner';
 import { IButtonProps, TypeButtonSizes } from '..';
 
-const Container = styled.div<{ $loading: boolean }>`
+const Container = styled.div<{ $loading: boolean}>`
   display: inline;
-  ${({$loading}) => $loading && css`
-    button {
-      cursor: wait;
-      &:disabled {
-        opacity: 1;
-      }
-    }
-  `};
 `;
 
 const TextContainer = styled.div<{size: TypeButtonSizes, position?: string}>`
@@ -26,7 +18,7 @@ const TextContainer = styled.div<{size: TypeButtonSizes, position?: string}>`
   align-items: center;
   white-space: nowrap;
   padding: 0 var(--button-h-padding);
-  
+
   transition: padding var(--speed-slow) var(--easing-primary-in-out);
 `;
 
@@ -45,7 +37,7 @@ const SpinnerContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   opacity: 0;
 `;
 
@@ -62,12 +54,12 @@ const IconArea = styled.div<{ position?: string, $loading: boolean }>`
 
   ${({ position }) => css`
     order: ${ position && position === 'left' ? 0 : 2 };
-    ${ position === 'left' 
-      ? `border-right-width: 1px;` 
-      : `border-left-width: 1px;` 
+    ${ position === 'left'
+      ? `border-right-width: 1px;`
+      : `border-left-width: 1px;`
     };
   `}
-    
+
   ${IconContainer}{
     svg {
       display:block;
@@ -88,32 +80,63 @@ const IconArea = styled.div<{ position?: string, $loading: boolean }>`
 
     ${SpinnerContainer}{
       opacity: 1;
-    }  
-    
+    }
+
     ${IconContainer}{
       opacity: 0;
     };
   `};
-  
+
 `;
 
-const InnerContainer = styled.div`
+const InnerContainer = styled.div<{disabled?: boolean}>`
   display: flex;
   height: inherit;
+
+  &:hover {
+    ${({disabled}) => !disabled && css`
+      ${IconContainer}{
+        svg {
+          path, rect, circle, d {
+            stroke: var(--button-hover-text-color);
+          }
+        }
+      }
+    `};
+  }
+
+  &:active{
+    ${IconContainer}{
+      svg {
+        path, rect, circle, d {
+          stroke: var(--button-active-text-color);
+        }
+      }
+    }
+  }
+
+  ${({disabled}) => disabled && css`
+    ${IconContainer}{
+        svg {
+          path, rect, circle, d {
+            stroke: var(--button-disabled-text-color);
+          }
+      }
+    }
+  `};
 `;
 
 export interface IButtonWithIcon extends IButtonProps {
   icon: string
   position?: 'left' | 'right'
-  loading?: boolean
   shadow?: boolean
 }
 
 const ButtonWithIcon : React.FC<IButtonWithIcon> = ({design = 'primary', size='normal', loading = false, shadow = false, onClick, disabled, position, icon, children, ...props}) => {
   return (
     <Container $loading={loading}>
-      <Button noPadding {...{ design, size, shadow, onClick, disabled }} {...props}>
-        <InnerContainer>
+      <Button noPadding disabled={disabled || loading} {...{ design, size, shadow, onClick, loading }} {...props}>
+        <InnerContainer {...{disabled, loading}}>
           <TextContainer {...{size, position}}>{children}</TextContainer>
           <IconArea $loading={loading} {...{ position }}>
             <IconContainer>

--- a/packages/ui-lib/src/Form/atoms/ButtonWithIcon.tsx
+++ b/packages/ui-lib/src/Form/atoms/ButtonWithIcon.tsx
@@ -106,13 +106,15 @@ const InnerContainer = styled.div<{disabled?: boolean}>`
   }
 
   &:active{
-    ${IconContainer}{
-      svg {
-        path, rect, circle, d {
-          stroke: var(--button-active-text-color);
+    ${({disabled}) => !disabled && css`
+      ${IconContainer}{
+        svg {
+          path, rect, circle, d {
+            stroke: var(--button-active-text-color);
+          }
         }
       }
-    }
+    `};
   }
 
   ${({disabled}) => disabled && css`

--- a/packages/ui-lib/src/Form/atoms/ButtonWithLoading.tsx
+++ b/packages/ui-lib/src/Form/atoms/ButtonWithLoading.tsx
@@ -6,7 +6,7 @@ import Spinner from '../../Indicators/Spinner';
 import { TypeButtonDesigns, IButtonProps, TypeButtonSizes} from '..';
 
 
-const Container = styled.div<{ $loading: boolean }>`
+const Container = styled.div`
   display: inline;
 `;
 
@@ -79,7 +79,7 @@ interface IProps extends IButtonProps {
 
 const ButtonWithLoading : React.FC<IProps> = ({design='primary', size='normal', shadow = false, onClick, disabled, position, loading=false, children,...rest}) => {
   return (
-    <Container $loading={loading} {...{disabled}}>
+    <Container>
       <Button noPadding disabled={disabled || loading} {...{ design, size, shadow, onClick, loading}} {...rest}>
         <InnerContainer $loading={loading} {...{ design, size}}>
           <TextContainer>{children}</TextContainer>

--- a/packages/ui-lib/src/Form/atoms/ButtonWithLoading.tsx
+++ b/packages/ui-lib/src/Form/atoms/ButtonWithLoading.tsx
@@ -3,19 +3,11 @@ import styled, { css } from 'styled-components';
 
 import Button from './Button';
 import Spinner from '../../Indicators/Spinner';
-import { TypeButtonDesigns, IButtonProps, TypeButtonSizes } from '..';
+import { TypeButtonDesigns, IButtonProps, TypeButtonSizes} from '..';
 
 
 const Container = styled.div<{ $loading: boolean }>`
   display: inline;
-  ${({$loading}) => $loading && css`
-    button {
-      cursor: wait;
-      &:disabled {
-        opacity: 1;
-      }
-    }
-  `};
 `;
 
 const TextContainer = styled.div`
@@ -49,9 +41,9 @@ const LoadingContainer = styled.div<{ design: TypeButtonDesigns, show?: boolean,
 
   ${({ position }) => css`
     order: ${ position && position === 'left' ? 0 : 2 };
-    ${ position === 'left' 
-      ? `border-right-width: 1px;` 
-      : `border-left-width: 1px;` 
+    ${ position === 'left'
+      ? `border-right-width: 1px;`
+      : `border-left-width: 1px;`
     };
   `}
 
@@ -82,14 +74,13 @@ const InnerContainer = styled.div<{position?: string, $loading: boolean, design:
 
 interface IProps extends IButtonProps {
   position?: 'left' | 'right'
-  loading: boolean
   shadow?: boolean
 }
 
-const ButtonWithLoading : React.FC<IProps> = ({design='primary', size='normal', shadow = false, onClick, disabled, position, loading, children,...rest}) => {
+const ButtonWithLoading : React.FC<IProps> = ({design='primary', size='normal', shadow = false, onClick, disabled, position, loading=false, children,...rest}) => {
   return (
-    <Container $loading={loading}>
-      <Button noPadding disabled={disabled || loading} {...{ design, size, shadow, onClick}} {...rest}>
+    <Container $loading={loading} {...{disabled}}>
+      <Button noPadding disabled={disabled || loading} {...{ design, size, shadow, onClick, loading}} {...rest}>
         <InnerContainer $loading={loading} {...{ design, size}}>
           <TextContainer>{children}</TextContainer>
           <LoadingContainer {...{ design, position }}>

--- a/packages/ui-lib/src/Form/index.ts
+++ b/packages/ui-lib/src/Form/index.ts
@@ -59,7 +59,7 @@ export {
 };
 
 export type TypeFieldState = 'default' | 'disabled' | 'required' | 'valid' | 'invalid' | 'processing';
-export type TypeButtonDesigns = 'primary' | 'secondary' | 'warning' | 'danger';
+export type TypeButtonDesigns = 'primary' | 'secondary' | 'warning' | 'danger' | 'text-only' | 'outline';
 export type TypeButtonSizes = 'xsmall' | 'small' | 'normal' | 'large';
 export type ISelectSizes = 'small' | 'normal';
 export type IInputOptionsType = "text" | "checkbox" | "radio";
@@ -70,6 +70,7 @@ export type TypeLabelDirection = 'column' | 'row' | 'row-reverse';
 interface ButtonProps {
   size?: TypeButtonSizes
   design?: TypeButtonDesigns
+  loading?: boolean
 }
 
 export type IButtonProps = ButtonProps & ButtonHTMLAttributes<HTMLButtonElement>

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -6,7 +6,7 @@ import { dimensions } from '../theme/common';
 
 
 const wrapperCss = css`
-  
+
   line-height: 0;
 
   svg {

--- a/packages/ui-lib/src/theme/ThemeHelpers.ts
+++ b/packages/ui-lib/src/theme/ThemeHelpers.ts
@@ -4,7 +4,7 @@ const BaseStyles = css`
 
   * , body{
     box-sizing: border-box;
-    text-rendering: geometricPrecision; 
+    text-rendering: geometricPrecision;
   }
   body, html , #root {
     min-width: 100%;
@@ -18,7 +18,7 @@ const BaseStyles = css`
     background: var(--main-background-gradient);
     background-attachment: fixed;
   }
-  
+
 `;
 
 export {

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -29,6 +29,7 @@ const ThemeVariables = createGlobalStyle`
     --button-font-size: 14px;
     --button-height: 32px;
     --button-h-padding: 8px;
+    --button-h-padding-outline: 7px;
     --button-lift-default-x: 0px;
     --button-lift-default-y: 2px;
     --button-lift-default-blur: 4px;
@@ -66,6 +67,7 @@ const ThemeVariables = createGlobalStyle`
     --button-font-size: 12px;
     --button-height: 20px;
     --button-h-padding: 4px;
+    --button-h-padding-outline: 3px;
     --button-icon-size: 12px;
     --button-icon-h-padding: 4px;
   }
@@ -74,6 +76,7 @@ const ThemeVariables = createGlobalStyle`
     --button-font-size: 12px;
     --button-height: 24px;
     --button-h-padding: 4px;
+    --button-h-padding-outline: 3px;
     --button-icon-size: 12px;
     --button-icon-h-padding: 8px;
   }
@@ -82,6 +85,7 @@ const ThemeVariables = createGlobalStyle`
     --button-font-size: 16px;
     --button-height: 40px;
     --button-h-padding: 8px;
+    --button-h-padding-outline: 7px;
     --button-icon-size: 16px;
     --button-icon-h-padding: 8px;
   }

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -66,8 +66,8 @@ const ThemeVariables = createGlobalStyle`
     --button-font-size: 12px;
     --button-height: 20px;
     --button-h-padding: 4px;
-    --button-icon-size: 10px;
-    --button-icon-h-padding: 8px;
+    --button-icon-size: 12px;
+    --button-icon-h-padding: 4px;
   }
 
   .button-size-small {

--- a/packages/ui-lib/src/theme/ThemeVariables.ts
+++ b/packages/ui-lib/src/theme/ThemeVariables.ts
@@ -36,7 +36,7 @@ const ThemeVariables = createGlobalStyle`
 
     --button-icon-size: 14px;
     --button-icon-h-padding: 8px;
-    
+
     // Inputs
     --input-box-shadow-x: 0;
     --input-box-shadow-y: 0;
@@ -86,7 +86,7 @@ const ThemeVariables = createGlobalStyle`
     --button-icon-h-padding: 8px;
   }
 
-  
+
 
   .split-button-primary {
     --border-color: var(--primary-9);

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -693,8 +693,12 @@ export const colorVariables = css`
     --button-drop-shadow-color: var(--shadow-primary-default);
     --button-text-color: var(--white-1);
     --button-divider-color: var(--primary-a3);
+
     --button-loading-area-background-color: var(--primary-a7);
     --button-loading-area-divider-color: var(--primary-a8);
+    --button-loading-text-color: var(--white-1);
+    --button-disabled-border-color: var(--button-border-color);
+    --button-disabled-text-color: var(--white-1);
 
     --button-hover-background-color: var(--primary-8);
     --button-hover-border-color: var(--primary-a6);
@@ -712,9 +716,6 @@ export const colorVariables = css`
     --button-active-divider-color: var(--primary-a3);
     --button-active-icon-area-background-color: var(--primary-a3);
 
-    --button-loading-text-color: var(--white-1);
-    --button-disabled-text-color: var(--white-1);
-
     --button-gradient-start: var(--primary-gradient-start);
     --button-gradient-end: var(--primary-gradient-end);
 
@@ -728,6 +729,7 @@ export const colorVariables = css`
 
       --button-loading-area-background-color: var(--grey-a4);
       --button-loading-area-divider-color: var(--grey-a3);
+      --button-disabled-border-color: var(--button-border-color);
 
       --button-hover-background-color: var(--grey-8);
       --button-hover-border-color: var(--grey-a6);
@@ -755,6 +757,7 @@ export const colorVariables = css`
 
       --button-loading-area-background-color: var(--warning-a7);
       --button-loading-area-divider-color: var(--warning-a9);
+      --button-disabled-border-color: var(--button-border-color);
 
       --button-hover-background-color: var(--warning-8);
       --button-hover-border-color: var(--warning-a6);
@@ -779,25 +782,55 @@ export const colorVariables = css`
       --button-gradient-start: transparent;
       --button-gradient-end: transparent;
       --button-drop-shadow-color: transparent;
-
+      --button-text-color: var(--grey-12);
       --button-divider-color: transparent;
 
       --button-loading-area-background-color: transparent;
       --button-loading-area-divider-color: transparent;
+      --button-loading-text-color: var(--grey-8);
+      --button-disabled-border-color: transparent;
+      --button-disabled-text-color: var(--grey-8);
 
       --button-hover-background-color: transparent;
       --button-hover-border-color: transparent;
       --button-hover-text-color: var(--primary-9);
       --button-hover-drop-shadow-color: transparent;
       --button-hover-inner-shadow-color: transparent;
+
       --button-active-inner-shadow-color: transparent;
       --button-active-drop-shadow-color: transparent;
       --button-active-background-color: transparent;
       --button-active-border-color: transparent;
       --button-active-text-color: var(--primary-10);
+    }
 
-      --button-loading-text-color: var(--grey-8);
-      --button-disabled-text-color: var(--grey-8);
+    .button-design-outline {
+      --button-background-color: transparent;
+      --button-border-color: var(--grey-11);
+      --button-inner-shadow-color: transparent;
+      --button-gradient-start: transparent;
+      --button-gradient-end: transparent;
+      --button-drop-shadow-color: var(--grey-a3);
+      --button-divider-color: var(--grey-a3);
+      --button-text-color: var(--grey-12);
+
+      --button-loading-area-background-color: transparent;
+      --button-loading-area-divider-color: var(--grey-a3);
+      --button-loading-text-color: var(--grey-10);
+      --button-disabled-border-color: var(--grey-a6);
+      --button-disabled-text-color: var(--grey-12);
+
+      --button-hover-background-color: transparent;
+      --button-hover-border-color: var(--primary-9);
+      --button-hover-text-color: var(--primary-9);
+      --button-hover-drop-shadow-color: var(--grey-a4);
+      --button-hover-inner-shadow-color: transparent;
+
+      --button-active-inner-shadow-color: transparent;
+      --button-active-drop-shadow-color: transparent;
+      --button-active-background-color: transparent;
+      --button-active-border-color: var(--primary-11);
+      --button-active-text-color: var(--primary-11);
     }
 
   }

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -536,16 +536,16 @@ export const colorVariables = css`
     /* Spinner */
     --spinner-primary-base: var(--primary-6);
     --spinner-primary-top: var(--white-1);
-    
+
     --spinner-secondary-base: var(--grey-8);
     --spinner-secondary-top: var(--white-1);
-    
+
     --spinner-simple-base: var(--grey-a8);
     --spinner-simple-top: var(--white-1);
-    
+
     --spinner-warning-base: var(--warning-8);
     --spinner-warning-top: var(--white-1);
-    
+
     /* Global */
     --main-background-gradient: radial-gradient(200% 200% at 50% -10%, var(--grey-2) 0%, var(--grey-3) 100%);
     --main-background-color: var(--grey-3);
@@ -561,7 +561,7 @@ export const colorVariables = css`
     --warning-gradient-start: var(--warning-9);
     --warning-gradient-end: var(--warning-10);
     --warning-gradient: linear-gradient(135deg, var(--warning-gradient-start), var(--warning-gradient-end));
-    
+
     --dividing-line: var(--grey-4);
     --global-element-background: var(--grey-2);
     --global-menu-icon-background-default: transparent;
@@ -573,7 +573,7 @@ export const colorVariables = css`
     --input-color-disabled: var(--grey-10);
     --input-color-placeholder: var(--grey-10);
     --input-color-unit: var(--grey-10);
-        
+
     --input-default-background-color: var(--grey-1);
     --input-default-border-color: var(--grey-6);
     --input-default-shadow-color: transparent;
@@ -624,28 +624,28 @@ export const colorVariables = css`
 
     /* Checkboxes and Radio Buttons */
     --input-toggle-icon-color: var(--white-12);
-    
+
     --input-toggle-unchecked-border-color: var(--grey-8);
     --input-toggle-unchecked-background-color: transparent;
-    
+
     --input-toggle-checked-border-color: var(--primary-9);
     --input-toggle-checked-background-color: var(--primary-9);
-    
-    
+
+
     --input-toggle-unchecked-hover-border-color: var(--primary-9);
     --input-toggle-unchecked-hover-background-color: transparent;
-    
+
     --input-toggle-checked-hover-border-color: var(--primary-7);
     --input-toggle-checked-hover-background-color: var(--primary-7);
-    
-    
+
+
     --input-toggle-unchecked-disabled-border-color: var(--grey-7);
     --input-toggle-unchecked-disabled-background-color: transparent;
 
     --input-toggle-checked-disabled-border-color: var(--grey-7);
     --input-toggle-checked-disabled-background-color: var(--grey-7);
 
-    
+
     --input-toggle-intermediate-border-color: var(--primary-11);
     --input-toggle-intermediate-background-color: var(--primary-11);
 
@@ -672,7 +672,7 @@ export const colorVariables = css`
 
     --filter-dropdown-background-color: color-mix(in srgb, var(--grey-1) 82%, transparent);
     --filter-dropdown-background-color-fallback: var(--grey-3);
-    --filter-dropdown-accent: var(--primary-a9); 
+    --filter-dropdown-accent: var(--primary-a9);
 
   }
 
@@ -712,6 +712,9 @@ export const colorVariables = css`
     --button-active-divider-color: var(--primary-a3);
     --button-active-icon-area-background-color: var(--primary-a3);
 
+    --button-loading-text-color: var(--white-1);
+    --button-disabled-text-color: var(--white-1);
+
     --button-gradient-start: var(--primary-gradient-start);
     --button-gradient-end: var(--primary-gradient-end);
 
@@ -722,7 +725,7 @@ export const colorVariables = css`
       --button-drop-shadow-color: var(--shadow-secondary-default);
       --button-text-color: var(--grey-12);
       --button-divider-color: var(--grey-a3);
-      
+
       --button-loading-area-background-color: var(--grey-a4);
       --button-loading-area-divider-color: var(--grey-a3);
 
@@ -737,7 +740,7 @@ export const colorVariables = css`
       --button-active-inner-shadow-color: var(--button-hover-inner-shadow-color);
       --button-active-drop-shadow-color: var(--button-hover-drop-shadow-color);
       --button-active-text-color: var(--white-1);
-      
+
       --button-gradient-start: var(--secondary-gradient-start);
       --button-gradient-end: var(--secondary-gradient-end);
     }
@@ -764,9 +767,37 @@ export const colorVariables = css`
       --button-active-inner-shadow-color: var(--button-hover-inner-shadow-color);
       --button-active-drop-shadow-color: var(--button-hover-drop-shadow-color);
       --button-active-text-color: var(--white-1);
-      
+
       --button-gradient-start: var(--warning-gradient-start);
       --button-gradient-end: var(--warning-gradient-end);
+    }
+
+    .button-design-text-only {
+      --button-background-color: transparent;
+      --button-border-color: transparent;
+      --button-inner-shadow-color: transparent;
+      --button-gradient-start: transparent;
+      --button-gradient-end: transparent;
+      --button-drop-shadow-color: transparent;
+
+      --button-divider-color: transparent;
+
+      --button-loading-area-background-color: transparent;
+      --button-loading-area-divider-color: transparent;
+
+      --button-hover-background-color: transparent;
+      --button-hover-border-color: transparent;
+      --button-hover-text-color: var(--primary-9);
+      --button-hover-drop-shadow-color: transparent;
+      --button-hover-inner-shadow-color: transparent;
+      --button-active-inner-shadow-color: transparent;
+      --button-active-drop-shadow-color: transparent;
+      --button-active-background-color: transparent;
+      --button-active-border-color: transparent;
+      --button-active-text-color: var(--primary-10);
+
+      --button-loading-text-color: var(--grey-8);
+      --button-disabled-text-color: var(--grey-8);
     }
 
   }
@@ -781,25 +812,25 @@ export const colorVariables = css`
     --switch-disabled-off-background: var(--grey-3);
     --switch-disabled-on-background: var(--primary-8);
     --switch-disabled-danger-background: var(--warning-8);
-    
+
     // Border
     --switch-default-off-border: var(--grey-7);
     --switch-default-on-border: var(--primary-9);
     --switch-default-danger-border: var(--warning-9);
-    
+
     --switch-disabled-off-border: var(--grey-6);
     --switch-disabled-on-border: var(--primary-a6);
     --switch-disabled-danger-border: var(--warning-a6);
-    
+
     // Inner
     --switch-default-off-inner: var(--primary-9);
     --switch-default-on-inner: var(--white-12);
     --switch-default-danger-inner: var(--white-12);
-    
+
     --switch-disabled-off-inner: var(--grey-7);
     --switch-disabled-on-inner: var(--primary-a9);
     --switch-disabled-danger-inner: var(--warning-a9);
-    
+
     // Special States
     --switch-special-locked-background: var(--grey-3);
     --switch-special-locked-border: var(--grey-11);
@@ -818,7 +849,7 @@ export const colorVariables = css`
     --switch-default-off-background: var(--grey-2);
     --switch-default-on-background: var(--primary-7);
     --switch-default-danger-background: var(--warning-9);
-    
+
     --switch-disabled-off-background: var(--grey-3);
     --switch-disabled-on-background: var(--primary-6);
     --switch-disabled-danger-background: var(--warning-8);
@@ -827,11 +858,11 @@ export const colorVariables = css`
     --switch-default-off-border: var(--grey-6);
     --switch-default-on-border: var(--primary-7);
     --switch-default-danger-border: var(--warning-9);
-    
+
     --switch-disabled-off-border: var(--grey-6);
     --switch-disabled-on-border: var(--primary-7);
     --switch-disabled-danger-border: var(--warning-a5);
-    
+
     // Inner
     --switch-default-off-inner: var(--primary-9);
     --switch-default-on-inner: var(--white-12);
@@ -840,7 +871,7 @@ export const colorVariables = css`
     --switch-disabled-off-inner: var(--grey-7);
     --switch-disabled-on-inner: var(--primary-9);
     --switch-disabled-danger-inner: var(--warning-a8);
-    
+
     // Special States
     --switch-special-locked-background: var(--grey-3);
     --switch-special-locked-border: var(--grey-8);

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -689,6 +689,7 @@ export const colorVariables = css`
   .light-theme, .dark-theme {
     --button-background-color: var(--primary-9);
     --button-border-color: var(--primary-9);
+    --button-border-width: 1px;
     --button-inner-shadow-color: transparent;
     --button-drop-shadow-color: var(--shadow-primary-default);
     --button-text-color: var(--white-1);
@@ -807,6 +808,7 @@ export const colorVariables = css`
     .button-design-outline {
       --button-background-color: transparent;
       --button-border-color: var(--grey-11);
+      --button-border-width: 2px;
       --button-inner-shadow-color: transparent;
       --button-gradient-start: transparent;
       --button-gradient-end: transparent;


### PR DESCRIPTION
### Description

Update request for buttons:

Within the designs for improvements to filters, new button variations are now being used and need to be added to the UI Kit.

**The new theme options** are `Text Only` and `Outline`. These are mostly changes to the colours of the buttons and are all linked to the theme. `Text Only` implies there is no button although the clickable area is still the same with the optional icon still there although not it is expected to rarely be used.

The `Outline` variant also has a thicker outline than other buttons.

**For the xsmall button variant** change, the size of the icon has gone from `10` → `12` and the horizontal padding in the icon area has gone from `8` → `4`

 ### Considerations on Implementation
No updates were made for any design differences for primary, secondary and warning buttons

 ### Reviewing/Testing steps

The storybook stories for Standard Button, WithLoading and WithIcon were added and can be review under Form, Buttons.


[Button With Icon video](https://drive.google.com/file/d/1KQnEpzbyvebNX0RjpMdq4i2RP-3UZBgd/view?usp=sharing)

<img width="1081" alt="Screenshot 2025-04-15 at 15 08 55" src="https://github.com/user-attachments/assets/2613e0f2-bfe9-4cfe-bab3-313374aef13a" />


