### PR TITLE
Release v3.0.0-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.5",
+      "version": "3.0.0-beta.6",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -11315,7 +11315,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.5",
+      "version": "3.0.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 3.0.0-beta.6
- Fix transient prop warnings and build type errors (#619)
- Add TypeScript and build checks to CI workflow (#620)

## Release steps
After merge:
```
git checkout main && git pull
git tag v3.0.0-beta.6
git push origin v3.0.0-beta.6
```