### PR TITLE
Export ThemeType from scorer-ui-kit

### DIFF
--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -2,6 +2,7 @@
 import defaultTheme from './theme';
 import ThemeVariables from './theme/ThemeVariables';
 import { BaseStyles } from './theme/ThemeHelpers';
+export type { ThemeType } from './styled';
 
 //Components Alerts
 import {

--- a/packages/ui-lib/src/styled.d.ts
+++ b/packages/ui-lib/src/styled.d.ts
@@ -3,7 +3,7 @@ import 'styled-components';
 // Import the actual theme object to derive its type
 import defaultTheme from './theme';
 
-type ThemeType = typeof defaultTheme;
+export type ThemeType = typeof defaultTheme;
 
 declare module 'styled-components' {
   export interface DefaultTheme extends ThemeType {}


### PR DESCRIPTION
## Summary
- Exports `ThemeType` (derived from `typeof defaultTheme`) from the package
- Consumers can now import `ThemeType` directly instead of using `typeof defaultTheme`
- No runtime changes — type-only export

## Usage
```typescript
import { ThemeType } from 'scorer-ui-kit';
```

## Test plan
- [x] `npm run build` passes cleanly
- [x] Verify `ThemeType` is available in consuming projects via autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)