### PR TITLE
Bump v3.0.0-beta.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.2",
+      "version": "3.0.0-beta.3",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -12393,7 +12393,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.2",
+      "version": "3.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
### Description - 3.0.0-beta.3

**Fixes**

- **Type exports:** Several type interfaces were missing from the main package entry point in the v3.0 beta. They are now re-exported correctly from `scorer-ui-kit`, so consumers can import types directly without using deep import paths:

  ```ts
  import { IRowData, ITableColumnConfig, IPointSet } from 'scorer-ui-kit'
  ```

  Types now available from the main entry point include: `IVector2`, `IPointSet`, `LineUIOptions`, `ITableColumnConfig`, `IRowData`, `ITypeTableData`, `IMenuTop`, `ITopBar`, `TypeButtonDesigns`, and others across the LineUI, Tables, Global, and Form modules.

  Existing deep import paths (e.g. `scorer-ui-kit/dist/Tables`) continue to work — explicit subpath exports were added to `package.json` to preserve backward compatibility.

**Dependencies**

- **`flatted`** (security fix): Transitive dependency updated from `3.3.3` to `3.4.2` to address a security advisory. This is a dev-only dependency used by ESLint's cache layer and has no impact on the published package or runtime behaviour.

- **Node.js engines:** Node 24 added to the supported engines range in `ui-lib`.
