### PR TITLE
Release v3.0.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.4",
+      "version": "3.0.0-beta.5",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -11315,7 +11315,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.4",
+      "version": "3.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 3.0.0-beta.5
- Includes notification system fix for React 19 StrictMode (#614)
- Storybook upgraded from 8.4.4 to 10.3.4
- Removed storybook-dark-mode (incompatible with SB 10)
- Fixed legacy @storybook/* import aliases for addon-knobs

## Release steps
After merge:
```
git checkout main && git pull
git tag v3.0.0-beta.5
git push origin v3.0.0-beta.5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)