### PR TITLE
Updating switch case knobs for storybook

### DIFF
--- a/packages/storybook/src/stories/Form/Switch.stories.tsx
+++ b/packages/storybook/src/stories/Form/Switch.stories.tsx
@@ -1,3 +1,4 @@
+
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { text, select, boolean } from '@storybook/addon-knobs';
@@ -22,17 +23,14 @@ export const _Switch = () => {
   const leftTheme = select("Left Theme", { Off: "off", On: "on", Danger: "danger" }, "off");
   const rightTheme = select("Right Theme", { Off: "off", On: "on", Danger: "danger" }, "on");
 
-  const checkedOption = select("Checked", {
-    Undefined: "undefined",
-    True: "true",
-    False: "false"
-  }, "undefined");
+  const checked = select('Checked', {
+    Undefined: undefined,
+    True: true,
+    False: false,
+  }, undefined);
 
-  const defaultChecked = boolean("defaultChecked", false);
+  const defaultChecked = boolean('defaultChecked', true);
   const onChangeCallback = action('value-changed');
-
-  // Interpret the selected checked value
-  const checked = checkedOption === "undefined" ? undefined : checkedOption === "true";
 
   return (
     <Switch

--- a/packages/storybook/src/stories/Form/Switch.stories.tsx
+++ b/packages/storybook/src/stories/Form/Switch.stories.tsx
@@ -1,24 +1,50 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { text, select, boolean } from "@storybook/addon-knobs";
-import {Switch} from 'scorer-ui-kit';
+import { text, select, boolean } from '@storybook/addon-knobs';
+import { Switch } from 'scorer-ui-kit';
 
 const SwitchStory = {
   title: 'Form/atoms',
   component: Switch,
-  decorators: []
 };
 
 export const _Switch = () => {
-
   const labelText = text("Label Text", "The Label");
-  const checked = boolean("Default Checked", true)
-  const state = select("State", { Default: "default", Disabled: "disabled", Locked: "locked", Loading: "loading", Failure: "failure" }, "default");
+
+  const state = select("State", {
+    Default: "default",
+    Disabled: "disabled",
+    Locked: "locked",
+    Loading: "loading",
+    Failure: "failure"
+  }, "default");
+
   const leftTheme = select("Left Theme", { Off: "off", On: "on", Danger: "danger" }, "off");
   const rightTheme = select("Right Theme", { Off: "off", On: "on", Danger: "danger" }, "on");
+
+  const checkedOption = select("Checked", {
+    Undefined: "undefined",
+    True: "true",
+    False: "false"
+  }, "undefined");
+
+  const defaultChecked = boolean("defaultChecked", false);
   const onChangeCallback = action('value-changed');
 
-  return <Switch {...{state, leftTheme, rightTheme, labelText, checked, onChangeCallback}} />;
+  // Interpret the selected checked value
+  const checked = checkedOption === "undefined" ? undefined : checkedOption === "true";
+
+  return (
+    <Switch
+      state={state}
+      leftTheme={leftTheme}
+      rightTheme={rightTheme}
+      labelText={labelText}
+      checked={checked}
+      defaultChecked={checked === undefined ? defaultChecked : undefined}
+      onChangeCallback={onChangeCallback}
+    />
+  );
 };
 
 export default SwitchStory;


### PR DESCRIPTION
### Description

This PR introduces improvements to the Switch Story in Storybook to allow better testing and visualization of both checked and defaultChecked props using knobs.

Previously, the checked prop was not clearly controlled via knobs, which made it difficult to simulate and test different states of the Switch component (checked, unchecked, and undefined). This change addresses that by adding a select knob for checked with three options: undefined, true (checked), and false (unchecked). The defaultChecked prop remains separately configurable via a boolean knob.

### Considerations on Implementation

```
Introduced a new select knob for the checked prop with tri-state options:

"undefined" – to allow default behavior via defaultChecked

"true" – to force the switch to be in the checked state

"false" – to force the switch to be in the unchecked state

Ensured that defaultChecked is only passed when checked is undefined to avoid React warnings.

Cleaned up the checkedOption parsing for clarity and predictability.

Retained backward compatibility for consumers of the component in Storybook.
```

This improves developer experience when using Storybook to simulate real component usage, including controlled and uncontrolled scenarios.

 ### Reviewing/Testing steps

Please review the following in Storybook under:

 Form → atoms → Switch

- Verify that the Checked knob appears as a dropdown with options: undefined, checked, unchecked.

- Verify that the defaultChecked knob appears as a boolean toggle.

- Test different combinations:

  - Checked = undefined, defaultChecked = true/false
  
  - Checked = true or false, defaultChecked should have no effect
  
  - Observe that the onChangeCallback fires correctly in all cases.
  
  ### Screenshots
  
  Here is a screenshot of the expected result.
  
![Screenshot from 2025-06-02 19-08-22](https://github.com/user-attachments/assets/901fb388-b9d8-43ff-b640-deb3302140e2)


