### PR TITLE
Bump v3.0.0-beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.3",
+      "version": "3.0.0-beta.4",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -12393,7 +12393,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.3",
+      "version": "3.0.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
  Description — 3.0.0-beta.4

  Fixes

  - WebRTCClient: Resolved several React 19 compatibility issues and timer leaks surfaced by StrictMode's double-mount behaviour — stale WebSocket event race condition, leaked reconnect/HELLO timers, duplicate reconnect calls on rapid disconnect, and a stale enabled closure in the
   reconnect path.
  - LineUI — HandleUnit: Fixed a bug where React.createRef() was used instead of useRef(), causing touch target comparisons to always fail on every render.
  - LineUI — HandleUnit / LineUnit: Global mousemove and mouseup listeners were not removed on unmount mid-drag, leading to leaked listeners. Cleanup is now handled via useEffect.
  - LineSet: Out-of-bounds line points are now clamped to video dimensions when video metadata first loads, without triggering again on window resize.