### PR TITLE
Bump v3.0.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.2",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -12434,7 +12434,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
### Description 

3.0.0-beta.2

**Fixes**

- **DatePicker:** Corrected a `date-fns` v4 import issue where `Interval` was not being imported explicitly, causing a runtime error when using date range selection after the `date-fns` v2 → v4 upgrade included in beta.1.

- **Crop tool helpers:** Fixed a long-standing bug where `typeof x !== undefined` was used instead of `typeof x !== 'undefined'`, causing the comparison to always evaluate to `true`.

**Dependencies**

- **`react-router` / `react-router-dom`:** Peer dependency range updated from `^6.4.0` to `^7.0.0`. React Router 7 is the first release explicitly built for React 19.

- **`react-use-websocket`:** Peer dependency range updated from `^2.9.1` to `^4.0.0`. Version 4 adds explicit React 19 support.

- **`date-fns`:** Upgraded from v2 to v4 (internal runtime dependency).

- **Build tooling:** `vite` upgraded from v5 to v7, `vitest` from v1 to v3, and `@vitejs/plugin-react` from v4 to v5. These are dev-only changes with no consumer impact.

- **ESLint:** Upgraded from v7 to v9 with migration to flat config format (`eslint.config.mjs`). `@typescript-eslint/*` packages upgraded from v5 to v8 in alignment. No lint rule behavior changes for consumers.

- **TypeScript:** `tsconfig` targets updated to `ES2022` across all packages.

- **`lodash.defaultsdeep`:** Removed as it was no longer used anywhere in the source.

- **Deployment fixes:** `gh-pages` is now declared as an explicit root devDependency, fixing a deploy workflow failure under npm 10 / Node 22 where stricter hoisting caused the binary to no longer be found. Storybook deployment was similarly fixed by declaring `react-router-dom` explicitly in the storybook package. Docker base image updated from `node:18` to `node:22`.

**Breaking changes**

- **`react-router-dom` peer dependency now requires v7.** Consumers on React Router 6 will encounter an `ERESOLVE` error on `npm install` and must upgrade to React Router 7 before adopting this release. The APIs used internally by the library (`Link`, `useNavigate`, `useLocation`) are identical in v6 and v7, so there is no runtime difference within the library itself. However, consumers using React Router's data routing APIs (loaders, actions, `createBrowserRouter`) will need to follow the [React Router v7 migration guide](https://reactrouter.com/upgrading/v6) to update their own application code.

- **`react-use-websocket` peer dependency now requires v4.** Consumers on v2 will encounter an `ERESOLVE` error on `npm install` and must upgrade. The hook APIs used internally (`sendJsonMessage`, `lastMessage`) are identical between v2 and v4. Note that v4 calls `flushSync` internally on incoming WebSocket messages — this is safe in current library usage, but may cause issues if the hook is used inside a React transition or concurrent feature in consumer application code.
