### PR TITLE
Fix placement when scrolled

### DIFF
--- a/packages/ui-lib/src/LineUI/LineSet.tsx
+++ b/packages/ui-lib/src/LineUI/LineSet.tsx
@@ -108,8 +108,8 @@ const LineSet: React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, line
     if(!screenCTM){ return; }
 
     const pointer = enforceBoundaries({
-      x: ((pointerPosition.x - screenCTM.e ) / screenCTM.a),
-      y: ((pointerPosition.y - screenCTM.f ) / screenCTM.d)
+      x: (((pointerPosition.x - window.scrollX) - screenCTM.e ) / screenCTM.a),
+      y: (((pointerPosition.y - window.scrollY) - screenCTM.f ) / screenCTM.d)
     });
     const point ={
       x: Math.round(pointer.x),
@@ -126,8 +126,8 @@ const LineSet: React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, line
     if(!screenCTM){ return; }
 
     const pointer = {
-      x: ((pointerPosition.x - screenCTM.e ) / screenCTM.a) - handleRadius,
-      y: ((pointerPosition.y - screenCTM.f ) / screenCTM.d) - handleRadius
+      x: (((pointerPosition.x - window.scrollX) - screenCTM.e) / screenCTM.a) - handleRadius,
+      y: (((pointerPosition.y - window.scrollY) - screenCTM.f) / screenCTM.d) - handleRadius
     };
 
     handleRelation.current = lineSetData.points.map((handle) => {
@@ -148,8 +148,8 @@ const LineSet: React.FC<ILineSetProps> = ({ getCTM, boundaries, unit, size, line
     const { points } = lineSetData;
 
     const pointer = {
-      x: ((pointerPosition.x - screenCTM.e ) / screenCTM.a) - handleRadius,
-      y: ((pointerPosition.y - screenCTM.f ) / screenCTM.d) - handleRadius
+      x: (((pointerPosition.x - window.scrollX) - screenCTM.e) / screenCTM.a) - handleRadius,
+      y: (((pointerPosition.y - window.scrollY) - screenCTM.f) / screenCTM.d) - handleRadius
     };
 
     const newPoints = points.map((_handle, index) => {


### PR DESCRIPTION
After scrolling, trying to drag the anything on the line UI would be offset from the mouse by the distance of the drag. While I'm sure we fixed this at least twice in the past, it seems like it snuck back in!

I've (re?)added an offset to the three instance the position is calculated to accommodate the offset. You can test this on the examples Line UI page by scrolling.