### PR TITLE
Filter Dropdown Interaction Improvements

### DIFF
--- a/packages/storybook/src/stories/Filters/molecules/FilterDropdownExamples.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterDropdownExamples.stories.tsx
@@ -18,7 +18,7 @@ import {
 import { generateIconList } from '../../helpers';
 
 export default {
-  title: 'Filters/molecules',
+  title: 'Filters/molecules/FilterDropdown',
   component: FilterDropdown,
   decorators: []
 };
@@ -90,7 +90,7 @@ const baseExample = [
   { text: "Fugiat Nulla", value: 8 },
 ];
 
-export const _FilterDropdown = () => {
+export const MultipleDropdownExamples = () => {
   const iconList = generateIconList();
 
   const language = select("Language", { English: 'english', Japanese: "japanese" }, "japanese");

--- a/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useCallback } from 'react';
+import styled from 'styled-components';
+import { boolean, text, select } from "@storybook/addon-knobs";
+import { action } from '@storybook/addon-actions';
+import {
+  FilterDropdown,
+  IFilterValue,
+  PageHeader,
+} from 'scorer-ui-kit';
+import { generateIconList } from '../../helpers';
+
+export default {
+  title: 'Filters/molecules/FilterDropdown',
+  component: FilterDropdown,
+  parameters: {
+    componentSubtitle: 'FilterDropdown component with footer controls',
+  }
+};
+
+const Wrapper = styled.div`
+  margin: 100px;
+  display: inline-block;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+// Sample data for the dropdown
+const foodItems = [
+  { text: 'Ramen', value: 0 },
+  { text: 'Takoyaki', value: 1 },
+  { text: 'Gyoza', value: 2 },
+  { text: 'Tempura', value: 3 },
+  { text: 'Sushi', value: 4 },
+  { text: 'Natto', value: 5 },
+  { text: 'Sashimi', value: 6 },
+];
+
+export const DropdownWithApplyAndReset = () => {
+
+  const iconList = generateIconList();
+  const buttonText = text('Button Text', 'Food Menu');
+  const buttonIcon = select("Icon", iconList, Object.keys(iconList)[0]);
+  const disabled = boolean('Disabled', false);
+  const hasOptionsFilter = boolean('Has Options Filter', true);
+  const searchPlaceholder = text('Search Placeholder', 'Filter by name...');
+
+  // State for selected items
+  const [selected, setSelected] = useState<IFilterValue>(null);
+
+  // Action trackers
+  const resetAction = action('Reset clicked');
+  const cancelAction = action('Cancel/Close clicked');
+  const applyAction = action('Apply clicked');
+  const selectAction = action('Item selected');
+  const hasApply = boolean('Has Apply', true);
+  const hasReset = boolean('Has Reset', true);
+
+  // Handlers for the dropdown
+  const handleSelect = useCallback((newSelection: IFilterValue) => {
+    selectAction(newSelection);
+    setSelected(newSelection);
+  }, [selectAction]);
+
+  const handleReset = useCallback(() => {
+    resetAction();
+  }, [resetAction]);
+
+  const handleCancel = useCallback(() => {
+    cancelAction();
+  }, [cancelAction]);
+
+  const handleApply = useCallback(() => {
+    applyAction(selected);
+  }, [applyAction, selected]);
+
+  return (
+    <Container>
+      <Wrapper>
+        <PageHeader
+          title="FilterDropdown with Footer Controls"
+          introductionText="This example demonstrates the FilterDropdown component with both Reset and Apply buttons."
+        />
+
+        <FilterDropdown
+          buttonIcon={buttonIcon}
+          buttonText={buttonText}
+          list={foodItems}
+          selected={selected}
+          disabled={disabled}
+          hasOptionsFilter={hasOptionsFilter}
+          searchPlaceholder={searchPlaceholder}
+          searchResultText="Showing [VISIBLE] of [TOTAL]"
+          optionType="checkbox"
+          onSelect={handleSelect}
+          onReset={handleReset}
+          onCancel={handleCancel}
+          onApply={handleApply}
+          hasReset={hasReset}
+          hasApply={hasApply}
+        />
+      </Wrapper>
+    </Container>
+  );
+};

--- a/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
@@ -8,8 +8,9 @@ import {
   PageHeader,
 } from 'scorer-ui-kit';
 import { generateIconList } from '../../helpers';
+import { searchTemplateResultEnglish, searchTemplateResultJapanese } from '../../helpers/data_samples';
 
-export default {
+const FilterDropdownWithFooterStory = {
   title: 'Filters/molecules/FilterDropdown',
   component: FilterDropdown,
   parameters: {
@@ -29,7 +30,7 @@ const Container = styled.div`
 `;
 
 // Sample data for the dropdown
-const foodItems = [
+const foodItemsEng = [
   { text: 'Ramen', value: 0 },
   { text: 'Takoyaki', value: 1 },
   { text: 'Gyoza', value: 2 },
@@ -39,14 +40,22 @@ const foodItems = [
   { text: 'Sashimi', value: 6 },
 ];
 
-export const DropdownWithApplyAndReset = () => {
+const foodItemsJap = [
+  { text: 'ラーメン', value: 0 },
+  { text: '蛸焼き', value: 1 },
+  { text: '餃子', value: 2 },
+  { text: '天婦羅', value: 3 },
+  { text: 'すし', value: 4 },
+  { text: '納豆', value: 5 },
+  { text: 'お造り', value: 6 },
+];
 
+export const DropdownWithApplyAndReset = () => {
+  const language = select("Language", { English: 'english', Japanese: "japanese" }, "japanese");
   const iconList = generateIconList();
-  const buttonText = text('Button Text', 'Food Menu');
   const buttonIcon = select("Icon", iconList, Object.keys(iconList)[0]);
   const disabled = boolean('Disabled', false);
   const hasOptionsFilter = boolean('Has Options Filter', true);
-  const searchPlaceholder = text('Search Placeholder', 'Filter by name...');
 
   // State for selected items
   const [selected, setSelected] = useState<IFilterValue>(null);
@@ -78,6 +87,7 @@ export const DropdownWithApplyAndReset = () => {
     applyAction(newSelection);
   }, [applyAction]);
 
+
   return (
     <Container>
       <Wrapper>
@@ -88,13 +98,13 @@ export const DropdownWithApplyAndReset = () => {
 
         <FilterDropdown
           buttonIcon={buttonIcon}
-          buttonText={buttonText}
-          list={foodItems}
+          buttonText={language === 'japanese' ? 'メニュー' : 'Menu' }
+          list={language === 'japanese' ? foodItemsJap : foodItemsEng}
           selected={selected}
           disabled={disabled}
           hasOptionsFilter={hasOptionsFilter}
-          searchPlaceholder={searchPlaceholder}
-          searchResultText="Showing [VISIBLE] of [TOTAL]"
+          searchPlaceholder={language === 'japanese' ?  'メニュー...' : 'Menu options...' }
+          searchResultText={language === 'japanese' ? searchTemplateResultJapanese : searchTemplateResultEnglish}
           optionType="checkbox"
           onSelect={handleSelect}
           onResetCallback={handleReset}
@@ -102,8 +112,16 @@ export const DropdownWithApplyAndReset = () => {
           onApplyCallback={handleApply}
           hasReset={hasReset}
           hasApply={hasApply}
+          resetText={ language === 'japanese' ? 'リセット' : 'Reset'}
+          cancelText={ language === 'japanese' ? 'キャンセル' : 'Cancel'}
+          closeText={ language === 'japanese' ? '閉じる' : 'Close' }
+          applyText={ language === 'japanese' ? '適用' : 'Apply' }
+          descendingText = { language === 'japanese' ? '降順' : 'Descending'}
+          ascendingText={ language === 'japanese' ? '昇順' : 'Ascending'}
         />
       </Wrapper>
     </Container>
   );
 };
+
+export default FilterDropdownWithFooterStory;

--- a/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
@@ -73,9 +73,9 @@ export const DropdownWithApplyAndReset = () => {
     cancelAction();
   }, [cancelAction]);
 
-  const handleApply = useCallback(() => {
-    applyAction(selected);
-  }, [applyAction, selected]);
+  const handleApply = useCallback((newSelection: IFilterValue) => {
+    applyAction(newSelection);
+  }, [applyAction]);
 
   return (
     <Container>
@@ -98,7 +98,7 @@ export const DropdownWithApplyAndReset = () => {
           onSelect={handleSelect}
           onReset={handleReset}
           onCancel={handleCancel}
-          onApply={handleApply}
+          onApplyCallback={handleApply}
           hasReset={hasReset}
           hasApply={hasApply}
         />

--- a/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import styled from 'styled-components';
-import { boolean, text, select } from "@storybook/addon-knobs";
+import { boolean, select } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
 import {
   FilterDropdown,
@@ -63,7 +63,6 @@ export const DropdownWithApplyAndReset = () => {
   // Action trackers
   const resetAction = action('Reset clicked');
   const cancelAction = action('Cancel/Close clicked');
-  const applyAction = action('Apply clicked');
   const selectAction = action('Item selected');
   const hasApply = boolean('Has Apply', true);
   const hasReset = boolean('Has Reset', true);
@@ -81,12 +80,6 @@ export const DropdownWithApplyAndReset = () => {
   const handleCancel = useCallback(() => {
     cancelAction();
   }, [cancelAction]);
-
-  const handleApply = useCallback((newSelection: IFilterValue) => {
-    setSelected(newSelection);
-    applyAction(newSelection);
-  }, [applyAction]);
-
 
   return (
     <Container>
@@ -109,7 +102,6 @@ export const DropdownWithApplyAndReset = () => {
           onSelect={handleSelect}
           onResetCallback={handleReset}
           onCancelCallback={handleCancel}
-          onApplyCallback={handleApply}
           hasReset={hasReset}
           hasApply={hasApply}
           resetText={ language === 'japanese' ? 'リセット' : 'Reset'}

--- a/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterDropdownWithFooter.stories.tsx
@@ -74,6 +74,7 @@ export const DropdownWithApplyAndReset = () => {
   }, [cancelAction]);
 
   const handleApply = useCallback((newSelection: IFilterValue) => {
+    setSelected(newSelection);
     applyAction(newSelection);
   }, [applyAction]);
 
@@ -96,8 +97,8 @@ export const DropdownWithApplyAndReset = () => {
           searchResultText="Showing [VISIBLE] of [TOTAL]"
           optionType="checkbox"
           onSelect={handleSelect}
-          onReset={handleReset}
-          onCancel={handleCancel}
+          onResetCallback={handleReset}
+          onCancelCallback={handleCancel}
           onApplyCallback={handleApply}
           hasReset={hasReset}
           hasApply={hasApply}

--- a/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
@@ -91,7 +91,7 @@ interface IFilterDropHandler {
 }
 
 export interface FilterDropHandlerRef {
-  cancelClose: () => void;
+  imperativeClose: () => void;
 }
 
 const FilterDropHandler = forwardRef<FilterDropHandlerRef, IFilterDropHandler>(
@@ -153,16 +153,16 @@ const FilterDropHandler = forwardRef<FilterDropHandlerRef, IFilterDropHandler>(
       });
     }, [onToggleOpenCallback, openState.isOpen]);
 
-    const handleCancel = useCallback(() => {
+    const handleImperativeClose = useCallback(() => {
       setOpenState((prev) => {
         const isOpen = false;
         return { ...prev, isOpen };
       });
     }, []);
 
-    // Expose cancelClose method via ref
+    // Expose imperativeClose method via ref
     useImperativeHandle(imperativeRef, () => ({
-      cancelClose: handleCancel,
+      imperativeClose: handleImperativeClose,
     }));
 
     return (

--- a/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
@@ -12,7 +12,7 @@ const ButtonWrapper = styled.div`
   display: inline-block;
 `;
 
-const ContentBox = styled.div<{ openState: IDropOpen, disabled: boolean, minWidth: number }>`
+const  ContentBox = styled.div<{ openState: IDropOpen, disabled: boolean, minWidth: number }>`
   z-index: 100;
   min-width: ${({ minWidth }) => minWidth}px;
   position: absolute;

--- a/packages/ui-lib/src/Filters/atoms/FilterDropdownContainer.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterDropdownContainer.tsx
@@ -9,7 +9,9 @@ const Container = styled.div<{ height?: string }>`
   };
 
   backdrop-filter: blur(20px);
-  border: var(--grey-6) 1px solid;
+  border-right: 1px solid var(--grey-6);
+  border-bottom: 1px solid var(--grey-6);
+  border-left: 1px solid var(--grey-6);
   border-radius: 3px;
   position: relative;
   display: inline-flex;

--- a/packages/ui-lib/src/Filters/atoms/FooterControls.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FooterControls.tsx
@@ -58,7 +58,7 @@ const FooterControls: React.FC<IFooterControls> = ({
   return (
     <FooterContainer>
       <FooterLeftSection>
-        {hasReset && <Button size='small' disabled={disableReset} onClick={onReset}>{resetText}</Button>}
+        {hasReset && <Button size='small' design="text-only" disabled={disableReset} onClick={onReset}>{resetText}</Button>}
       </FooterLeftSection>
       {hasApply && (
         <FooterRightSection>

--- a/packages/ui-lib/src/Filters/atoms/FooterControls.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FooterControls.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from '../../Form/atoms/Button';
+
+const FooterContainer = styled.div`
+  display: flex;
+  padding: 8px;
+  justify-content: space-between;
+  align-items: flex-start;
+  border-top: 1px solid var(--grey-6);
+  background: var(--grey-a2);
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.05);
+`;
+
+const FooterLeftSection = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const FooterRightSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export interface IFooterControls {
+  resetText?: string
+  cancelText?: string
+  closeText?: string
+  applyText?: string
+  hasReset?: boolean
+  hasApply?: boolean
+  disableApply?: boolean
+  isCancellable?: boolean
+  onReset?: () => void
+  onCancel?: () => void
+  onApply?: () => void
+}
+
+const FooterControls: React.FC<IFooterControls> = ({
+  resetText = 'Reset',
+  cancelText = 'Cancel',
+  closeText = 'Close',
+  applyText = 'Apply',
+  hasReset = false,
+  hasApply = false,
+  disableApply = false,
+  isCancellable = false,
+  onReset = () => { },
+  onCancel = () => { },
+  onApply = () => { },
+}) => {
+  return (
+    <FooterContainer>
+      <FooterLeftSection>
+        {hasReset && <Button size='small' onClick={onReset}>{resetText}</Button>}
+      </FooterLeftSection>
+      {hasApply && (
+        <FooterRightSection>
+          <Button size='small' design='secondary' onClick={onCancel}>{isCancellable ? cancelText: closeText}</Button>
+          <Button size='small' onClick={onApply} disabled={disableApply}>
+            {applyText}
+          </Button>
+        </FooterRightSection>
+      )}
+    </FooterContainer>
+  );
+};
+
+export default FooterControls;

--- a/packages/ui-lib/src/Filters/atoms/FooterControls.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FooterControls.tsx
@@ -23,7 +23,13 @@ const FooterRightSection = styled.div`
   gap: 8px;
 `;
 
-export interface IFooterControls {
+interface OwnProps {
+  onReset?: () => void
+  onCancel?: () => void
+  onApply?: () => void
+}
+
+export interface IFilterFooterControls {
   resetText?: string
   cancelText?: string
   closeText?: string
@@ -31,11 +37,10 @@ export interface IFooterControls {
   hasReset?: boolean
   hasApply?: boolean
   disableApply?: boolean
-  isCancellable?: boolean
-  onReset?: () => void
-  onCancel?: () => void
-  onApply?: () => void
+  disableReset?: boolean
 }
+
+type IFooterControls = OwnProps & IFilterFooterControls
 
 const FooterControls: React.FC<IFooterControls> = ({
   resetText = 'Reset',
@@ -45,7 +50,7 @@ const FooterControls: React.FC<IFooterControls> = ({
   hasReset = false,
   hasApply = false,
   disableApply = false,
-  isCancellable = false,
+  disableReset = true,
   onReset = () => { },
   onCancel = () => { },
   onApply = () => { },
@@ -53,14 +58,12 @@ const FooterControls: React.FC<IFooterControls> = ({
   return (
     <FooterContainer>
       <FooterLeftSection>
-        {hasReset && <Button size='small' onClick={onReset}>{resetText}</Button>}
+        {hasReset && <Button size='small' disabled={disableReset} onClick={onReset}>{resetText}</Button>}
       </FooterLeftSection>
       {hasApply && (
         <FooterRightSection>
-          <Button size='small' design='secondary' onClick={onCancel}>{isCancellable ? cancelText: closeText}</Button>
-          <Button size='small' onClick={onApply} disabled={disableApply}>
-            {applyText}
-          </Button>
+          <Button size='small' design='secondary' onClick={onCancel}>{disableApply ? closeText : cancelText }</Button>
+          <Button size='small' onClick={onApply} disabled={disableApply}>{applyText}</Button>
         </FooterRightSection>
       )}
     </FooterContainer>

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -95,7 +95,7 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
       setMountedPicker({ initialValue: validInitialValue, isMount: false });
     }
     onCancelCallback();
-    DropdownHandlerRef.current?.cancelClose();
+    DropdownHandlerRef.current?.imperativeClose();
   }, [onCancelCallback, selected]);
 
 
@@ -103,7 +103,7 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
     if (pickerValue.current && (pickerValue.current !== selected)) {
       onApplyCallback(pickerValue.current);
     }
-    DropdownHandlerRef.current?.cancelClose();
+    DropdownHandlerRef.current?.imperativeClose();
   },[onApplyCallback, selected]);
 
   /**

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -349,18 +349,17 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
     setTempSelected(selected);
     setDisableReset(true);
     onCancelCallback();
-    DropdownHandlerRef.current?.cancelClose();
+    DropdownHandlerRef.current?.imperativeClose();
   },[onCancelCallback, selected]);
 
   const handleApply = useCallback(()=>{
     setDisableReset(true);
     onApplyCallback(tempSelected);
-    DropdownHandlerRef.current?.cancelClose();
+    DropdownHandlerRef.current?.imperativeClose();
 },[onApplyCallback, tempSelected]);
 
 
 const handleReset = useCallback(() => {
-  console.log('selected', selected);
   if(!hasApply){
     onSelect(selected);
   }

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -64,6 +64,7 @@ const ResultCounter = styled.div`
   color: var(--grey-11);
   font-size: 12px;
   text-align: center;
+  white-space: nowrap;
   &:lang(ja) {
       font-style: normal;
   }
@@ -160,7 +161,7 @@ const sortList = (unSortedList: IFilterItem[], isSortAscending: boolean): IFilte
   const sorted = [...unSortedList];
 
   sorted.sort((a, b) => {
-    const diff = a.text.localeCompare(b.text);
+    const diff = a.text.localeCompare(b.text); // need to add comparison Ja and En
 
     return isSortAscending ? diff : -diff;
   });
@@ -283,7 +284,6 @@ export type IFilterDropdownOwn = {
   descendingText?: string
   isListAscending?: boolean
   onSelect: (newSelection: IFilterValue) => void;
-  onApplyCallback?: (newSelection: IFilterValue) => void;
   onResetCallback?: () => void
   onCancelCallback?: () => void
 }
@@ -315,7 +315,6 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   ascendingText = 'Ascending',
   isListAscending = true,
   onSelect = () => { },
-  onApplyCallback = () => { },
   onResetCallback = () => { },
   onCancelCallback = () => { },
   ...props
@@ -371,11 +370,11 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
     onCancelCallback();
     DropdownHandlerRef.current?.imperativeClose();
   }, [onCancelCallback, selected]);
+const handleApply = useCallback(() => {
+  onSelect(tempSelected);
+  DropdownHandlerRef.current?.imperativeClose();
+}, [onSelect, tempSelected]);
 
-  const handleApply = useCallback(() => {
-    onApplyCallback(tempSelected);
-    DropdownHandlerRef.current?.imperativeClose();
-  }, [onApplyCallback, tempSelected]);
 
 
   const handleReset = useCallback(() => {

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -42,10 +42,10 @@ const SortingButtonWrapper = styled.div`
   height: 24px;
   padding: 0px 8px;
   align-items: center;
-  justify-content: center;
+  justify-content: left;
   gap: 8px;
   border-left: 1px solid var(--grey-6);
-  min-width: 120px;
+  width: auto;
 `;
 
 const FilterResultsToolbar = styled.div`

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -232,6 +232,7 @@ export type IFilterDropdownOwn = {
   emptyResultText?: string
   design?: FilterButtonDesign
   onSelect: (newSelection: IFilterValue) => void;
+  onApplyCallback?: (newSelection: IFilterValue) => void;
 }
 
 export type IFilterDropdown = IFilterDropdownOwn & IFooterControls
@@ -254,11 +255,13 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   hasApply,
   hasReset,
   onSelect = () => { },
+  onApplyCallback,
   ...props
 }) => {
 
   const [visibleList, setVisibleList] = useState(selectedOrderList(list, maxDisplayedItems, selected));
   const [searchText, setSearchText] = useState<string>('');
+  const [tempSelected, setTempSelected] = useState(selected);
 
   const DropdownHandlerRef = useRef<FilterDropHandlerRef>(null);
 
@@ -275,6 +278,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   const handleSelection = useCallback((item: IFilterItem) => {
     const newSelected = getNewSelected(item, selected, optionType);
     onSelect(newSelected);
+    setTempSelected(newSelected);
   }, [selected, optionType, onSelect]);
 
   const handleInputFilter = useCallback((e) => {
@@ -296,6 +300,13 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   const handleCancel =useCallback(() => {
     DropdownHandlerRef.current?.cancelClose();
   },[]);
+
+  const handleApply = useCallback(()=>{
+    if(onApplyCallback) {
+      onApplyCallback(tempSelected);
+    }
+
+},[onApplyCallback, tempSelected]);
 
   useEffect(() => {
     let isActive = true;
@@ -366,6 +377,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
             <FooterControls
               {...{ hasApply, hasReset }}
               onCancel={handleCancel}
+              onApply={handleApply}
             />)
           }
         </FilterDropdownContainer>

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -92,7 +92,7 @@ const EmptyResultText = styled.div`
   font-size: 12px;
 `;
 
-const Gradient = styled.div`
+const OptionListGradient = styled.div`
   position: absolute;
   bottom: 0px;
   height: 15px;
@@ -325,7 +325,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   const [searchText, setSearchText] = useState<string>('');
   const [tempSelected, setTempSelected] = useState(selected);
 
-  const DropdownHandlerRef = useRef<FilterDropHandlerRef>(null);
+  const dropdownHandlerRef = useRef<FilterDropHandlerRef>(null);
 
   const handleClose = useCallback(() => {
     setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, isSortAscending));
@@ -369,11 +369,11 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   const handleCancel = useCallback(() => {
     setTempSelected(selected);
     onCancelCallback();
-    DropdownHandlerRef.current?.imperativeClose();
+    dropdownHandlerRef.current?.imperativeClose();
   }, [onCancelCallback, selected]);
 const handleApply = useCallback(() => {
   onSelect(tempSelected);
-  DropdownHandlerRef.current?.imperativeClose();
+  dropdownHandlerRef.current?.imperativeClose();
 }, [onSelect, tempSelected]);
 
 
@@ -422,7 +422,7 @@ const handleApply = useCallback(() => {
   return (
     <Container {...props}>
       <FilterDropHandler
-        ref={DropdownHandlerRef}
+        ref={dropdownHandlerRef}
         {...{ buttonIcon, buttonText, disabled, design }}
         onCloseCallback={handleClose}
         onToggleOpenCallback={handleToggleOpen}
@@ -475,7 +475,7 @@ const handleApply = useCallback(() => {
 
                     : <EmptyResultText>{emptyResultText}</EmptyResultText>}
                 </OptionList>
-                {list.length > 5 && <Gradient />}
+                {list.length > 5 && <OptionListGradient />}
               </ResultsContainer>)}
 
           {(hasApply || hasReset) && (

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -159,9 +159,10 @@ const sortList = (unSortedList: IFilterItem[], isSortAscending: boolean): IFilte
   }
 
   const sorted = [...unSortedList];
+  const lang = document.documentElement.lang || 'en';
 
   sorted.sort((a, b) => {
-    const diff = a.text.localeCompare(b.text); // need to add comparison Ja and En
+    const diff = a.text.localeCompare(b.text, lang);
 
     return isSortAscending ? diff : -diff;
   });

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -323,19 +323,19 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   const [visibleList, setVisibleList] = useState(selectedOrderList(list, maxDisplayedItems, selected, isSortAscending));
   const [searchText, setSearchText] = useState<string>('');
   const [tempSelected, setTempSelected] = useState(selected);
-  const [disableReset, setDisableReset] = useState(true);
 
   const DropdownHandlerRef = useRef<FilterDropHandlerRef>(null);
 
   const handleClose = useCallback(() => {
-    setSearchText('');
     setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected,isSortAscending));
   }, [isSortAscending, list, maxDisplayedItems, tempSelected]);
 
   const handleToggleOpen = useCallback(() => {
     setSearchText('');
-    setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, isSortAscending));
-  }, [isSortAscending, list, maxDisplayedItems, tempSelected]);
+    setTempSelected(selected);
+    setIsSortAscending(isListAscending);
+    setVisibleList(selectedOrderList(list, maxDisplayedItems, selected, isListAscending));
+  }, [isListAscending, list, maxDisplayedItems, selected]);
 
   const handleSelection = useCallback((item: IFilterItem) => {
     const newSelected = getNewSelected(item, tempSelected, optionType);
@@ -346,7 +346,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
     }
     setTempSelected(newSelected);
     setVisibleList(selectedOrderList(list, maxDisplayedItems, newSelected, isSortAscending));
-    setDisableReset(false);
+    setSearchText('');
   }, [tempSelected, optionType, hasApply, list, maxDisplayedItems, isSortAscending, onSelect]);
 
   const handleInputFilter = useCallback((e) => {
@@ -363,18 +363,15 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
 
     // sending null so the filtered list doesn't force the selected values to appear.
     setVisibleList(selectedOrderList(newList, maxDisplayedItems, null, isSortAscending));
-    setDisableReset(false);
   }, [isSortAscending, list, maxDisplayedItems, tempSelected]);
 
   const handleCancel = useCallback(() => {
     setTempSelected(selected);
-    setDisableReset(true);
     onCancelCallback();
     DropdownHandlerRef.current?.imperativeClose();
   },[onCancelCallback, selected]);
 
   const handleApply = useCallback(()=>{
-    setDisableReset(true);
     onApplyCallback(tempSelected);
     DropdownHandlerRef.current?.imperativeClose();
 },[onApplyCallback, tempSelected]);
@@ -387,7 +384,6 @@ const handleReset = useCallback(() => {
   setSearchText('');
   setVisibleList(selectedOrderList(list, maxDisplayedItems, null, isListAscending));
   setTempSelected(null);
-  setDisableReset(true);
   setIsSortAscending(isListAscending);
   onResetCallback();
 }, [hasApply, list, maxDisplayedItems, isListAscending, onResetCallback, onSelect]);
@@ -399,20 +395,6 @@ const handleSort = useCallback(() => {
   });
 
 },[list, maxDisplayedItems, tempSelected]);
-
-
-  useEffect(() => {
-    let isActive = true;
-    if (isActive && !hasApply) {
-      setSearchText(''); // clears searchText if something was selected and the dropdown is still open
-      setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, isSortAscending));
-    }
-
-    return () => {
-      isActive = false;
-    };
-
-  }, [hasApply, list, maxDisplayedItems, tempSelected, isSortAscending]);
 
 useEffect(() => {
   setTempSelected(selected);
@@ -488,7 +470,7 @@ const noChangeInSelection = useMemo(() => {
               onApply={handleApply}
               disableApply={noChangeInSelection}
               onReset={handleReset}
-              disableReset={disableReset && (isSortAscending === isListAscending)}
+              disableReset={(tempSelected === null) && (isSortAscending === isListAscending) && (searchText === '')}
             />)
           }
         </FilterDropdownContainer>

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -20,8 +20,8 @@ const StyledFilterOption = styled(FilterOption)`
   letter-spacing: 0.2px;
 `;
 
-const OptionList = styled.div<{moreItem?: boolean}>`
-  max-height: ${({moreItem}) => moreItem ? '228px' : '196px'};
+const OptionList = styled.div<{ moreItem?: boolean }>`
+  max-height: ${({ moreItem }) => moreItem ? '228px' : '196px'};
   min-height: 40px;
   position: relative;
   overflow-y: auto;
@@ -42,6 +42,7 @@ const OrderButtonWrapper = styled.div`
   height: 24px;
   padding: 0px 8px;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   border-left: 1px solid var(--grey-6);
   min-width: 120px;
@@ -62,10 +63,10 @@ const ResultCounter = styled.div`
   font-family: var(--font-ui);
   color: var(--grey-11);
   font-size: 12px;
+  text-align: center;
   &:lang(ja) {
       font-style: normal;
   }
-  font-weight: 500;
   line-height: 12px;
 `;
 
@@ -150,16 +151,16 @@ const getNewSelected = (item: IFilterItem, selected: IFilterValue, optionType: I
   return item;
 };
 
-const sortList = (unSortedList: IFilterItem[], isSortAscending: boolean ): IFilterItem[] => {
+const sortList = (unSortedList: IFilterItem[], isSortAscending: boolean): IFilterItem[] => {
 
-  if(unSortedList.length <= 1){
+  if (unSortedList.length <= 1) {
     return unSortedList;
   }
 
   const sorted = [...unSortedList];
 
-  sorted.sort((a,b) => {
-    const diff =  a.text.localeCompare(b.text);
+  sorted.sort((a, b) => {
+    const diff = a.text.localeCompare(b.text);
 
     return isSortAscending ? diff : -diff;
   });
@@ -231,7 +232,7 @@ const getResultText = (template: string, visible: number, total: number) => {
   return newMessage.replace('[VISIBLE]', `${visible}`);
 };
 
-const areSelectionsEqual = (tempSelected: IFilterValue, selected: IFilterValue) : boolean => {
+const areSelectionsEqual = (tempSelected: IFilterValue, selected: IFilterValue): boolean => {
 
   if (tempSelected === null && selected === null) {
     return true;
@@ -316,7 +317,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   onSelect = () => { },
   onApplyCallback = () => { },
   onResetCallback = () => { },
-  onCancelCallback = () => {},
+  onCancelCallback = () => { },
   ...props
 }) => {
   const [isSortAscending, setIsSortAscending] = useState(isListAscending);
@@ -327,7 +328,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
   const DropdownHandlerRef = useRef<FilterDropHandlerRef>(null);
 
   const handleClose = useCallback(() => {
-    setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected,isSortAscending));
+    setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, isSortAscending));
   }, [isSortAscending, list, maxDisplayedItems, tempSelected]);
 
   const handleToggleOpen = useCallback(() => {
@@ -341,7 +342,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
     const newSelected = getNewSelected(item, tempSelected, optionType);
 
     // onSelect is unavailable if hasApply feature is enabled to prevent misusage
-    if(!hasApply) {
+    if (!hasApply) {
       onSelect(newSelected);
     }
     setTempSelected(newSelected);
@@ -369,40 +370,53 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
     setTempSelected(selected);
     onCancelCallback();
     DropdownHandlerRef.current?.imperativeClose();
-  },[onCancelCallback, selected]);
+  }, [onCancelCallback, selected]);
 
-  const handleApply = useCallback(()=>{
+  const handleApply = useCallback(() => {
     onApplyCallback(tempSelected);
     DropdownHandlerRef.current?.imperativeClose();
-},[onApplyCallback, tempSelected]);
+  }, [onApplyCallback, tempSelected]);
 
 
-const handleReset = useCallback(() => {
-  if(!hasApply){
-    onSelect(null);
-  }
-  setSearchText('');
-  setVisibleList(selectedOrderList(list, maxDisplayedItems, null, isListAscending));
-  setTempSelected(null);
-  setIsSortAscending(isListAscending);
-  onResetCallback();
-}, [hasApply, list, maxDisplayedItems, isListAscending, onResetCallback, onSelect]);
+  const handleReset = useCallback(() => {
+    if (!hasApply) {
+      onSelect(null);
+    }
+    setSearchText('');
+    setVisibleList(selectedOrderList(list, maxDisplayedItems, null, isListAscending));
+    setTempSelected(null);
+    setIsSortAscending(isListAscending);
+    onResetCallback();
+  }, [hasApply, list, maxDisplayedItems, isListAscending, onResetCallback, onSelect]);
 
-const handleSort = useCallback(() => {
-  setIsSortAscending((prev) =>  {
-    setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, !prev));
-    return !prev;
-  });
+  const handleSort = useCallback(() => {
+    setIsSortAscending((prev) => {
+      setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, !prev));
+      return !prev;
+    });
 
-},[list, maxDisplayedItems, tempSelected]);
+  }, [list, maxDisplayedItems, tempSelected]);
 
-useEffect(() => {
-  setTempSelected(selected);
-}, [selected]);
+  useEffect(() => {
+    let isActive = true;
+    if (isActive) {
+      setSearchText(''); // clears searchText if something was selected and the dropdown is still open
+      setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, isSortAscending));
+    }
 
-const noChangeInSelection = useMemo(() => {
-  return areSelectionsEqual(tempSelected, selected);
-}, [selected, tempSelected]);
+    return () => {
+      isActive = false;
+    };
+
+  }, [isSortAscending, list, maxDisplayedItems, tempSelected]);
+
+  useEffect(() => {
+    setTempSelected(selected);
+  }, [selected]);
+
+  const noChangeInSelection = useMemo(() => {
+    return areSelectionsEqual(tempSelected, selected);
+  }, [selected, tempSelected]);
 
   return (
     <Container {...props}>
@@ -437,10 +451,10 @@ const noChangeInSelection = useMemo(() => {
                   <ResultsMiddleGroup>
                     <ResultCounter>{getResultText(searchResultText, visibleList.length, list.length)}</ResultCounter>
                     <OrderButtonWrapper>
-                      <ButtonWithIcon design='text-only' position='left' size='xsmall' onClick={handleSort} icon={isSortAscending? 'FilterAscending' : 'FilterDescending'}>{isSortAscending? ascendingText : descendingText}</ButtonWithIcon>
+                      <ButtonWithIcon design='text-only' position='left' size='xsmall' weight='light' onClick={handleSort} icon={isSortAscending ? 'FilterAscending' : 'FilterDescending'}>{isSortAscending ? ascendingText : descendingText}</ButtonWithIcon>
                     </OrderButtonWrapper>
                   </ResultsMiddleGroup>
-                  )}
+                )}
                 <OptionList moreItem={list.length > 5}>
                   {(visibleList.length > 0)
 
@@ -465,7 +479,7 @@ const noChangeInSelection = useMemo(() => {
 
           {(hasApply || hasReset) && (
             <FooterControls
-              {...{ hasApply, hasReset, resetText, cancelText, closeText,applyText }}
+              {...{ hasApply, hasReset, resetText, cancelText, closeText, applyText }}
               onCancel={handleCancel}
               onApply={handleApply}
               disableApply={noChangeInSelection}

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -37,7 +37,7 @@ const ResultsContainer = styled.div`
   min-width: 252px;
 `;
 
-const OrderButtonWrapper = styled.div`
+const SortingButtonWrapper = styled.div`
   display: flex;
   height: 24px;
   padding: 0px 8px;
@@ -451,9 +451,9 @@ const handleApply = useCallback(() => {
                 {hasOptionsFilter && (
                   <FilterResultsToolbar>
                     <ResultCounter>{getResultText(searchResultText, visibleList.length, list.length)}</ResultCounter>
-                    <OrderButtonWrapper>
+                    <SortingButtonWrapper>
                       <ButtonWithIcon design='text-only' position='left' size='xsmall' weight='light' onClick={handleSort} icon={isSortAscending ? 'FilterAscending' : 'FilterDescending'}>{isSortAscending ? ascendingText : descendingText}</ButtonWithIcon>
-                    </OrderButtonWrapper>
+                    </SortingButtonWrapper>
                   </FilterResultsToolbar>
                 )}
                 <OptionList moreItem={list.length > 5}>

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -48,7 +48,7 @@ const OrderButtonWrapper = styled.div`
   min-width: 120px;
 `;
 
-const ResultsMiddleGroup = styled.div`
+const FilterResultsToolbar = styled.div`
   display: flex;
   height: 24px;
   padding-left: 16px;
@@ -397,6 +397,7 @@ const handleApply = useCallback(() => {
 
   }, [list, maxDisplayedItems, tempSelected]);
 
+  // This UseEffect ensures visible list is updated when toggling language
   useEffect(() => {
     let isActive = true;
     if (isActive) {
@@ -448,12 +449,12 @@ const handleApply = useCallback(() => {
             : (
               <ResultsContainer>
                 {hasOptionsFilter && (
-                  <ResultsMiddleGroup>
+                  <FilterResultsToolbar>
                     <ResultCounter>{getResultText(searchResultText, visibleList.length, list.length)}</ResultCounter>
                     <OrderButtonWrapper>
                       <ButtonWithIcon design='text-only' position='left' size='xsmall' weight='light' onClick={handleSort} icon={isSortAscending ? 'FilterAscending' : 'FilterDescending'}>{isSortAscending ? ascendingText : descendingText}</ButtonWithIcon>
                     </OrderButtonWrapper>
-                  </ResultsMiddleGroup>
+                  </FilterResultsToolbar>
                 )}
                 <OptionList moreItem={list.length > 5}>
                   {(visibleList.length > 0)

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -216,6 +216,39 @@ const getResultText = (template: string, visible: number, total: number) => {
   return newMessage.replace('[VISIBLE]', `${visible}`);
 };
 
+const areSelectionsEqual = (tempSelected: IFilterValue, selected: IFilterValue) : boolean => {
+  // If both are null, they are equal
+  if (tempSelected === null && selected === null) {
+    return true;
+  }
+
+  // If only one is null, they are not equal
+  if (tempSelected === null || selected === null) {
+    return false;
+  }
+
+  // If both are arrays
+  if (Array.isArray(tempSelected) && Array.isArray(selected)) {
+    // If arrays have different lengths, they are not equal
+    if (tempSelected.length !== selected.length) {
+      return false;
+    }
+
+    // Check if every item in tempSelected exists in selected with the same value
+    return tempSelected.every(tempItem =>
+      selected.some(selectedItem => selectedItem.value === tempItem.value)
+    );
+  }
+
+  // If one is array and the other is not, they are not equal
+  if (Array.isArray(tempSelected) || Array.isArray(selected)) {
+    return false;
+  }
+
+  // Both are single IFilterItem objects, compare their values
+  return tempSelected.value === selected.value;
+};
+
 export type IFilterDropdownOwn = {
   buttonIcon: string
   buttonText: string
@@ -378,6 +411,7 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
               {...{ hasApply, hasReset }}
               onCancel={handleCancel}
               onApply={handleApply}
+              disableApply={areSelectionsEqual(tempSelected, selected)}
             />)
           }
         </FilterDropdownContainer>

--- a/packages/ui-lib/src/Form/atoms/Button.tsx
+++ b/packages/ui-lib/src/Form/atoms/Button.tsx
@@ -46,6 +46,7 @@ const StyledButton = styled.button<IStyledComponentProps>`
   height: var(--button-height);
   font-size: var(--button-font-size);
   color: var(--button-text-color);
+  font-weight: 600;
 
   ${({ $noPadding, isOutline }) => $noPadding ? css`
       padding: 0px;

--- a/packages/ui-lib/src/Form/atoms/Button.tsx
+++ b/packages/ui-lib/src/Form/atoms/Button.tsx
@@ -46,7 +46,6 @@ const StyledButton = styled.button<IStyledComponentProps>`
   height: var(--button-height);
   font-size: var(--button-font-size);
   color: var(--button-text-color);
-  font-weight: 600;
 
   ${({ $noPadding, isOutline }) => $noPadding ? css`
       padding: 0px;

--- a/packages/ui-lib/src/Form/atoms/ButtonWithIcon.tsx
+++ b/packages/ui-lib/src/Form/atoms/ButtonWithIcon.tsx
@@ -4,12 +4,13 @@ import Button from './Button';
 import Icon from '../../Icons/Icon';
 import Spinner from '../../Indicators/Spinner';
 import { IButtonProps, TypeButtonSizes } from '..';
+import { IWeight } from '../..';
 
 const Container = styled.div`
   display: inline;
 `;
 
-const TextContainer = styled.div<{size: TypeButtonSizes, position?: string}>`
+const TextContainer = styled.div<{ size: TypeButtonSizes, position?: string, weight?: IWeight }>`
   height: inherit;
   flex: 1;
   order: 1;
@@ -18,8 +19,8 @@ const TextContainer = styled.div<{size: TypeButtonSizes, position?: string}>`
   align-items: center;
   white-space: nowrap;
   padding: 0 var(--button-h-padding);
-
   transition: padding var(--speed-slow) var(--easing-primary-in-out);
+  font-weight: ${({weight}) => weight === 'light' ? '500' : '600'};
 `;
 
 const IconContainer = styled.div`
@@ -53,8 +54,8 @@ const IconArea = styled.div<{ position?: string, $loading: boolean }>`
   padding: 0 var(--button-h-padding);
 
   ${({ position }) => css`
-    order: ${ position && position === 'left' ? 0 : 2 };
-    ${ position === 'left'
+    order: ${position && position === 'left' ? 0 : 2};
+    ${position === 'left'
       ? `border-right-width: 1px;`
       : `border-left-width: 1px;`
     };
@@ -75,7 +76,7 @@ const IconArea = styled.div<{ position?: string, $loading: boolean }>`
     transition: opacity var(--speed-fast) var(--easing-primary-out);
   }
 
-  ${({$loading}) => $loading && css`
+  ${({ $loading }) => $loading && css`
     border-color: var(--button-loading-area-divider-color);
 
     ${SpinnerContainer}{
@@ -89,12 +90,12 @@ const IconArea = styled.div<{ position?: string, $loading: boolean }>`
 
 `;
 
-const InnerContainer = styled.div<{disabled?: boolean}>`
+const InnerContainer = styled.div<{ disabled?: boolean }>`
   display: flex;
   height: inherit;
 
   &:hover {
-    ${({disabled}) => !disabled && css`
+    ${({ disabled }) => !disabled && css`
       ${IconContainer}{
         svg {
           path, rect, circle, d {
@@ -106,7 +107,7 @@ const InnerContainer = styled.div<{disabled?: boolean}>`
   }
 
   &:active{
-    ${({disabled}) => !disabled && css`
+    ${({ disabled }) => !disabled && css`
       ${IconContainer}{
         svg {
           path, rect, circle, d {
@@ -117,7 +118,7 @@ const InnerContainer = styled.div<{disabled?: boolean}>`
     `};
   }
 
-  ${({disabled}) => disabled && css`
+  ${({ disabled }) => disabled && css`
     ${IconContainer}{
         svg {
           path, rect, circle, d {
@@ -132,25 +133,27 @@ export interface IButtonWithIcon extends IButtonProps {
   icon: string
   position?: 'left' | 'right'
   shadow?: boolean
+  weight?: IWeight
 }
 
-const ButtonWithIcon : React.FC<IButtonWithIcon> = ({design = 'primary', size='normal', loading = false, shadow = false, onClick, disabled, position, icon, children, ...props}) => {
+const ButtonWithIcon: React.FC<IButtonWithIcon> = ({ design = 'primary', size = 'normal', loading = false, shadow = false, onClick, disabled, position, icon, weight = 'regular', children, ...props }) => {
   return (
     <Container>
       <Button noPadding disabled={disabled || loading} {...{ design, size, shadow, onClick, loading }} {...props}>
-        <InnerContainer {...{disabled, loading}}>
-          <TextContainer {...{size, position}}>{children}</TextContainer>
+        <InnerContainer {...{ disabled, loading }}>
+          <TextContainer {...{ size, position, weight }}>{children}</TextContainer>
           <IconArea $loading={loading} {...{ position }}>
             <IconContainer>
-              <Icon icon={icon} weight='regular' />
+              <Icon icon={icon} weight={weight} />
             </IconContainer>
             <SpinnerContainer>
-              <Spinner size={size ==='xsmall' || size ==='small' ? 'xsmall' : 'small'} styling={design} />
+              <Spinner size={size === 'xsmall' || size === 'small' ? 'xsmall' : 'small'} styling={design} />
             </SpinnerContainer>
           </IconArea>
         </InnerContainer>
       </Button>
     </Container>
-  );};
+  );
+};
 
 export default ButtonWithIcon;

--- a/packages/ui-lib/src/Form/index.ts
+++ b/packages/ui-lib/src/Form/index.ts
@@ -63,7 +63,6 @@ export type TypeButtonDesigns = 'primary' | 'secondary' | 'warning' | 'danger' |
 export type TypeButtonSizes = 'xsmall' | 'small' | 'normal' | 'large';
 export type ISelectSizes = 'small' | 'normal';
 export type IInputOptionsType = "text" | "checkbox" | "radio";
-
 export type TypeLabelDirection = 'column' | 'row' | 'row-reverse';
 
 

--- a/packages/ui-lib/src/Icons/Icon.tsx
+++ b/packages/ui-lib/src/Icons/Icon.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 import { IconSVGs } from '@future-standard/icons';
 
 import { dimensions } from '../theme/common';
+import { IWeight } from '..';
 
 
 const wrapperCss = css`
@@ -33,7 +34,7 @@ export { IconWrapper, IconWrapperForSVG, IconSVGs };
 export interface IconProps {
   icon: string;
   size?: number;
-  weight?: 'light' | 'regular' | 'heavy' | 'strong';
+  weight?: IWeight;
   color?: ISvgIcons['color'];
   forSvgUsage?: boolean;
 }

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -383,7 +383,7 @@ export type IFeedbackColor = 'error' | 'warning' | 'info' | 'success' | 'neutral
 export type ITimeUnit = 'seconds' | 'minutes' | 'hours';
 export type IMediaType = 'img' | 'video'
 export type IStatusDot = 'caution' | 'danger' | 'good' | 'neutral' | 'highlight';
-export type IWeight= 'light' | 'regular' | 'heavy' | 'strong';  // Is this the right place?
+export type IWeight = 'light' | 'regular' | 'heavy' | 'strong';  // Is this the right place?
 
 export type {
   IModal,

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -383,7 +383,7 @@ export type IFeedbackColor = 'error' | 'warning' | 'info' | 'success' | 'neutral
 export type ITimeUnit = 'seconds' | 'minutes' | 'hours';
 export type IMediaType = 'img' | 'video'
 export type IStatusDot = 'caution' | 'danger' | 'good' | 'neutral' | 'highlight';
-export type IWeight = 'light' | 'regular' | 'heavy' | 'strong';  // Is this the right place?
+export type IWeight = 'light' | 'regular' | 'heavy' | 'strong';
 
 export type {
   IModal,

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -383,6 +383,7 @@ export type IFeedbackColor = 'error' | 'warning' | 'info' | 'success' | 'neutral
 export type ITimeUnit = 'seconds' | 'minutes' | 'hours';
 export type IMediaType = 'img' | 'video'
 export type IStatusDot = 'caution' | 'danger' | 'good' | 'neutral' | 'highlight';
+export type IWeight= 'light' | 'regular' | 'heavy' | 'strong';  // Is this the right place?
 
 export type {
   IModal,

--- a/packages/ui-lib/src/theme/variables/Colors.ts
+++ b/packages/ui-lib/src/theme/variables/Colors.ts
@@ -722,7 +722,7 @@ export const colorVariables = css`
 
     .button-design-secondary {
       --button-background-color: var(--grey-9);
-      --button-border-color: var(--grey-9);
+      --button-border-color: var(--grey-6);
       --button-inner-shadow-color: transparent;
       --button-drop-shadow-color: var(--shadow-secondary-default);
       --button-text-color: var(--grey-12);


### PR DESCRIPTION
### Description

Filter Dropdown Interaction Improvements. The update will include:

- Adding optional Submit, Cancel and Reset buttons to each dropdown as a standard.
- Considerations for custom components to easily use the same dropdown UI pattern. 
*Possibly this goes in to the DropdownContainer component.*



 ### Considerations on Implementation
 
~Currently evaluating if onSelect property should become optional and callback be disabled if hasApply prop is provided.~
 onSelect will act as onApply 
 
Will Follow up in a different PR with 
 
 -> FilterBar correct integration and Storybook example
 -> Integration of Footer controls with Datepicker

New `IWeight` interface for Icons weight. It was added for the ButtonWithIcon to have font-weight for text and icon. It does not cause a breaking change,  but maybe there is a suggestion for a more polish version of this update. This was required for the `SortingButtonWrapper`  in the  `FilterResultsToolbar` of the `FilterDropdown`.

 ### Reviewing/Testing steps
 
 Run Storybook
 
 Filters -> Molecules -> FilterDropdown -> MultipleExamples

 -> Verify dropdown callbacks work when selection as previously to this implementation

 
 Filters -> Molecules -> FilterDropdown -> Dropdown With Apply and Reset
 
 
 - Review Dropdown interactions following the Design rules in Figma
 
 ```
- These new buttons will be shown if the filter pattern requires manual applying of changes.
- If we use the older pattern, these will not be shown.
- Apply will submit the values selected and close the dropdown.
- Cancel will revert any changes made and return to the currently active state for this filter.
- Reset will go the default state of the filter, for instance, no values selected, search empty and sorting reset. It will not close the dropdown.
- Buttons are disabled if there actions would not change anything, for example:
- Reset is disabled in the default state.
- Cancel is changed to Close when the filter set is the same as the active one.
- Apply is only active when there is different value to the current state.
- After a Reset, it is assumed that Apply will be disabled as it should meet those requirements described.
```

I’ve put together a [document]( https://docs.google.com/spreadsheets/d/1XG2n_Gh-lawRhCg6r3bmMtO1V6_v-m-3sM9OXuyb1s0/edit?usp=sharing 
) to demonstrate some button interactions, such as selection and reset.
Feel free to use it for reference or request changes if there are any mistakes.
 
 
### Screenshot and Video
   [Video Demo](https://drive.google.com/file/d/1ph5imm99nJU_ZYiLqZH1LR-ZYV2qynoW/view?usp=sharing)
   
<img width="1417" alt="Screenshot 2025-06-23 at 16 22 56" src="https://github.com/user-attachments/assets/ce02dac5-60b5-4e96-a2a2-52ea30c5f5e4" />


 
