### PR TITLE
HOT FIX - examples page rendering blank, package-lock had some react18 transitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1397,9 +1397,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6381,6 +6381,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6881,6 +6882,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7921,14 +7923,10 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7945,17 +7943,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-i18next": {
@@ -8395,14 +8391,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/scorer-ui-kit": {
       "resolved": "packages/ui-lib",
@@ -10208,33 +10200,6 @@
         "@babel/runtime": "^7.23.2"
       }
     },
-    "packages/example/node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/example/node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
-    "packages/example/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
     "packages/storybook": {
       "name": "scorer-ui-kit-storybook",
       "version": "0.0.0",
@@ -10927,15 +10892,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/storybook/node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "packages/storybook/node_modules/react-docgen": {
       "version": "8.0.3",
       "dev": true,
@@ -10955,24 +10911,6 @@
       "engines": {
         "node": "^20.9.0 || >=22"
       }
-    },
-    "packages/storybook/node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
-    "packages/storybook/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
     },
     "packages/storybook/node_modules/semver": {
       "version": "7.7.4",
@@ -11384,36 +11322,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "packages/ui-lib/node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/ui-lib/node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
-    "packages/ui-lib/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/ui-lib/node_modules/semver": {
       "version": "7.7.4",

--- a/packages/example/src/index.tsx
+++ b/packages/example/src/index.tsx
@@ -83,7 +83,11 @@ const Index : FC = () => {
   );
 };
 
-const root = createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById('root')!, {
+  onUncaughtError: (error, errorInfo) => {
+    console.error('Uncaught render error:', error, errorInfo.componentStack);
+  },
+});
 root.render(
   <React.StrictMode>
     <Index />


### PR DESCRIPTION
## Description

**Bug fix.** After the Vite 8 upgrade (#628), the GitHub Pages examples page rendered a completely blank screen with the following error in the browser console:

```
Uncaught TypeError: Cannot read properties of null (reading 'useState')
```

### Root cause

The `package-lock.json` was stale: it had `react@18.3.1` at the workspace root. The root-level `overrides` in `package.json` declare `"react": "^19.0.0"`, but npm reads the lockfile as authoritative and skips re-resolution when it considers it consistent — so it never upgraded to React 19 at the root level.

Because the root React was still 18, npm could not satisfy the `^19.x` React requirements declared in each workspace package's `devDependencies`. It resolved the conflict by installing **React 19.2.4 separately inside each workspace package** (`packages/example`, `packages/storybook`, `packages/ui-lib`).

When Rolldown (Vite 8) bundled the example app for production, it resolved `react` imports differently depending on which module they came from:

- Example app code → root `node_modules/react` (React 18)
- `scorer-ui-kit` dist → `packages/ui-lib/node_modules/react` (React 19)

Both copies ended up in the single `index-*.js` production bundle. `createRoot` initialised React 18's dispatcher; `useThemeToggle` (and other hooks from the library) went through React 19's `ReactSharedInternals.H` — which was never set → `null` → crash.

This was confirmed by finding **two separate occurrences** of `{H:null,A:null,T:null,S:null}` (React 19's shared internals initialisation) at byte offsets 2601 and 230117 inside the deployed bundle.

### Fix applied

1. **Deleted and regenerated `package-lock.json`** — this forced npm to apply the `overrides` from scratch. React 19.2.5 is now hoisted to the workspace root. The per-package `react`/`react-dom`/`scheduler` sub-installs under `packages/*/node_modules/` are gone; all three workspace packages resolve to the single root copy.

2. **Added `onUncaughtError` to `createRoot`** — React 19 changed error propagation: uncaught render errors no longer re-throw to `window.onerror`; they only call `window.reportError`. Without this callback, render crashes produce a completely silent blank page with no console output, making future regressions very hard to diagnose.

### Background

- Storybook already had the equivalent defensive measure (`config.resolve.dedupe = ['react', 'react-dom']`) with the comment "Ensure single React instance".
- The `@storybook/addon-knobs@8.0.1` peer-dep ELSPROBLEMS warning (`"react": "^16.8.0 || ^17.0.0 || ^18.0.0"`) is a pre-existing issue tracked in future-standard/scorer-ui-kit#370 and is unrelated to this fix.

---

## Considerations on Implementation

- The `package-lock.json` diff is large because npm re-resolved the full dependency graph. The meaningful changes are: `react` and `react-dom` going from `18.3.1` → `19.2.5` at the root, `scheduler` from `0.23.2` → `0.27.0`, and the removal of all `packages/*/node_modules/react` sub-entries.
- `onUncaughtError` logs `error` and `errorInfo.componentStack` via `console.error`. This is intentional — it makes React 19 render crashes visible in the browser console for developers and in CI logs. `componentStack` is typed `string | null` in React 19; passing it to `console.error` is safe.
- No source code changes were made to the library (`packages/ui-lib`). The fix is entirely in the dependency graph and the example app entry point.

---

## Reviewing / Testing steps

1. **Check out this branch** and run:
   ```bash
   npm install
   npm ls react  # should show react@19.2.5 with no duplicates at the root
   ```

2. **Build and serve the example app:**
   ```bash
   cd packages/example
   npm run build
   # open build/index.html or serve with a static server
   ```
   The page should load correctly with no blank screen or console errors.

3. **Verify production bundle has a single React instance:**
   In the built `build/assets/index-*.js`, search for `{H:null,A:null,T:null,S:null}` — it should appear **exactly once**.

4. **Dev server smoke test:**
   ```bash
   cd packages/example
   npm start
   ```
   Navigate to `http://localhost:3000/scorer-ui-kit` — all pages should render without errors.

5. **Confirm GitHub Pages** at `https://future-standard.github.io/scorer-ui-kit/` renders correctly after CI deploys (triggered automatically on merge to `main`).
