### PR TITLE
Fix alignment for FilterDropdown Search bar

### DIFF
--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -29,7 +29,7 @@ const OptionList = styled.div<{ moreItem?: boolean }>`
 
   ${StyledFilterOption} {
     height: 40px;
-    padding-left: 14px;
+    padding-left: 16px;
   }
 `;
 
@@ -72,10 +72,13 @@ const ResultCounter = styled.div`
 `;
 
 const SearchWrapper = styled.div`
+  --search-input-font-size: 14px;
+  --search-input-font-family: var(--font-data);
+  --search-input-container-gap: 10px;
   height: 40px;
   display: flex;
   align-items: center;
-  padding: 0 8px;
+  padding: 4px 4px 4px 14px;
 `;
 
 const EmptyResultText = styled.div`

--- a/packages/ui-lib/src/Misc/atoms/BasicSearchInput.tsx
+++ b/packages/ui-lib/src/Misc/atoms/BasicSearchInput.tsx
@@ -11,7 +11,7 @@ const Container = styled.div<{ hasBorder: boolean, disabled: boolean, noBackgrou
   ${({ hasBorder, disabled, noBackground, width }) => css`
 
     transition: all var(--speed-normal) var(--easing-primary-in);
-    gap: 6px;
+    gap: var(--search-input-container-gap, 6px);
     height: var(--input-compact-height);
     padding: 0;
     align-items: center;
@@ -80,8 +80,8 @@ const CrossButton = styled.button`
 const StyledInput = styled.input<{ color: string }>`
   ${removeAutoFillStyle};
 
-  font-family: var(--font-ui);
-  font-size: 12px;
+  font-family: var(--search-input-font-family,var(--font-ui));
+  font-size: var(--search-input-font-size, 12px);
   font-weight: 500;
   color: var(--grey-12);
 
@@ -99,7 +99,6 @@ const StyledInput = styled.input<{ color: string }>`
     cursor: not-allowed;
   }
 
-  font-size: 12px;
   border: none;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
### Description

This PR resolves alignment issues in the `FilterDropdown` search bar component. The changes focus on enhancing the visual consistency and alignment of the search input elements within the dropdown.

### Implementation Details

Key changes include:
1. Adjusted the padding in the `FilterDropdown` option list from 14px to 16px.
2. Modified the `SearchWrapper` padding for improved alignment (as reviewed in Figma).
3. Implemented CSS variables in `BasicSearchInput`:
    - `--search-input-font-size`
    - `--search-input-font-family`
    - `--search-input-container-gap`

### Review and Testing Steps

To review, run **Storybook** and navigate to **Filters → Molecules → FilterDropdown with Footer Controls**.

- Verify that the search bar is properly aligned within the dropdown alongside the options and search result.
- Ensure the search text input is centered and maintains consistent padding.
- Confirm that the search icon and input field have appropriate and consistent spacing.

### Screenshoots 

**Before**
![Screenshot 2025-07-10 at 12 53 53](https://github.com/user-attachments/assets/f4c2adf1-7e27-4767-a649-902374df42cc)

**After**
![Screenshot 2025-07-10 at 12 51 15](https://github.com/user-attachments/assets/62931651-7ba3-43ec-b4c5-c0e0cb9a327c)
