### PR TITLE
Add TypeScript and build checks to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint check
+name: CI checks
 on:
   push:
 
@@ -35,8 +35,14 @@ jobs:
     - name: Install Deps
       run: npm install
 
+    - name: TypeScript check
+      run: npm run test:types -w packages/ui-lib
+
     - name: eslint
       run: npm run test:lint -w packages/ui-lib
+
+    - name: Build
+      run: npm run build -w packages/ui-lib
 
   lint-status:
     name: lint

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -44,6 +44,7 @@
     "prepublishOnly": "run-s build",
     "test": "run-s test:unit test:lint test:build",
     "test:build": "run-s build",
+    "test:types": "tsc --noEmit",
     "test:lint": "eslint 'src/**/*.{ts,tsx}'",
     "test:unit": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
### Depends on #618 

## Summary
- Rename lint workflow to "CI checks" and add `tsc --noEmit` and `vite build` steps
- Add `test:types` script to `packages/ui-lib`
- CI now catches type errors and build failures on every push, not just on deploy

## Test plan
- [ ] Verify the workflow runs successfully on this branch's push
- [ ] Confirm tsc, eslint, and build steps all pass on Node 20 and 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)