### PR TITLE
Fixed eslint error with default exports

### DIFF
--- a/packages/storybook/src/stories/Alerts/AlertBar.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/AlertBar.stories.tsx
@@ -8,11 +8,11 @@ const Container = styled.div`
   margin: 100px;
 `;
 
-export default {
+const AlertBarStory = {
   title: 'Alerts/atoms',
   component: AlertBar,
   decorators: []
-};
+}
 
 export const _AlertBar = () => {
   const message = text("Message", 'Look Out!');
@@ -22,3 +22,5 @@ export const _AlertBar = () => {
   return <Container><AlertBar {...{message, type, hideCloseButton}} ></AlertBar></Container>;
 
 };
+
+export default AlertBarStory;

--- a/packages/storybook/src/stories/Alerts/MixAlerts/MixAlerts.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/MixAlerts/MixAlerts.stories.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
   row-gap: 15px;
 `;
 
-export default {
+const MixAlertsStory = {
   title: 'Alerts/Mix',
   components: useNotification,
   decorator: []
@@ -60,3 +60,5 @@ export const _MixAlertsExample = () => {
     </Container>
   );
 }
+
+export default MixAlertsStory;

--- a/packages/storybook/src/stories/Alerts/Modals/BaseModal.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/Modals/BaseModal.stories.tsx
@@ -10,7 +10,7 @@ import {
   IModal,
 } from 'scorer-ui-kit';
 
-export default {
+const BaseModalStory = {
   title: 'Alerts/Modals',
   components: ModalProvider,
   decorator: []
@@ -64,3 +64,5 @@ export const _BaseModal = () => {
     </Container>
   )
 }
+
+export default BaseModalStory;

--- a/packages/storybook/src/stories/Alerts/Modals/ConfirmationModal.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/Modals/ConfirmationModal.stories.tsx
@@ -12,7 +12,7 @@ import { TypeButtonDesigns } from 'scorer-ui-kit/dist/Form';
 
 const Container = styled.div``;
 
-export default {
+const ConfirmationModalStory = {
   title: 'Alerts/Modals',
   components: ConfirmationModal,
   decorator: []
@@ -91,3 +91,5 @@ export const _ConfirmationTemplate = () => {
     </ModalProvider>
   </Container>
 }
+
+export default ConfirmationModalStory;

--- a/packages/storybook/src/stories/Alerts/Modals/CustomModal.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/Modals/CustomModal.stories.tsx
@@ -9,7 +9,7 @@ import {
   IModal,
 } from 'scorer-ui-kit';
 
-export default {
+const CustomModalStory = {
   title: 'Alerts/Modals',
   components: LoginModalExample,
   decorator: []
@@ -57,3 +57,5 @@ export const _CustomExampleModal = () => {
     </Container>
   )
 }
+
+export default CustomModalStory;

--- a/packages/storybook/src/stories/Alerts/Modals/MediaModal.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/Modals/MediaModal.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from 'scorer-ui-kit';
 import { boolean, text } from '@storybook/addon-knobs';
 
-export default {
+const MediaModalStory = {
   title: 'Alerts/Modals',
   components: MediaBox,
   decorator: []
@@ -58,3 +58,5 @@ export const _MediaModal = () => {
     </Container>
   )
 }
+
+export default MediaModalStory;

--- a/packages/storybook/src/stories/Alerts/Notification.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/Notification.stories.tsx
@@ -18,7 +18,7 @@ const Container = styled.div`
   row-gap: 15px;
 `;
 
-export default {
+const NotificationStory = {
   title: 'Alerts/atoms',
   components: useNotification,
   decorator: []
@@ -83,3 +83,5 @@ export const _Notification = () => {
     </Container>
   );
 }
+
+export default NotificationStory;

--- a/packages/storybook/src/stories/Alerts/Tooltip.stories.tsx
+++ b/packages/storybook/src/stories/Alerts/Tooltip.stories.tsx
@@ -4,7 +4,7 @@ import { PageTitle, Tooltip } from "scorer-ui-kit";
 import { generateIconList } from "../helpers";
 import styled from "styled-components";
 
-export default {
+const TooltipStory = {
   title: 'Alerts/atoms',
   component: Tooltip,
   decorators: []
@@ -68,3 +68,5 @@ export const _Tooltip = () => {
     </Container>
   )
 }
+
+export default TooltipStory;

--- a/packages/storybook/src/stories/CameraPanels/organisms/CameraPanels.stories.tsx
+++ b/packages/storybook/src/stories/CameraPanels/organisms/CameraPanels.stories.tsx
@@ -6,7 +6,7 @@ import { generateIconList } from '../../helpers';
 import Photo from '../../assets/placeholder.jpg';
 import { action } from '@storybook/addon-actions';
 
-export default {
+const CameraPanelsStory = {
   title: 'CameraPanels/organisms',
   component: CameraPanels,
   decorators: []
@@ -143,3 +143,5 @@ export const _CameraPanels = () => {
     </Container>
   )
 }
+
+export default CameraPanelsStory;

--- a/packages/storybook/src/stories/Filters/atoms/FilterButton.stories.tsx
+++ b/packages/storybook/src/stories/Filters/atoms/FilterButton.stories.tsx
@@ -4,7 +4,7 @@ import { FilterButton } from 'scorer-ui-kit';
 import styled from 'styled-components';
 import { generateIconList } from '../../helpers';
 
-export default {
+const FilterButtonStory = {
   title: 'Filters/atoms',
   component: FilterButton,
   decorators: []
@@ -31,3 +31,5 @@ export const _FilterButton = () => {
     </FilterButton>
   </Content>
 }
+
+export default FilterButtonStory;

--- a/packages/storybook/src/stories/Filters/atoms/ToggleButton.stories.tsx
+++ b/packages/storybook/src/stories/Filters/atoms/ToggleButton.stories.tsx
@@ -4,7 +4,7 @@ import { boolean, object, select, text } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import styled from "styled-components";
 
-export default {
+const ToggleButtonStory = {
   title: 'Filters/atoms',
   component: ToggleButton,
   decorators: []
@@ -123,3 +123,5 @@ export const _ToggleButton = () => {
     </Container>
   )
 }
+
+export default ToggleButtonStory;

--- a/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/DatePicker.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { boolean, object, select, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
@@ -9,7 +9,7 @@ const Container = styled.div`
   margin: 20px;
 `;
 
-export default {
+const DatePickerStory = {
   title: 'Filters/molecules',
   component: DatePicker,
   decorators: [],
@@ -72,3 +72,5 @@ export const _DatePicker = () => {
       </FilterDropdownContainer>
     </Container>);
 };
+
+export default DatePickerStory;

--- a/packages/storybook/src/stories/Filters/molecules/FilterDropdown.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterDropdown.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../helpers/data_samples';
 import { generateIconList } from '../../helpers';
 
-export default {
+const FilterDropdownStory = {
   title: 'Filters/molecules',
   component: FilterDropdown,
   decorators: []
@@ -284,3 +284,5 @@ export const _FilterDropdown = () => {
     </Wrapper>
   </Content>
 };
+
+export default FilterDropdownStory;

--- a/packages/storybook/src/stories/Filters/molecules/FilterInputs.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterInputs.stories.tsx
@@ -32,7 +32,7 @@ import {
   clearJp,
 } from '../../helpers/data_samples';
 
-export default {
+const FilterInputsStory = {
   title: 'Filters/molecules',
   component: 'FilterInputs',
   decorators: []
@@ -274,3 +274,5 @@ export const _FilterInputs = () => {
       />
     </Container>)
 }
+
+export default FilterInputsStory;

--- a/packages/storybook/src/stories/Filters/molecules/FilterLayout.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/FilterLayout.stories.tsx
@@ -4,7 +4,7 @@ import { FilterLayout } from 'scorer-ui-kit';
 import { select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
-export default {
+const FilterLayoutStory = {
   title: 'Filters/molecules',
   component: FilterLayout,
   decorators: []
@@ -54,3 +54,5 @@ export const _FilterLayout = () => {
     </Container>
   )
 }
+
+export default FilterLayoutStory;

--- a/packages/storybook/src/stories/Filters/molecules/SortDropdown.stories.tsx
+++ b/packages/storybook/src/stories/Filters/molecules/SortDropdown.stories.tsx
@@ -4,7 +4,7 @@ import { IFilterItem, SortDropdown } from 'scorer-ui-kit';
 import { boolean, object, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
-export default {
+const SortDropdownStory = {
   title: 'Filters/molecules',
   component: SortDropdown,
   decorators: [],
@@ -68,3 +68,5 @@ export const _SortDropdown = () => {
     </Container>
   )
 }
+
+export default SortDropdownStory;

--- a/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
+++ b/packages/storybook/src/stories/Filters/organisms/FilterBar.stories.tsx
@@ -48,7 +48,7 @@ import {
 import { ITypeTableData } from 'scorer-ui-kit/dist/Tables';
 import { dataContentDays, datesRange, InitialSelectedDate } from '../../helpers/datePicker_sample';
 
-export default {
+const FilterBarStory = {
   title: 'Filters/Organism',
   component: 'FilterBar',
   decorators: []
@@ -280,3 +280,5 @@ export const _FilterBar = () => {
       </TypeTableWrapper>
     </Container>)
 }
+
+export default FilterBarStory;

--- a/packages/storybook/src/stories/Form/Buttons/Button.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/Button.stories.tsx
@@ -4,7 +4,7 @@ import {  text, select, boolean } from "@storybook/addon-knobs";
 import {Button} from 'scorer-ui-kit';
 
 
-export default {
+const ButtonStory = {
   title: 'Form/Buttons',
   component: Button,
   decorators: []
@@ -20,3 +20,5 @@ export const StandardButton = () => {
 
   return <Button design={buttonDesign} size={buttonSize} shadow={buttonShadow} onClick={buttonOnClick} disabled={buttonDisabled}>{buttonText}</Button>;
 };
+
+export default ButtonStory;

--- a/packages/storybook/src/stories/Form/Buttons/ButtonWithIcons.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/ButtonWithIcons.stories.tsx
@@ -4,7 +4,7 @@ import {  text, select, boolean } from "@storybook/addon-knobs";
 import {ButtonWithIcon} from 'scorer-ui-kit';
 import { generateIconList } from '../../helpers';
 
-export default {
+const ButtonWithIconsStory = {
   title: 'Form/Buttons',
   component: ButtonWithIcon,
   decorators: []
@@ -25,3 +25,5 @@ export const _WithIcon = () => {
 
   return <ButtonWithIcon design={buttonDesign} size={buttonSize} shadow={buttonShadow} onClick={buttonOnClick} icon={buttonIcon} position={buttonIconPosition} disabled={buttonDisabled} loading={buttonLoading}>{buttonText}</ButtonWithIcon>;
 };
+
+export default ButtonWithIconsStory;

--- a/packages/storybook/src/stories/Form/Buttons/ButtonWithLoading.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/ButtonWithLoading.stories.tsx
@@ -4,7 +4,7 @@ import {  text, select, boolean } from "@storybook/addon-knobs";
 import {ButtonWithLoading} from 'scorer-ui-kit';
 
 
-export default {
+const ButtonWithLoadingStory = {
   title: 'Form/Buttons',
   component: ButtonWithLoading,
   decorators: []
@@ -22,3 +22,5 @@ export const _WithLoading = () => {
 
   return <ButtonWithLoading design={buttonDesign} size={buttonSize} shadow={buttonShadow} onClick={buttonOnClick} loading={buttonLoading} position={buttonLoadingPosition} disabled={buttonDisabled}>{buttonText}</ButtonWithLoading>;
 };
+
+export default ButtonWithLoadingStory;

--- a/packages/storybook/src/stories/Form/Buttons/SplitButton.stories.tsx
+++ b/packages/storybook/src/stories/Form/Buttons/SplitButton.stories.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement, useEffect, useState } from "react";
 import { ISplitButtonProps, ModalProvider, SplitButton, useModal } from 'scorer-ui-kit';
 import styled from "styled-components";
 
-export default {
+const SplitButtonStory = {
   title: 'Form/Buttons',
   component: SplitButton,
   decorators: []
@@ -69,3 +69,5 @@ export const _SplitButton = () => {
     </ModalProvider>
   )
 }
+
+export default SplitButtonStory;

--- a/packages/storybook/src/stories/Form/Checkbox.stories.tsx
+++ b/packages/storybook/src/stories/Form/Checkbox.stories.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean } from "@storybook/addon-knobs";
 import {Checkbox} from 'scorer-ui-kit';
 
-export default {
+const CheckboxStory = {
   title: 'Form/atoms',
   component: Checkbox,
   decorators: []
@@ -18,3 +18,5 @@ export const _Checkbox = () => {
 
   return <Checkbox {...{checked, disabled, onChange}} />;
 };
+
+export default CheckboxStory;

--- a/packages/storybook/src/stories/Form/FileManagement/AreaUploadManager.stories.tsx
+++ b/packages/storybook/src/stories/Form/FileManagement/AreaUploadManager.stories.tsx
@@ -4,7 +4,7 @@ import { AreaUploadManager, PageHeader } from 'scorer-ui-kit';
 import { text, object, boolean } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
 
-export default {
+const AreaUploadManagerStory = {
   title: 'Form/File Management',
   component: AreaUploadManager,
   decorators: []
@@ -58,3 +58,5 @@ export const _AreaUploadManager = () => {
     </Container>
   )
 }
+
+export default AreaUploadManagerStory;

--- a/packages/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
+++ b/packages/storybook/src/stories/Form/FileManagement/AvatarUploader.stories.tsx
@@ -6,7 +6,7 @@ import { text, boolean } from "@storybook/addon-knobs";
 
 const Container = styled.div``;
 
-export default {
+const AvatarUploaderStory = {
   title: 'Form/File Management',
   component: AvatarUploader,
   decorators: []
@@ -66,3 +66,5 @@ export const _AvatarUploader = () => {
     </Container>
   )
 };
+
+export default AvatarUploaderStory;

--- a/packages/storybook/src/stories/Form/FileManagement/CropTool.stories.tsx
+++ b/packages/storybook/src/stories/Form/FileManagement/CropTool.stories.tsx
@@ -14,7 +14,7 @@ const CropResult = styled.img`
 
 const NewImageArea = styled.div``;
 
-export default {
+const CropToolStory = {
   title: 'Form/File Management',
   component: CropTool,
   decorators: [],
@@ -76,3 +76,5 @@ export const _CropTool = () => {
     </Container>
   )
 };
+
+export default CropToolStory;

--- a/packages/storybook/src/stories/Form/FileManagement/DropArea.stories.tsx
+++ b/packages/storybook/src/stories/Form/FileManagement/DropArea.stories.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
   max-width: 500px;
 `;
 
-export default {
+const DropAreaStory = {
   title: 'Form/File Management',
   component: DropArea,
   decorators:[]
@@ -41,3 +41,5 @@ export const _DropArea = () => {
     </Container>
   )
 };
+
+export default DropAreaStory;

--- a/packages/storybook/src/stories/Form/FileManagement/InputFileButton.stories.tsx
+++ b/packages/storybook/src/stories/Form/FileManagement/InputFileButton.stories.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
     margin: 20px;
 `;
 
-export default {
+const InputFileButtonStory = {
   title: 'Form/File Management',
   component: InputFileButton,
   decorators:[]
@@ -43,3 +43,5 @@ export const _InputFileButton = () => {
     </Container>
   )
 };
+
+export default InputFileButtonStory;

--- a/packages/storybook/src/stories/Form/Input/DurationSlider.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/DurationSlider.stories.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { DurationSlider, ISliderMark, PageHeader, ITimeUnit } from 'scorer-ui-kit';
 
 
-export default {
+const DurationSliderStory = {
   title: 'Form/Input',
   component: DurationSlider,
   decorators: []
@@ -327,3 +327,5 @@ export const _DurationSlider = () => {
     </Container>
   )
 }
+
+export default DurationSliderStory;

--- a/packages/storybook/src/stories/Form/Input/Input.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/Input.stories.tsx
@@ -7,7 +7,7 @@ const Container = styled.div`
     margin: 20px;
 `;
 
-export default {
+const InputStory = {
   title: 'Form/Input',
   component: TextField,
   decorators: []
@@ -39,3 +39,5 @@ export const TextInput = () => {
       required={fieldRequired} />
     </Container>;
 };
+
+export default InputStory;

--- a/packages/storybook/src/stories/Form/Input/PasswordInput.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/PasswordInput.stories.tsx
@@ -7,7 +7,7 @@ const Container = styled.div`
     margin: 20px;
 `;
 
-export default {
+const PasswordInputStory = {
   title: 'Form/Input',
   component: PasswordField,
   decorators: []
@@ -37,3 +37,5 @@ export const PasswordInput = () => {
   </Container>;
 
 };
+
+export default PasswordInputStory;

--- a/packages/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/PercentageSlider.stories.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import {PercentageSlider, ISliderMark, IFeedbackColor} from 'scorer-ui-kit';
 
 
-export default {
+const PercentageSliderStory = {
   title: 'Form/Input',
   component: PercentageSlider,
   decorators: []
@@ -98,3 +98,5 @@ export const _PercentageSlider = () => {
     </Container>
   )
 }
+
+export default PercentageSliderStory;

--- a/packages/storybook/src/stories/Form/Input/RadioButton.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/RadioButton.stories.tsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text } from "@storybook/addon-knobs";
 import { RadioButton, Label } from 'scorer-ui-kit';
 
-export default {
+const RadioButtonStory = {
   title: 'Form/Input',
   component: RadioButton,
   decorators: []
@@ -48,3 +48,5 @@ export const _RadioButton = () => {
     </Container>)
 
 }
+
+export default RadioButtonStory;

--- a/packages/storybook/src/stories/Form/Input/SliderInput.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/SliderInput.stories.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import {SliderInput, ISliderMark} from 'scorer-ui-kit';
 
 
-export default {
+const SliderInputStory = {
   title: 'Form/Input',
   component: SliderInput,
   decorators: []
@@ -83,3 +83,5 @@ export const _SliderInput = () => {
     </Container>
   )
 }
+
+export default SliderInputStory;

--- a/packages/storybook/src/stories/Form/Input/SmallInput.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/SmallInput.stories.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import {  text, select, boolean } from "@storybook/addon-knobs";
 import {SmallInput} from 'scorer-ui-kit';
 
-export default {
+const SmallInputStory = {
   title: 'Form/Input',
   component: SmallInput,
   decorators: []
@@ -39,3 +39,5 @@ export const _SmallInput = () => {
   </Container>;
 
 };
+
+export default SmallInputStory;

--- a/packages/storybook/src/stories/Form/Input/TextAreaField.stories.tsx
+++ b/packages/storybook/src/stories/Form/Input/TextAreaField.stories.tsx
@@ -7,7 +7,7 @@ const Container = styled.div`
   margin: 20px;
 `;
 
-export default {
+const TextAreaFieldStory = {
   title: 'Form/Input',
   component: TextAreaField,
   decorators: []
@@ -43,3 +43,5 @@ export const _TextAreaField = () => {
       ></TextAreaField>
     </Container>
 };
+
+export default TextAreaFieldStory;

--- a/packages/storybook/src/stories/Form/SelectField.stories.tsx
+++ b/packages/storybook/src/stories/Form/SelectField.stories.tsx
@@ -5,7 +5,7 @@ import { action } from '@storybook/addon-actions';
 import { SelectField, SelectWrapper} from 'scorer-ui-kit';
 import { generateIconList } from '../helpers';
 
-export default {
+const SelectFieldStory = {
   title: 'Form/atoms',
   component: SelectField,
   decorators: []
@@ -132,3 +132,5 @@ export const _SelectField = () => {
     </Container>
   );
 }
+
+export default SelectFieldStory;

--- a/packages/storybook/src/stories/Form/Switch.stories.tsx
+++ b/packages/storybook/src/stories/Form/Switch.stories.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { text, select, boolean } from "@storybook/addon-knobs";
 import {Switch} from 'scorer-ui-kit';
 
-export default {
+const SwitchStory = {
   title: 'Form/atoms',
   component: Switch,
   decorators: []
@@ -20,3 +20,5 @@ export const _Switch = () => {
 
   return <Switch {...{state, leftTheme, rightTheme, labelText, checked, onChangeCallback}} />;
 };
+
+export default SwitchStory;

--- a/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
+++ b/packages/storybook/src/stories/Global/GlobalUI.stories.tsx
@@ -32,7 +32,7 @@ import logoTextSvg from '../assets/logo-text.svg';
 import { text, object, boolean, select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
-export default {
+const GlobalUIStory = {
   title: 'Global',
   component: GlobalUI,
   parameters: {
@@ -585,3 +585,5 @@ export const _GlobalUI = () => {
     </Container>
   )
 }
+
+export default GlobalUIStory;

--- a/packages/storybook/src/stories/Global/MainMenu.stories.tsx
+++ b/packages/storybook/src/stories/Global/MainMenu.stories.tsx
@@ -5,7 +5,7 @@ import logoMarkSvg from '../assets/logo-mark.svg';
 import logoTextSvg from '../assets/logo-text.svg';
 import { text, object, boolean } from '@storybook/addon-knobs';
 
-export default {
+const MainMenuStory = {
   title: 'Global',
   component: MainMenu,
   decorators: [
@@ -103,3 +103,5 @@ export const _MainMenu = () => {
     </Layout>
   );
 };
+
+export default MainMenuStory;

--- a/packages/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/packages/storybook/src/stories/Global/TopBar.stories.tsx
@@ -11,7 +11,7 @@ const Container = styled.div`
   right: 0;
 `;
 
-export default {
+const TopBarStory = {
   title: 'Global',
   component: TopBar,
   decorators: []
@@ -216,3 +216,5 @@ export const _TopBar = () => {
     </Container>
   );
 };
+
+export default TopBarStory;

--- a/packages/storybook/src/stories/Global/molecules/UtilityHeader.stories.tsx
+++ b/packages/storybook/src/stories/Global/molecules/UtilityHeader.stories.tsx
@@ -6,7 +6,7 @@ import {
 import styled from 'styled-components';
 import { object, boolean } from '@storybook/addon-knobs';
 
-export default {
+const UtilityHeaderStory = {
   title: 'Global/molecules',
   component: UtilityHeader,
   decorators: [
@@ -64,3 +64,5 @@ export const _UtilityHeader = () => {
     </Container>
   )
 }
+
+export default UtilityHeaderStory;

--- a/packages/storybook/src/stories/Global/organisms/ContentLayout.stories.tsx
+++ b/packages/storybook/src/stories/Global/organisms/ContentLayout.stories.tsx
@@ -12,7 +12,7 @@ import {
 import styled from 'styled-components';
 import { select } from '@storybook/addon-knobs';
 
-export default {
+const ContentLayoutStory = {
   title: 'Global/organisms',
   component: GlobalUI,
   decorators: [
@@ -77,3 +77,5 @@ export const _ContentLayout = () => {
     </Container>
   )
 }
+
+export default ContentLayoutStory;

--- a/packages/storybook/src/stories/Global/organisms/NestedSplitLayout.stories.tsx
+++ b/packages/storybook/src/stories/Global/organisms/NestedSplitLayout.stories.tsx
@@ -10,7 +10,7 @@ import {
 
 import styled from 'styled-components';
 
-export default {
+const NestedSplitLayoutStory = {
   title: 'Global/organisms',
   component: GlobalUI,
   decorators: [
@@ -59,3 +59,5 @@ export const _SplitLayoutNested = () => {
     </Container>
   )
 };
+
+export default NestedSplitLayoutStory;

--- a/packages/storybook/src/stories/Global/organisms/SplitLayout.stories.tsx
+++ b/packages/storybook/src/stories/Global/organisms/SplitLayout.stories.tsx
@@ -9,7 +9,7 @@ import {
 import styled from 'styled-components';
 import { boolean } from '@storybook/addon-knobs';
 
-export default {
+const SplitLayoutStory = {
   title: 'Global/organisms',
   component: GlobalUI,
   decorators: [
@@ -63,3 +63,5 @@ export const _SplitLayout = () => {
     </Container>
   )
 };
+
+export default SplitLayoutStory;

--- a/packages/storybook/src/stories/Indicators/Spinner.stories.tsx
+++ b/packages/storybook/src/stories/Indicators/Spinner.stories.tsx
@@ -3,7 +3,7 @@ import { select, text, number } from "@storybook/addon-knobs";
 import styled from 'styled-components';
 import {Spinner} from 'scorer-ui-kit';
 
-export default {
+const SpinnerStory = {
   title: 'Misc',
   component: Spinner,
   decorators: []
@@ -36,3 +36,5 @@ export const LoadingSpinner = () => {
     <Spinner size={spinnerSize} styling={spinnerType} custom={{ size: customSize, ...{ baseColor, topColor } }} />
   </Container>;
 };
+
+export default SpinnerStory;

--- a/packages/storybook/src/stories/Misc/Colors.stories.tsx
+++ b/packages/storybook/src/stories/Misc/Colors.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export default {
+const ColorsStory = {
   title: 'Misc',
   decorators: []
 };
@@ -79,3 +79,5 @@ export const _Colors = () => {
     })}
   </Container>;
 };
+
+export default ColorsStory;

--- a/packages/storybook/src/stories/Misc/Fonts.stories.tsx
+++ b/packages/storybook/src/stories/Misc/Fonts.stories.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import styled from 'styled-components';
 import {  select } from "@storybook/addon-knobs";
 
-export default {
+const FontsStory = {
   title: 'Misc',
   decorators: []
 };
@@ -181,3 +181,5 @@ export const _FontSheet = () => {
     
   </Container>;
 };
+
+export default FontsStory;

--- a/packages/storybook/src/stories/Misc/Icons.stories.tsx
+++ b/packages/storybook/src/stories/Misc/Icons.stories.tsx
@@ -7,7 +7,7 @@ import { generateIconList } from '../helpers';
 
 
 
-export default {
+const IconsStory = {
   title: 'Misc',
   component: Icon,
   decorators: []
@@ -64,3 +64,5 @@ export const _Icons = () => {
 
   </Container>;
 };
+
+export default IconsStory;

--- a/packages/storybook/src/stories/Misc/StatusIcon.stories.tsx
+++ b/packages/storybook/src/stories/Misc/StatusIcon.stories.tsx
@@ -5,7 +5,7 @@ import {StatusIcon} from 'scorer-ui-kit';
 import { generateIconList } from '../helpers';
 
 
-export default {
+const StatusIconStory = {
   title: 'Misc',
   component: StatusIcon,
   decorators: []
@@ -30,3 +30,5 @@ export const _Status_Icon = () => {
     </Container>
   );
 }
+
+export default StatusIconStory;

--- a/packages/storybook/src/stories/Misc/atoms/BasicSearchInput.stories.tsx
+++ b/packages/storybook/src/stories/Misc/atoms/BasicSearchInput.stories.tsx
@@ -5,7 +5,7 @@ import { text, boolean, select, number } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
 import { emptyCallbackForStory } from '../../helpers';
 
-export default {
+const BasicSearchInputStory = {
   title: 'Misc/atoms',
   component: BasicSearchInput,
   decorators: [],
@@ -44,3 +44,5 @@ export const _BasicSearchInput = () => {
     </Container>
   )
 }
+
+export default BasicSearchInputStory;

--- a/packages/storybook/src/stories/Misc/atoms/TabWithIcon.stories.tsx
+++ b/packages/storybook/src/stories/Misc/atoms/TabWithIcon.stories.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Tabs, TabList, TabWithIcon } from 'scorer-ui-kit';
 import { text, boolean } from "@storybook/addon-knobs";
 
-export default {
+const TabWithIconStory = {
   title: 'Misc/atoms',
   component: TabWithIcon,
   decorators: []
@@ -31,3 +31,5 @@ export const _TabWithIcon = () => {
   )
 
 }
+
+export default TabWithIconStory;

--- a/packages/storybook/src/stories/Misc/atoms/Tag.stories.tsx
+++ b/packages/storybook/src/stories/Misc/atoms/Tag.stories.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import {Tag} from 'scorer-ui-kit';
 import { generateIconList } from '../../helpers';
 
-export default {
+const TagStory = {
   title: 'Misc/atoms',
   component: Tag,
   decorators: []
@@ -38,3 +38,5 @@ export const _Tag = () => {
     </Container>
   )
 }
+
+export default TagStory;

--- a/packages/storybook/src/stories/Misc/molecules/DebouncedSearcher.stories.tsx
+++ b/packages/storybook/src/stories/Misc/molecules/DebouncedSearcher.stories.tsx
@@ -5,7 +5,7 @@ import { text, boolean, select, number } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
 import { emptyCallbackForStory } from '../../helpers';
 
-export default {
+const DebouncedSearcherStory = {
   title: 'Misc/molecules',
   component: DebouncedSearcher,
   decorators: [],
@@ -42,3 +42,5 @@ export const _DebouncedSearcher = () => {
     </Container>
   )
 }
+
+export default DebouncedSearcherStory;

--- a/packages/storybook/src/stories/Misc/molecules/Pagination.stories.tsx
+++ b/packages/storybook/src/stories/Misc/molecules/Pagination.stories.tsx
@@ -3,7 +3,7 @@ import { boolean, number, object, text } from '@storybook/addon-knobs';
 import React, { useEffect, useState } from 'react';
 import {Pagination}  from 'scorer-ui-kit';
 
-export default {
+const PaginationStory = {
   title: 'Misc/Molecules',
   component: Pagination,
   decorators: []
@@ -62,3 +62,5 @@ export const _Pagination = () => {
     />
   )
 }
+
+export default PaginationStory;

--- a/packages/storybook/src/stories/Misc/molecules/TabsWithIconBar.stories.tsx
+++ b/packages/storybook/src/stories/Misc/molecules/TabsWithIconBar.stories.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { TabsWithIconBar, ITabIcon, PageHeader } from 'scorer-ui-kit';
 import { text, object } from "@storybook/addon-knobs";
 
-export default {
+const TabsWithIconBarStory = {
   title: 'Misc/molecules',
   component: TabsWithIconBar,
   decorators: []
@@ -66,3 +66,5 @@ export const _TabWithIconBar = () => {
     </Container>
   )
 }
+
+export default TabsWithIconBarStory;

--- a/packages/storybook/src/stories/Misc/molecules/TagList.stories.tsx
+++ b/packages/storybook/src/stories/Misc/molecules/TagList.stories.tsx
@@ -4,7 +4,7 @@ import {TagList, ITag} from 'scorer-ui-kit';
 import {object} from "@storybook/addon-knobs";
 
 
-export default {
+const TagListStory = {
   title: 'Misc/Molecules',
   component: TagList,
   decorators: []
@@ -50,3 +50,5 @@ export const _TagList = () => {
     </Container>
   );
 };
+
+export default TagListStory;

--- a/packages/storybook/src/stories/Pages/IntroductionText.stories.tsx
+++ b/packages/storybook/src/stories/Pages/IntroductionText.stories.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
   margin: 100px;
 `;
 
-export default {
+const IntroductionTextStory = {
   title: 'Pages/atoms',
   component: IntroductionText,
   decorators: []
@@ -21,3 +21,5 @@ export const _IntroductionText = () => {
   return <Container><IntroductionText>{introductionText}</IntroductionText></Container>;
 
 };
+
+export default IntroductionTextStory;

--- a/packages/storybook/src/stories/Pages/PageHeader.stories.tsx
+++ b/packages/storybook/src/stories/Pages/PageHeader.stories.tsx
@@ -9,7 +9,7 @@ const Container = styled.div`
   margin: 100px;
 `;
 
-export default {
+const PageHeaderStory = {
   title: 'Pages/molecules',
   component: PageHeader,
   decorators: []
@@ -99,3 +99,5 @@ export const _PageHeader = () => {
       </Container>;
 
 };
+
+export default PageHeaderStory;

--- a/packages/storybook/src/stories/Pages/PageTitle.stories.tsx
+++ b/packages/storybook/src/stories/Pages/PageTitle.stories.tsx
@@ -9,7 +9,7 @@ const Container = styled.div`
   margin: 100px;
 `;
 
-export default {
+const PageTitleStory = {
   title: 'Pages/atoms',
   component: PageTitle,
   decorators: []
@@ -29,3 +29,5 @@ export const _PageTitle = () => {
   return <Container><PageTitle {...{title, areaTitle, areaHref, areaTitleBottom, iconColor}} icon={icon || undefined} /></Container>;
 
 };
+
+export default PageTitleStory;

--- a/packages/storybook/src/stories/Tables/atoms/EditableCell.stories.tsx
+++ b/packages/storybook/src/stories/Tables/atoms/EditableCell.stories.tsx
@@ -4,7 +4,7 @@ import { text, select } from "@storybook/addon-knobs";
 import {EditCell} from 'scorer-ui-kit';
 import {sleep} from '../../helpers';
 
-export default {
+const EditableCellStory = {
   title: 'Tables/atoms',
   component: EditCell,
   decorators: []
@@ -53,3 +53,5 @@ export const _EditCell = () => {
       />
   </Container>
 };
+
+export default EditableCellStory;

--- a/packages/storybook/src/stories/Tables/atoms/TableHeaderTitle.stories.tsx
+++ b/packages/storybook/src/stories/Tables/atoms/TableHeaderTitle.stories.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import {  boolean, text } from "@storybook/addon-knobs";
 import {TableHeaderTitle} from 'scorer-ui-kit';
 
-export default {
+const TableHeaderTitleStory = {
   title: 'Tables/atoms',
   component: TableHeaderTitle,
   decorators: []
@@ -48,3 +48,5 @@ export const _TableHeaderTitle = () => {
   </Container>
 
 };
+
+export default TableHeaderTitleStory;

--- a/packages/storybook/src/stories/Tables/atoms/TableRowThumbnail.stories.tsx
+++ b/packages/storybook/src/stories/Tables/atoms/TableRowThumbnail.stories.tsx
@@ -9,7 +9,7 @@ import { action } from '@storybook/addon-actions';
 const video = 'https://future-standard.github.io/scorer-ui-kit/traffic.mp4'
 
 
-export default {
+const TableRowThumbnailStory = {
   title: 'Tables/atoms',
   component: TableRowThumbnail,
   decorators: []
@@ -48,3 +48,5 @@ export const _RowThumbnail = () => {
     </Container>
   )
 };
+
+export default TableRowThumbnailStory;

--- a/packages/storybook/src/stories/Tables/molecules/ActionsTable.stories.tsx
+++ b/packages/storybook/src/stories/Tables/molecules/ActionsTable.stories.tsx
@@ -31,7 +31,7 @@ const TimeText = styled.div`
   }
 `;
 
-export default {
+const ActionsTableStory = {
   title: 'Tables/molecules',
   component: TypeTableCustom,
   decorators: []
@@ -226,3 +226,5 @@ export const ActionsTable = () => {
     </Container>
   )
 };
+
+export default ActionsTableStory;

--- a/packages/storybook/src/stories/Tables/molecules/EditableTable.stories.tsx
+++ b/packages/storybook/src/stories/Tables/molecules/EditableTable.stories.tsx
@@ -17,7 +17,7 @@ import {
   ITypeTableData
 } from 'scorer-ui-kit/dist/Tables';
 
-export default {
+const EditableTableStory = {
   title: 'Tables/molecules',
   component: EditableTable,
   decorators: []
@@ -174,3 +174,5 @@ export const _EditableTable = () => {
     </Container>
   )
 };
+
+export default EditableTableStory;

--- a/packages/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
+++ b/packages/storybook/src/stories/Tables/molecules/LoadingTable.stories.tsx
@@ -10,7 +10,7 @@ import {
   ITypeTableData
 } from 'scorer-ui-kit/dist/Tables';
 
-export default {
+const LoadingTableStory = {
   title: 'Tables/molecules',
   component: LoadingTable,
   decorators: []
@@ -181,3 +181,5 @@ export const _LoadingTable = () => {
 
 
 };
+
+export default LoadingTableStory;

--- a/packages/storybook/src/stories/Tables/molecules/TypeTable.stories.tsx
+++ b/packages/storybook/src/stories/Tables/molecules/TypeTable.stories.tsx
@@ -14,7 +14,7 @@ const Container = styled.div`
   padding: 100px;
 `;
 
-export default {
+const TypeTableStory = {
   title: 'Tables/molecules',
   component: TypeTable,
   decorators: [],
@@ -101,3 +101,5 @@ export const _TypeTable = () => {
     </Container>
   );
 };
+
+export default TypeTableStory;

--- a/packages/storybook/src/stories/Tables/organisms/TableMultiActions.stories.tsx
+++ b/packages/storybook/src/stories/Tables/organisms/TableMultiActions.stories.tsx
@@ -13,7 +13,7 @@ import {
 const Container = styled.div`
   padding: 100px;
 `;
-export default {
+const TableMultiActionsStory = {
   title: 'Tables/molecules',
   component: TypeTable,
   decorators: [],
@@ -35,3 +35,5 @@ export const _TableMultiActions = () => {
     </Container>
   );
 };
+
+export default TableMultiActionsStory;


### PR DESCRIPTION
This PR fixes ESLint warnings related to the direct export of story objects in Storybook files. 

The issue was that story configuration objects were being directly exported using export default {...} syntax, which violates the ESLint rule requiring objects to be assigned to variables before export. The fix changes the current export in to a const and re-adds the `export default` to the end of the file.

It also removes one unused import that was also showing as a warning in ESLint.