### PR TITLE
Circular Dependency Fix (Manual Alternative)

### DIFF
--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -21,7 +21,7 @@ export default {
 const exampleCallback = <T extends Function>(fn: T): T => {
   /** A toString to render the function in storybook */
   // eslint-disable-next-line no-param-reassign
-  fn.toString = () => '   updateCallback: (data: DateInterval | Date) => {}';
+  fn.toString = () => '   updateCallback: (data: IDateInterval | Date) => {}';
   return fn;
 };
 

--- a/packages/storybook/src/stories/Filters/molecules/FilterInputs.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterInputs.stories.tsx
@@ -12,7 +12,7 @@ import {
   IFilterLabel,
   IFilterItem,
   IFilterType,
-  DateInterval,
+  IDateInterval,
 } from 'scorer-ui-kit';
 
 import {
@@ -128,7 +128,7 @@ const generateResultsLabelData = (dropdownFilters: IFilterDropdownExt[], searchF
   return labelLists;
 }
 
-const isDifferentValue = (item: IFilterItem | Date | DateInterval, compareItem: IFilterItem | Date | DateInterval) : boolean => {
+const isDifferentValue = (item: IFilterItem | Date | IDateInterval, compareItem: IFilterItem | Date | IDateInterval) : boolean => {
   if(isFilterItem(item) && isFilterItem(compareItem)) {
     return compareItem.value !== item.value;
   }
@@ -240,7 +240,7 @@ export const _FilterInputs = () => {
   }, []);
 
 
-  const onRemoveFilter = useCallback((filterId: string, type: IFilterType, item: IFilterItem | Date | DateInterval) => {
+  const onRemoveFilter = useCallback((filterId: string, type: IFilterType, item: IFilterItem | Date | IDateInterval) => {
     if (type === 'dropdown' ) {
       const foundFilter = dropdownFilters.find((dropdown) => dropdown.id === filterId);
       if (foundFilter && foundFilter.onSelect) {

--- a/packages/storybook/src/stories/helpers/datePicker_sample.ts
+++ b/packages/storybook/src/stories/helpers/datePicker_sample.ts
@@ -1,4 +1,4 @@
-import { DateInterval } from "scorer-ui-kit";
+import { IDateInterval } from "scorer-ui-kit";
 
 const TODAY: Date = new Date();
 const TOMORROW: Date = new Date();
@@ -7,7 +7,7 @@ const TWO_WEEKS_BEFORE: Date = new Date();
 TWO_WEEKS_BEFORE.setDate(TODAY.getDate() - 15);
 
 // Selected example
-const InitialSelectedDate: DateInterval = {
+const InitialSelectedDate: IDateInterval = {
   start: TWO_WEEKS_BEFORE,
   end: TOMORROW
 }

--- a/packages/storybook/src/stories/helpers/sample_table_helpers.tsx
+++ b/packages/storybook/src/stories/helpers/sample_table_helpers.tsx
@@ -1,5 +1,5 @@
 import { ITableSampleData } from "./data_samples";
-import { DateInterval, IFilterItem, isFilterItem } from 'scorer-ui-kit';
+import { IDateInterval, IFilterItem, isFilterItem } from 'scorer-ui-kit';
 import photo from '../assets/placeholder.jpg';
 import { IRowData, ITypeTableData } from "scorer-ui-kit/dist/Tables";
 
@@ -120,7 +120,7 @@ const filterByCreationDate = (data: ITableSampleData[], filterVal: IFilterItem):
   return data;
 };
 
-const filterByCreationDatePicker = (data: ITableSampleData[], filterVal: Date | DateInterval): ITableSampleData[] => {
+const filterByCreationDatePicker = (data: ITableSampleData[], filterVal: Date | IDateInterval): ITableSampleData[] => {
 
   if (filterVal instanceof Date) {
     const newData: ITableSampleData[] = data.filter((sample) => {

--- a/packages/ui-lib/src/Filters/FilterTypes.ts
+++ b/packages/ui-lib/src/Filters/FilterTypes.ts
@@ -1,8 +1,8 @@
 import { IInputOptionsType } from '../Form';
 import { IBasicSearchInput } from '../Misc/atoms/BasicSearchInput';
-import { DateInterval } from './molecules/DatePicker';
 import { IDropdownDatePicker } from './molecules/DropdownDatePicker';
 import { IFilterDropdown } from './molecules/FilterDropdown';
+import { IDateInterval } from '.';
 
 type IFilterItem = { text: string; value: string | number; }
 type IFilterValue = IFilterItem | IFilterItem[] | null;
@@ -28,7 +28,7 @@ const isFilterItem = (item: any): item is IFilterItem => {
 interface IFilterResult {
   id: string
   type: IFilterType
-  selected: IFilterItem | IFilterItem[] | DateInterval | Date | null;
+  selected: IFilterItem | IFilterItem[] | IDateInterval | Date | null;
 }
 
 interface ISearchFilter extends IBasicSearchInput {

--- a/packages/ui-lib/src/Filters/index.ts
+++ b/packages/ui-lib/src/Filters/index.ts
@@ -1,4 +1,4 @@
-import DatePicker from './molecules/DatePicker';
+import DatePicker, { IDatePicker } from './molecules/DatePicker';
 import { isDateInterval } from '../helpers';
 import FilterDropdownContainer from './atoms/FilterDropdownContainer';
 import FilterButton from './atoms/FilterButton';
@@ -62,4 +62,5 @@ export type {
   IFilterDatePicker,
   FilterButtonDesign,
   IToggleOption,
+  IDatePicker
 };

--- a/packages/ui-lib/src/Filters/index.ts
+++ b/packages/ui-lib/src/Filters/index.ts
@@ -1,4 +1,5 @@
-import DatePicker, { DateInterval, isDateInterval, DateRange } from './molecules/DatePicker';
+import DatePicker from './molecules/DatePicker';
+import { isDateInterval } from '../helpers';
 import FilterDropdownContainer from './atoms/FilterDropdownContainer';
 import FilterButton from './atoms/FilterButton';
 import FilterDropdown from './molecules/FilterDropdown';
@@ -8,6 +9,16 @@ import FilterInputs, { IFilterInputs } from './molecules/FilterInputs';
 import FiltersResults, { IFilterLabel } from './molecules/FiltersResults';
 import FilterBar from './organisms/FilterBar';
 import ToggleButton from './atoms/ToggleButton';
+
+export interface DateInterval {
+  start: Date;
+  end: Date;
+}
+
+export interface DateRange {
+  start: Date | null;
+  end: Date | null;
+}
 
 import {
   IFilterType,
@@ -48,9 +59,7 @@ export type {
   IFilterItem,
   IFilterResult,
   IFilterValue,
-  DateInterval,
   IFilterDatePicker,
   FilterButtonDesign,
   IToggleOption,
-  DateRange
 };

--- a/packages/ui-lib/src/Filters/index.ts
+++ b/packages/ui-lib/src/Filters/index.ts
@@ -10,12 +10,12 @@ import FiltersResults, { IFilterLabel } from './molecules/FiltersResults';
 import FilterBar from './organisms/FilterBar';
 import ToggleButton from './atoms/ToggleButton';
 
-export interface DateInterval {
+export interface IDateInterval {
   start: Date;
   end: Date;
 }
 
-export interface DateRange {
+export interface IDateRange {
   start: Date | null;
   end: Date | null;
 }

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -7,14 +7,14 @@ import { format, startOfMonth, endOfMonth, eachDayOfInterval, isAfter, eachWeekO
 import { ja, enUS } from 'date-fns/locale';
 import { resetButtonStyles } from '../../common';
 import Button from '../../Form/atoms/Button';
-import { DateInterval, DateRange } from '..';
+import { IDateInterval, IDateRange } from '..';
 
 /**
  * Convert a single days duration to an interval.
  * @param day The day to convert to an interval
  */
 
-const initializeInterval = (day: Date): DateInterval => {
+const initializeInterval = (day: Date): IDateInterval => {
   return {
     start: set(day, { seconds: 0, milliseconds: 0 }),
     end: endOfDay(day)
@@ -22,7 +22,7 @@ const initializeInterval = (day: Date): DateInterval => {
 };
 
 const TODAY = new Date();
-const TODAY_INTERVAL: DateInterval = initializeInterval(startOfDay(new Date()));
+const TODAY_INTERVAL: IDateInterval = initializeInterval(startOfDay(new Date()));
 
 type CellStates = "off" | "single" | "start" | "end" | "inside" | "hover" | "insideHover";
 type DateMode = "single" | "interval";
@@ -342,7 +342,7 @@ const jpDayGuide: string[] = ['日', '月', '火', '水', '木', '金', '土'];
 
 
 export interface IDatePicker {
-  initialValue?: Date | DateInterval
+  initialValue?: Date | IDateInterval
   dateMode?: DateMode
   timeMode?: TimeMode
   hasEmptyValue?: boolean
@@ -350,14 +350,14 @@ export interface IDatePicker {
   dateTimeTextLower?: string
   timeZoneTitle?: string
   timeZoneValueTitle?: string
-  availableRange?: DateRange
+  availableRange?: IDateRange
   contentDays?: Date[]
   lang?: 'en' | 'ja'
   cancelText?: string
   applyText?: string
   hasApply?: boolean
   disableApply?: boolean
-  updateCallback?: (data: DateInterval | Date) => void
+  updateCallback?: (data: IDateInterval | Date) => void
   applyCallback?: () => void
   cancelCallback?: () => void
 }
@@ -385,7 +385,7 @@ const DatePicker: React.FC<IDatePicker> = ({
 
   // TODO: Have a function to output tidied up data for the configuration.
 
-  const [selectedRange, setSelectedRange] = useState<DateInterval | null>(getInitialValue(hasEmptyValue, initialValue));
+  const [selectedRange, setSelectedRange] = useState<IDateInterval | null>(getInitialValue(hasEmptyValue, initialValue));
   const [focusedMonth, setFocusedMonth] = useState(selectedRange === null ? TODAY : selectedRange.start);
   const [targetedDate, setTargetedDate] = useState<'start' | 'end' | 'done'>('start');
   const [weeksOfMonth, setWeeksOfMonth] = useState<Date[]>([]);
@@ -634,7 +634,7 @@ const updateDay = (date: Date, target: Date) => {
   return newDate;
 };
 
-const getInitialValue = (hasEmptyValue: boolean, initialValue?: Date | DateInterval): DateInterval | null => {
+const getInitialValue = (hasEmptyValue: boolean, initialValue?: Date | IDateInterval): IDateInterval | null => {
   if (hasEmptyValue && initialValue === undefined) {
     return null;
   }
@@ -644,7 +644,7 @@ const getInitialValue = (hasEmptyValue: boolean, initialValue?: Date | DateInter
   return (validInitial instanceof Date) ? initializeInterval(validInitial) : validInitial;
 };
 
-const isPrevMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): boolean => {
+const isPrevMonthOutOfRange = (focusedMonth: Date, availableRange?: IDateRange): boolean => {
   if (!availableRange?.start) return false;
 
   try {
@@ -662,7 +662,7 @@ const isPrevMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): 
   return false;
 };
 
-const isNextMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): boolean => {
+const isNextMonthOutOfRange = (focusedMonth: Date, availableRange?: IDateRange): boolean => {
   if (!availableRange?.end) return false;
 
   try {
@@ -681,7 +681,7 @@ const isNextMonthOutOfRange = (focusedMonth: Date, availableRange?: DateRange): 
 };
 
 
-const isDayOutOfRange = (currentDay: Date, availableRange?: DateRange): boolean => {
+const isDayOutOfRange = (currentDay: Date, availableRange?: IDateRange): boolean => {
   if (!availableRange) return false;
 
   const { start, end } = availableRange;

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -7,6 +7,7 @@ import { format, startOfMonth, endOfMonth, eachDayOfInterval, isAfter, eachWeekO
 import { ja, enUS } from 'date-fns/locale';
 import { resetButtonStyles } from '../../common';
 import Button from '../../Form/atoms/Button';
+import { DateInterval, DateRange } from '..';
 
 /**
  * Convert a single days duration to an interval.
@@ -337,31 +338,8 @@ const enDayGuide: string[] = [
 
 const jpDayGuide: string[] = ['日', '月', '火', '水', '木', '金', '土'];
 
-export const isDateInterval = (value: any): value is DateInterval => {
-  if (value === null || value === undefined) {
-    return false;
-  }
 
-  if (value.start === null || value.start === undefined) {
-    return false;
-  }
 
-  if (value.end === null || value.end === undefined) {
-    return false;
-  }
-
-  return (value.start instanceof Date) && (value.end instanceof Date);
-};
-
-export interface DateInterval {
-  start: Date;
-  end: Date;
-}
-
-export interface DateRange {
-  start: Date | null;
-  end: Date | null;
-}
 
 export interface IDatePicker {
   initialValue?: Date | DateInterval

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -1,9 +1,10 @@
 import React, { useRef, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import FilterDropdownContainer from '../atoms/FilterDropdownContainer';
-import DatePicker, { DateInterval, IDatePicker } from './DatePicker';
+import DatePicker from './DatePicker';
 import FilterDropHandler, { FilterDropHandlerRef } from '../atoms/FilterDropHandler';
 import { areDatesEqual } from '../../helpers';
+import { IDateInterval, IDatePicker } from '..';
 
 const MIN_WIDTH = 470;
 const MIN_HEIGHT = 360;
@@ -11,7 +12,7 @@ const MIN_HEIGHT = 360;
 const Container = styled.div``;
 
 interface IMountPicker {
-  initialValue: DateInterval | Date | undefined
+  initialValue: IDateInterval | Date | undefined
   isMount: boolean
 }
 
@@ -19,12 +20,12 @@ export interface IDropdownDatePicker extends IDatePicker {
   buttonIcon: string
   buttonText: string
   disabled?: boolean
-  selected?: DateInterval | Date | null;
-  onCloseCallback?: (value: DateInterval | Date | null) => void
-  onUpdateCallback?: (value: DateInterval | Date | null) => void
-  onToggleCallback?: (value: DateInterval | Date | null, isOpen: boolean) => void
+  selected?: IDateInterval | Date | null;
+  onCloseCallback?: (value: IDateInterval | Date | null) => void
+  onUpdateCallback?: (value: IDateInterval | Date | null) => void
+  onToggleCallback?: (value: IDateInterval | Date | null, isOpen: boolean) => void
   onCancelCallback?: () => void
-  onApplyCallback?:  (data: DateInterval | Date) => void
+  onApplyCallback?:  (data: IDateInterval | Date) => void
 }
 
 const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
@@ -57,12 +58,12 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
    * This will keep the value of the picker when it updates so on close will send the most fresh value
    * without re-renders.
    */
-  const pickerValue = useRef<DateInterval | Date | null>(null);
+  const pickerValue = useRef<IDateInterval | Date | null>(null);
   const [mountedPicker, setMountedPicker] = useState<IMountPicker>({ initialValue: initialValue, isMount: true });
   const [disableApply, setDisableApply] = useState(false);
 
   const DropdownHandlerRef = useRef<FilterDropHandlerRef>(null);
-  const handleUpdateCallback = useCallback((data: DateInterval | Date) => {
+  const handleUpdateCallback = useCallback((data: IDateInterval | Date) => {
     pickerValue.current = data;
     onUpdateCallback(data);
     setDisableApply(areDatesEqual(selected, data));

--- a/packages/ui-lib/src/Filters/molecules/FiltersResults.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FiltersResults.tsx
@@ -4,8 +4,9 @@ import { IFilterItem, IFilterType } from '../FilterTypes';
 import { resetButtonStyles } from '../../common/index';
 import Icon, { IconWrapper } from '../../Icons/Icon';
 import { isFilterItem } from '../FilterTypes';
-import { DateInterval, isDateInterval } from './DatePicker';
 import { format, add, startOfDay } from 'date-fns';
+import { isDateInterval } from '../../helpers';
+import { DateInterval } from '..';
 
 const Container = styled.div`
   display: flex;

--- a/packages/ui-lib/src/Filters/molecules/FiltersResults.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FiltersResults.tsx
@@ -6,7 +6,7 @@ import Icon, { IconWrapper } from '../../Icons/Icon';
 import { isFilterItem } from '../FilterTypes';
 import { format, add, startOfDay } from 'date-fns';
 import { isDateInterval } from '../../helpers';
-import { DateInterval } from '..';
+import { IDateInterval } from '..';
 
 const Container = styled.div`
   display: flex;
@@ -98,7 +98,7 @@ const renderResults = (template: string, total: number) => {
 };
 
 
-const renderLabel = (item: IFilterItem | DateInterval | Date, resultsDateFormat: string, icon?: string, filterName?: string) => {
+const renderLabel = (item: IFilterItem | IDateInterval | Date, resultsDateFormat: string, icon?: string, filterName?: string) => {
 
   let textLabel: string = "";
   const isDateFormatValid = validateDateFormat(resultsDateFormat);
@@ -130,7 +130,7 @@ const renderLabel = (item: IFilterItem | DateInterval | Date, resultsDateFormat:
 
 export interface IFilterLabel {
   filterId: string
-  item: IFilterItem | Date | DateInterval
+  item: IFilterItem | Date | IDateInterval
   type: IFilterType
   icon?: string
   filterName?: string
@@ -142,7 +142,7 @@ interface IFilterResults {
   resultTextTemplate?: string
   clearText?: string
   resultsDateFormat?: string
-  onRemoveFilter?: (filterId: string, type: IFilterType, item: IFilterItem | Date | DateInterval) => void
+  onRemoveFilter?: (filterId: string, type: IFilterType, item: IFilterItem | Date | IDateInterval) => void
   onClearAll?: () => void
 }
 

--- a/packages/ui-lib/src/Filters/organisms/FilterBar.tsx
+++ b/packages/ui-lib/src/Filters/organisms/FilterBar.tsx
@@ -12,7 +12,7 @@ import FilterInputs from '../molecules/FilterInputs';
 import { IFilterDropdownExt, ISearchFilter, IFilterDatePicker } from '../FilterTypes';
 import FiltersResults, { IFilterLabel } from '../../Filters/molecules/FiltersResults';
 import { isDateInterval } from '../../helpers';
-import { DateInterval } from '..';
+import { IDateInterval } from '..';
 import isequal from 'lodash.isequal';
 import debounce from 'lodash.debounce';
 
@@ -106,29 +106,29 @@ const createDatePickers = (
   datePickersConfig: IFilterDatePicker[],
   filtersValues: IFilterResult[],
   singleFilter: boolean,
-  handleDatePickers: (selection: DateInterval | Date | null, filterId: string) => void,
+  handleDatePickers: (selection: IDateInterval | Date | null, filterId: string) => void,
 ): IFilterDatePicker[] => {
   const datePickersFilters: IFilterDatePicker[] = [];
 
   datePickersConfig.forEach((datePicker) => {
-    const onCloseCallback = (value: DateInterval | Date | null) => {
+    const onCloseCallback = (value: IDateInterval | Date | null) => {
       handleDatePickers(value, datePicker.id);
     };
 
-    const onToggleCallback = (value: DateInterval | Date | null, isOpen: boolean) => {
+    const onToggleCallback = (value: IDateInterval | Date | null, isOpen: boolean) => {
       // if it was open before toggle means the user closed it and value should be updated.
       if (!isOpen) {
         handleDatePickers(value, datePicker.id);
       }
     };
 
-    const onApplyCallback = (value: DateInterval | Date) => {
+    const onApplyCallback = (value: IDateInterval | Date) => {
       handleDatePickers(value, datePicker.id);
     };
 
     const disabled = getDisableValue(filtersValues, singleFilter, datePicker);
     const foundPicker = filtersValues.find(filter => filter.id === datePicker.id);
-    let validInitialValue: Date | DateInterval | undefined = undefined;
+    let validInitialValue: Date | IDateInterval | undefined = undefined;
 
     if (datePicker.selected) {
       validInitialValue = datePicker.selected;
@@ -262,7 +262,7 @@ const initFilters = (
 
   datePickersConfig.forEach(({ id, initialValue, selected }) => {
 
-    let validSelected: Date | DateInterval | null = null;
+    let validSelected: Date | IDateInterval | null = null;
 
     if (initialValue) {
       validSelected = initialValue;
@@ -368,7 +368,7 @@ const FilterBar: React.FC<IFilterBar> = ({
     setFiltersValues(updatedFilters);
   }, [filtersValues, handleChange]);
 
-  const handleOnRemoveFilter = useCallback((filterId: string, type: IFilterType, item: IFilterItem | Date | DateInterval) => {
+  const handleOnRemoveFilter = useCallback((filterId: string, type: IFilterType, item: IFilterItem | Date | IDateInterval) => {
 
     setFiltersValues((prev) => {
       const updatedFilters = [...prev];
@@ -397,7 +397,7 @@ const FilterBar: React.FC<IFilterBar> = ({
 
   }, [handleChange]);
 
-  const handleDatePickers = useCallback((selection: DateInterval | Date | null, filterId: string) => {
+  const handleDatePickers = useCallback((selection: IDateInterval | Date | null, filterId: string) => {
 
     const updatedDatePickers = [...filtersValues];
     const foundFilter = updatedDatePickers.find((datePicker) => datePicker.id === filterId);

--- a/packages/ui-lib/src/Filters/organisms/FilterBar.tsx
+++ b/packages/ui-lib/src/Filters/organisms/FilterBar.tsx
@@ -11,7 +11,8 @@ import {
 import FilterInputs from '../molecules/FilterInputs';
 import { IFilterDropdownExt, ISearchFilter, IFilterDatePicker } from '../FilterTypes';
 import FiltersResults, { IFilterLabel } from '../../Filters/molecules/FiltersResults';
-import { DateInterval, isDateInterval } from '../molecules/DatePicker';
+import { isDateInterval } from '../../helpers';
+import { DateInterval } from '..';
 import isequal from 'lodash.isequal';
 import debounce from 'lodash.debounce';
 

--- a/packages/ui-lib/src/helpers/index.tsx
+++ b/packages/ui-lib/src/helpers/index.tsx
@@ -1,6 +1,6 @@
 import { isEqual } from 'date-fns';
 import { ITimeUnit } from '..';
-import { DateInterval } from '../Filters';
+import { IDateInterval } from '../Filters';
 
 const isInsideRange = (value: number, min: number, max: number) : boolean => {
   if( value < min) {return false;}
@@ -92,7 +92,7 @@ const uniqueID = () =>
     return intValue !== intValue;
   };
 
-  const areDatesEqual = (storedValue: DateInterval | Date | null | undefined, currentDisplay: DateInterval | Date | null): boolean => {
+  const areDatesEqual = (storedValue: IDateInterval | Date | null | undefined, currentDisplay: IDateInterval | Date | null): boolean => {
     if (storedValue === null && currentDisplay === null) {
       return true;
     }
@@ -113,7 +113,7 @@ const uniqueID = () =>
   };
 
 
-  const isDateInterval = (value: any): value is DateInterval => {
+  const isDateInterval = (value: any): value is IDateInterval => {
     if (value === null || value === undefined) {
       return false;
     }

--- a/packages/ui-lib/src/helpers/index.tsx
+++ b/packages/ui-lib/src/helpers/index.tsx
@@ -1,5 +1,6 @@
 import { isEqual } from 'date-fns';
-import {DateInterval, isDateInterval, ITimeUnit} from '../index';
+import { ITimeUnit } from '..';
+import { DateInterval } from '../Filters';
 
 const isInsideRange = (value: number, min: number, max: number) : boolean => {
   if( value < min) {return false;}
@@ -111,9 +112,27 @@ const uniqueID = () =>
     return false;
   };
 
+
+  const isDateInterval = (value: any): value is DateInterval => {
+    if (value === null || value === undefined) {
+      return false;
+    }
+  
+    if (value.start === null || value.start === undefined) {
+      return false;
+    }
+  
+    if (value.end === null || value.end === undefined) {
+      return false;
+    }
+  
+    return (value.start instanceof Date) && (value.end instanceof Date);
+  };
+
 export {
   clamp,
   isValidImage,
+  isDateInterval,
   getImageType,
   getTextTimeUnit,
   isInsideRange,

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -55,9 +55,7 @@ import {
 // Components - Filter
 import {
   DatePicker,
-  DateInterval,
   isDateInterval,
-  DateRange,
   IFilterDatePicker,
   FilterDropdownContainer,
   FilterButton,
@@ -78,7 +76,9 @@ import {
   isFilterItem,
   FilterButtonDesign,
   ToggleButton,
-  IToggleOption
+  IToggleOption,
+  IDateInterval,
+  IDateRange
 } from './Filters';
 
 import Icon, { IconSVGs } from './Icons/Icon';
@@ -403,7 +403,6 @@ export type {
   IFilterItem,
   IFilterValue,
   IFilterResult,
-  DateInterval,
   IFilterDatePicker,
   ICameraPanel,
   IMediaStream,
@@ -423,5 +422,6 @@ export type {
   ITooltipType,
   FilterButtonDesign,
   IToggleOption,
-  DateRange
+  IDateInterval,
+  IDateRange
 };


### PR DESCRIPTION
This PR contains two commits, which when reviewing I recommend you switch to review individually. This is because the first is moving the parts that caused the circular dependency issue, then the other renames the interfaces to match our naming convention in such cases. Viewing together just has a lot of noise as a result.

In response to #571, I was bothered by the fact it moved functions out of centralised places which goes against how we try to keep things scalable and reusable. Even though it was okay, it felt like bad practice that left some rough edges.

This fix moves `isDateInterval` out of `DatePicker.tsx` and in to `helpers`. It also moves the two interfaces it uses out of the same file to the `Filters/index.ts` file which is should be the central point for all the types and interfaces being past around in the folder.

I feel this approach keeps within our best practices and that move the code outward to fix the problem rather than inward (to individual components).

# Notes For Documentation
While fixing the circular dependency issue, the two interfaces `DateInterval` and `DateRange` were moved to a higher level and renamed `IDateInterval` and `IDateRange` to become consistent with how we name exported interfaces.

If you are using either of these in projects then you will need to update them in your code base. While you can do this any way you prefer, it can be done easily with find and replace in VSCode (or any IDE with a Regex based find and replace feature) by using the following...
Find: `(?<![A-Za-z])DateInterval` -> Replace `IDateInterval`
Find: `(?<![A-Za-z])DateRange` -> Replace `IDateRange`

_Note: This regex should fixed references that aren't already prefixed and also exclude similar strings such as the function `isDateInterval`._

_Please however take a moment to check that any changes are valid and compile without error._

