### PR TITLE
Fix deep module exports missing type interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10813,7 +10813,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10831,7 +10830,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10849,7 +10847,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10867,7 +10864,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10885,7 +10881,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10903,7 +10898,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10921,7 +10915,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10939,7 +10932,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10957,7 +10949,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10975,7 +10966,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10993,7 +10983,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11011,7 +11000,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11029,7 +11017,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11047,7 +11034,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11065,7 +11051,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11083,7 +11068,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11101,7 +11085,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11119,7 +11102,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11137,7 +11119,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11155,7 +11136,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11173,7 +11153,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11191,7 +11170,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11209,7 +11187,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11651,24 +11628,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -17,6 +17,21 @@
       "import": "./dist/index.modern.js",
       "require": "./dist/index.js"
     },
+    "./dist/Tables": {
+      "types": "./dist/Tables/index.d.ts"
+    },
+    "./dist/LineUI": {
+      "types": "./dist/LineUI/index.d.ts"
+    },
+    "./dist/LineUI/LineReducer": {
+      "types": "./dist/LineUI/LineReducer.d.ts"
+    },
+    "./dist/Global": {
+      "types": "./dist/Global/index.d.ts"
+    },
+    "./dist/Form": {
+      "types": "./dist/Form/index.d.ts"
+    },
     "./dist/*": "./dist/*"
   },
   "sideEffects": false,

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -52,6 +52,15 @@ import {
   IButtonStack,
   TypeSwitchState
 } from './Form';
+import type {
+  TypeFieldState,
+  TypeButtonDesigns,
+  TypeButtonSizes,
+  ISelectSizes,
+  IInputOptionsType,
+  TypeLabelDirection,
+  IButtonProps,
+} from './Form';
 
 // Components - Filter
 import {
@@ -93,6 +102,15 @@ import {
   LineSetContext,
   LineReducer
 } from './LineUI';
+import type {
+  IVector2,
+  IPointSet,
+  IMinMax,
+  IBoundary,
+  IDragLineUISharedOptions,
+  LineUIOptions,
+  LineUIVideoOptions,
+} from './LineUI';
 
 // Pages
 import {
@@ -109,6 +127,18 @@ import {
   TableRowThumbnail,
   TableHeaderTitle,
   EditCell,
+} from './Tables';
+import type {
+  TypeCellStyle,
+  TypeCellAlignment,
+  TableHeaders,
+  TableHeaderItem,
+  ITableColumnConfig,
+  IDeviceStatus,
+  ICellData,
+  IRowHeader,
+  IRowData,
+  ITypeTableData,
 } from './Tables';
 
 import {
@@ -206,6 +236,17 @@ import {
   INotificationItem,
   INotificationsHistory,
   ICustomDrawer
+} from './Global';
+import type {
+  IMenuTop,
+  IMenuItemTop,
+  IMenuItemSubmenu,
+  IMenu,
+  IUserDrawerMeta,
+  IUserDrawerFooter,
+  IUserSubmenuItem,
+  ITopBar,
+  ITopBarBadge,
 } from './Global';
 
 // Tabs
@@ -426,5 +467,46 @@ export type {
   IToggleOption,
   IDateInterval,
   IDateRange,
-  TypeSwitchState
+  TypeSwitchState,
+
+  // LineUI types
+  IVector2,
+  IPointSet,
+  IMinMax,
+  IBoundary,
+  IDragLineUISharedOptions,
+  LineUIOptions,
+  LineUIVideoOptions,
+
+  // Tables types
+  TypeCellStyle,
+  TypeCellAlignment,
+  TableHeaders,
+  TableHeaderItem,
+  ITableColumnConfig,
+  IDeviceStatus,
+  ICellData,
+  IRowHeader,
+  IRowData,
+  ITypeTableData,
+
+  // Global types
+  IMenuTop,
+  IMenuItemTop,
+  IMenuItemSubmenu,
+  IMenu,
+  IUserDrawerMeta,
+  IUserDrawerFooter,
+  IUserSubmenuItem,
+  ITopBar,
+  ITopBarBadge,
+
+  // Form types
+  TypeFieldState,
+  TypeButtonDesigns,
+  TypeButtonSizes,
+  ISelectSizes,
+  IInputOptionsType,
+  TypeLabelDirection,
+  IButtonProps,
 };


### PR DESCRIPTION
## Summary
- Re-export all missing type interfaces (LineUI, Tables, Global, Form) from the main `index.tsx` entry point so consumers can import types directly: `import { IRowData, ITableColumnConfig, IPointSet } from 'scorer-ui-kit'`
- Add explicit subpath exports in `package.json` for `./dist/Tables`, `./dist/LineUI`, `./dist/Global`, `./dist/Form` to preserve backward compatibility with existing deep import paths
- Types added: `IVector2`, `IPointSet`, `LineUIOptions`, `ITableColumnConfig`, `IRowData`, `ITypeTableData`, `IMenuTop`, `ITopBar`, `TypeButtonDesigns`, and more

## Test plan
- [x] Verify `npm run build` succeeds in `packages/ui-lib`
- [x] Verify deep imports like `import { IRowData } from 'scorer-ui-kit/dist/Tables'` resolve correctly
- [ ] Verify main entry imports like `import { IRowData } from 'scorer-ui-kit'` resolve correctly
- [ ] Run consuming project TypeScript compilation to confirm implicit-any errors are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)