### PR TITLE
Add deploy previews for PRs and branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,7 +118,7 @@ jobs:
         git push origin HEAD:gh-pages
 
     - name: Create deployment status
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const env = '${{ steps.target.outputs.env_name }}';

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,6 @@ jobs:
         script: |
           const env = '${{ steps.target.outputs.env_name }}';
           const url = '${{ steps.target.outputs.url }}';
-          const storybookUrl = url + 'storybook/';
 
           const { data: deployment } = await github.rest.repos.createDeployment({
             owner: context.repo.owner,
@@ -141,5 +140,4 @@ jobs:
             deployment_id: deployment.id,
             state: 'success',
             environment_url: url,
-            description: `Example: ${url} | Storybook: ${storybookUrl}`,
           });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [ 'main', 'demo', 'deploy-test3']
 
+permissions:
+  contents: write
+  deployments: write
+
+# Share concurrency group with PR deploys to avoid push races
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
 
@@ -36,11 +45,31 @@ jobs:
     - name: Build library
       run: npm run build -w packages/ui-lib
 
+    - name: Determine deploy target
+      id: target
+      run: |
+        BRANCH="${GITHUB_REF_NAME}"
+        if [ "$BRANCH" = "main" ]; then
+          echo "is_production=true" >> "$GITHUB_OUTPUT"
+          echo "base_path=/scorer-ui-kit" >> "$GITHUB_OUTPUT"
+          echo "dest_dir=" >> "$GITHUB_OUTPUT"
+          echo "env_name=production" >> "$GITHUB_OUTPUT"
+          echo "url=https://future-standard.github.io/scorer-ui-kit/" >> "$GITHUB_OUTPUT"
+        else
+          echo "is_production=false" >> "$GITHUB_OUTPUT"
+          echo "base_path=/scorer-ui-kit/branch/${BRANCH}/" >> "$GITHUB_OUTPUT"
+          echo "dest_dir=branch/${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "env_name=preview-${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "url=https://future-standard.github.io/scorer-ui-kit/branch/${BRANCH}/" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Build example
       run: |
         cd packages/example
         npm run build
         date >> build/deployed.html
+      env:
+        VITE_BASE_PATH: ${{ steps.target.outputs.base_path }}
 
     - name: Build storybook
       run: |
@@ -49,7 +78,68 @@ jobs:
 
     - name: Deploy GH Pages
       run: |
-        git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-        npm run actions-deploy -- -u "github-actions-bot <support+actions@github.com>"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        git config user.name "github-actions-bot"
+        git config user.email "support+actions@github.com"
+
+        git fetch origin gh-pages
+
+        git worktree add gh-pages-dir origin/gh-pages
+
+        IS_PROD="${{ steps.target.outputs.is_production }}"
+        DEST_DIR="${{ steps.target.outputs.dest_dir }}"
+
+        if [ "$IS_PROD" = "true" ]; then
+          # Production: replace root content but preserve preview subdirectories
+          mkdir -p /tmp/gh-pages-preserve
+          for dir in gh-pages-dir/pr gh-pages-dir/branch; do
+            if [ -d "$dir" ]; then
+              mv "$dir" /tmp/gh-pages-preserve/
+            fi
+          done
+
+          rm -rf gh-pages-dir/*
+          cp -r packages/example/build/* gh-pages-dir/
+
+          for dir in /tmp/gh-pages-preserve/*; do
+            if [ -d "$dir" ]; then
+              mv "$dir" gh-pages-dir/
+            fi
+          done
+        else
+          # Branch deploy: only replace this branch's subdirectory
+          rm -rf "gh-pages-dir/${DEST_DIR}"
+          mkdir -p "gh-pages-dir/${DEST_DIR}"
+          cp -r packages/example/build/* "gh-pages-dir/${DEST_DIR}/"
+        fi
+
+        cd gh-pages-dir
+        git add .
+        git commit -m "Deploy ${DEST_DIR:-production} from ${GITHUB_SHA::7}" || echo "No changes to deploy"
+        git push origin HEAD:gh-pages
+
+    - name: Create deployment status
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const env = '${{ steps.target.outputs.env_name }}';
+          const url = '${{ steps.target.outputs.url }}';
+          const storybookUrl = url + 'storybook/';
+
+          const { data: deployment } = await github.rest.repos.createDeployment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: context.sha,
+            environment: env,
+            auto_merge: false,
+            required_contexts: [],
+            description: `Deploy ${env}`,
+          });
+
+          await github.rest.repos.createDeploymentStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            deployment_id: deployment.id,
+            state: 'success',
+            environment_url: url,
+            description: `Example: ${url} | Storybook: ${storybookUrl}`,
+          });

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -74,7 +74,7 @@ jobs:
         git push origin HEAD:gh-pages
 
     - name: Comment preview URLs on PR
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -70,7 +70,7 @@ jobs:
         # Commit and push
         cd gh-pages-dir
         git add .
-        git commit -m "Deploy preview for PR #${PR_NUM}" || echo "No changes to deploy"
+        git commit -m "Deploy preview for PR ${PR_NUM}" || echo "No changes to deploy"
         git push origin HEAD:gh-pages
 
     - name: Comment preview URLs on PR
@@ -79,16 +79,12 @@ jobs:
         script: |
           const prNumber = context.payload.pull_request.number;
           const sha = context.payload.pull_request.head.sha.substring(0, 7);
-          const exampleUrl = `https://future-standard.github.io/scorer-ui-kit/pr/${prNumber}/`;
-          const storybookUrl = `https://future-standard.github.io/scorer-ui-kit/pr/${prNumber}/storybook/`;
+          const previewUrl = `https://future-standard.github.io/scorer-ui-kit/pr/${prNumber}/`;
 
           const body = [
             `## Deploy Preview`,
             ``,
-            `| App | URL |`,
-            `|-----|-----|`,
-            `| Example | ${exampleUrl} |`,
-            `| Storybook | ${storybookUrl} |`,
+            `${previewUrl}`,
             ``,
             `_Built from ${sha} — ${new Date().toISOString()}_`,
           ].join('\n');
@@ -141,9 +137,9 @@ jobs:
           rm -rf "gh-pages-dir/pr/${PR_NUM}"
           cd gh-pages-dir
           git add .
-          git commit -m "Remove preview for PR #${PR_NUM}"
+          git commit -m "Remove preview for PR ${PR_NUM}"
           git push origin HEAD:gh-pages
-          echo "Cleaned up preview for PR #${PR_NUM}"
+          echo "Cleaned up preview for PR ${PR_NUM}"
         else
-          echo "No preview found for PR #${PR_NUM}, nothing to clean up"
+          echo "No preview found for PR ${PR_NUM}, nothing to clean up"
         fi

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -1,0 +1,149 @@
+name: PR Deploy Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize all gh-pages pushes so concurrent PR deploys don't race
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Use Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22.x'
+
+    - name: Cache node modules
+      uses: actions/cache@v5
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build library
+      run: npm run build -w packages/ui-lib
+
+    - name: Build example
+      run: npm run build -w packages/example
+      env:
+        VITE_BASE_PATH: /scorer-ui-kit/pr/${{ github.event.pull_request.number }}/
+
+    - name: Build storybook
+      run: npm run build-storybook -w packages/storybook
+
+    - name: Deploy preview to gh-pages
+      run: |
+        PR_NUM=${{ github.event.pull_request.number }}
+
+        git config user.name "github-actions-bot"
+        git config user.email "support+actions@github.com"
+
+        # Fetch gh-pages branch
+        git fetch origin gh-pages
+
+        # Create a working copy of gh-pages
+        git worktree add gh-pages-dir origin/gh-pages
+
+        # Clear any previous build for this PR and copy new build
+        rm -rf "gh-pages-dir/pr/${PR_NUM}"
+        mkdir -p "gh-pages-dir/pr/${PR_NUM}"
+        cp -r packages/example/build/* "gh-pages-dir/pr/${PR_NUM}/"
+
+        # Commit and push
+        cd gh-pages-dir
+        git add .
+        git commit -m "Deploy preview for PR #${PR_NUM}" || echo "No changes to deploy"
+        git push origin HEAD:gh-pages
+
+    - name: Comment preview URLs on PR
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const prNumber = context.payload.pull_request.number;
+          const sha = context.payload.pull_request.head.sha.substring(0, 7);
+          const exampleUrl = `https://future-standard.github.io/scorer-ui-kit/pr/${prNumber}/`;
+          const storybookUrl = `https://future-standard.github.io/scorer-ui-kit/pr/${prNumber}/storybook/`;
+
+          const body = [
+            `## Deploy Preview`,
+            ``,
+            `| App | URL |`,
+            `|-----|-----|`,
+            `| Example | ${exampleUrl} |`,
+            `| Storybook | ${storybookUrl} |`,
+            ``,
+            `_Built from ${sha} — ${new Date().toISOString()}_`,
+          ].join('\n');
+
+          // Update existing comment or create new one
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+          });
+          const existing = comments.find(c =>
+            c.user.type === 'Bot' && c.body.includes('Deploy Preview')
+          );
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+          }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Remove preview from gh-pages
+      run: |
+        PR_NUM=${{ github.event.pull_request.number }}
+
+        git config user.name "github-actions-bot"
+        git config user.email "support+actions@github.com"
+
+        git fetch origin gh-pages
+
+        git worktree add gh-pages-dir origin/gh-pages
+
+        if [ -d "gh-pages-dir/pr/${PR_NUM}" ]; then
+          rm -rf "gh-pages-dir/pr/${PR_NUM}"
+          cd gh-pages-dir
+          git add .
+          git commit -m "Remove preview for PR #${PR_NUM}"
+          git push origin HEAD:gh-pages
+          echo "Cleaned up preview for PR #${PR_NUM}"
+        else
+          echo "No preview found for PR #${PR_NUM}, nothing to clean up"
+        fi

--- a/packages/example/src/basePath.ts
+++ b/packages/example/src/basePath.ts
@@ -1,0 +1,1 @@
+export const BASE_PATH = import.meta.env.BASE_URL;

--- a/packages/example/src/pages/Index.tsx
+++ b/packages/example/src/pages/Index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import {Link} from 'react-router-dom';
 import { FilenameTag } from '../components/ExamplesFilename';
+import { BASE_PATH } from '../basePath';
 
 const Container = styled.div`
   margin: 0 auto;
@@ -86,7 +87,7 @@ const LinksPage : React.FC = () => {
         <Subheader>Key Resources</Subheader>
         <List>
           <Item>
-            <a href='/scorer-ui-kit/storybook'>
+            <a href={`${BASE_PATH}storybook`}>
               <Title>Storybook</Title>
               <Description>All the key components of the SCORER UI Kit, previewable along with options using Storybook.</Description>
             </a>

--- a/packages/example/src/pages/LinePage.tsx
+++ b/packages/example/src/pages/LinePage.tsx
@@ -16,6 +16,7 @@ import {
 } from 'scorer-ui-kit';
 import { IPointSet, LineUIOptions } from 'scorer-ui-kit/dist/LineUI';
 import ExamplesFilename from '../components/ExamplesFilename';
+import { BASE_PATH } from '../basePath';
 
 const Line: React.FC<{}> = () => {
   const [state, dispatch] = useReducer(LineReducer, []);
@@ -254,7 +255,7 @@ const Line: React.FC<{}> = () => {
       <Content $padBottom={false}>
         {error && <div>{error}</div>}
         <LineSetContext.Provider value={{ state, dispatch }}>
-          <LineUI options={options} onLineClick={selectLine} src="/scorer-ui-kit/images/line-ui-railyard.jpg" />
+          <LineUI options={options} onLineClick={selectLine} src={`${BASE_PATH}images/line-ui-railyard.jpg`} />
         </LineSetContext.Provider>
       </Content>
     </Layout>

--- a/packages/example/src/pages/LineVideoPage.tsx
+++ b/packages/example/src/pages/LineVideoPage.tsx
@@ -19,6 +19,7 @@ import styled from 'styled-components';
 import {LineUIOptions} from 'scorer-ui-kit/dist/LineUI';
 import {LineUIVideoOptions} from 'scorer-ui-kit/dist/LineUI';
 import ExamplesFilename from '../components/ExamplesFilename';
+import { BASE_PATH } from '../basePath';
 
 const StyledButton = styled(ButtonWithIcon)`
   width: 100%;
@@ -193,7 +194,7 @@ const Line: React.FC<{}> = () => {
       muted: true,
     })
 
-    createMediaModal({ mediaType: 'video', src: '/scorer-ui-kit/traffic.mp4', dismissCallback: handleModalClose })
+    createMediaModal({ mediaType: 'video', src: `${BASE_PATH}traffic.mp4`, dismissCallback: handleModalClose })
   }, [createMediaModal, handleModalClose])
 
   const selectLine = useCallback((lineId: number) => {
@@ -246,7 +247,7 @@ const Line: React.FC<{}> = () => {
       <Content $padBottom={false}>
         {error && <div>{error}</div>}
         <LineSetContext.Provider value={{ state, dispatch }}>
-          <LineUIVideo options={options} onLineClick={selectLine} videoOptions={videoOptions} src='/scorer-ui-kit/traffic.mp4' />
+          <LineUIVideo options={options} onLineClick={selectLine} videoOptions={videoOptions} src={`${BASE_PATH}traffic.mp4`} />
         </LineSetContext.Provider>
         <ButtonWrapper>
           <Button onClick={handleMediaModal}>Open Video Modal</Button>

--- a/packages/example/src/pages/TablePage.tsx
+++ b/packages/example/src/pages/TablePage.tsx
@@ -4,6 +4,7 @@ import { TypeTable, PageHeader, Content, useModal, SplitButton } from 'scorer-ui
 import { ITableColumnConfig, ITypeTableData } from 'scorer-ui-kit/dist/Tables';
 import { StatusComponent } from '../components/StatusComponent';
 import ExamplesFilename from '../components/ExamplesFilename';
+import { BASE_PATH } from '../basePath';
 
 const Container = styled.div`
   margin: 100px 200px;
@@ -85,7 +86,7 @@ const TablePage: React.FC = () => {
       id: 'device-id-1',
       header: {
         image: "https://picsum.photos/id/43/367/267",
-        mediaUrl: "/scorer-ui-kit/traffic.mp4",
+        mediaUrl: `${BASE_PATH}traffic.mp4`,
         mediaType: 'video',
       },
       columns:
@@ -102,8 +103,8 @@ const TablePage: React.FC = () => {
       _checked: true,
       id: 'device-id-2',
       header: {
-        image: "/scorer-ui-kit/images/cityscape.jpg",
-        mediaUrl: "/scorer-ui-kit/images/cityscape.jpg",
+        image: `${BASE_PATH}images/cityscape.jpg`,
+        mediaUrl: `${BASE_PATH}images/cityscape.jpg`,
         mediaType: 'img',
         onClickThumbnail: () => openCustomModal('device-id-2'),
       },
@@ -129,8 +130,8 @@ const TablePage: React.FC = () => {
     {
       id: 'device-id-3',
       header: {
-        image: "/scorer-ui-kit/images/cityscape.jpg",
-        mediaUrl: "/scorer-ui-kit/images/cityscape.jpg",
+        image: `${BASE_PATH}images/cityscape.jpg`,
+        mediaUrl: `${BASE_PATH}images/cityscape.jpg`,
         mediaType: 'img'
       },
       columns:
@@ -146,8 +147,8 @@ const TablePage: React.FC = () => {
     {
       id: 'device-id-4',
       header: {
-        image: "/scorer-ui-kit/images/cityscape.jpg",
-        mediaUrl: "/scorer-ui-kit/images/cityscape.jpg",
+        image: `${BASE_PATH}images/cityscape.jpg`,
+        mediaUrl: `${BASE_PATH}images/cityscape.jpg`,
         mediaType: 'img'
       },
       columns:

--- a/packages/example/src/svg/login-screen.svg
+++ b/packages/example/src/svg/login-screen.svg
@@ -5,21 +5,21 @@
               font-family: Monorale;
               font-weight: 400;
               font-style: normal;
-              src: url('/scorer-ui-kit/fonts/Monorale-Regular.woff') format('woff');
+              src: url('fonts/Monorale-Regular.woff') format('woff');
               font-display: fallback;
             }
             @font-face {
                 font-family: Monorale;
                 font-weight: 500;
                 font-style: normal;
-                src: url('/scorer-ui-kit/fonts/Monorale-Medium.woff') format('woff');
+                src: url('fonts/Monorale-Medium.woff') format('woff');
                 font-display: fallback;
             }
             @font-face {
                 font-family: Monorale;
                 font-weight: 700;
                 font-style: normal;
-                src: url('/scorer-ui-kit/fonts/Monorale-Bold.woff') format('woff');
+                src: url('fonts/Monorale-Bold.woff') format('woff');
                 font-display: fallback;
             }
         </style>

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       },
     }),
   ],
-  base: '/scorer-ui-kit',
+  base: process.env.VITE_BASE_PATH || '/scorer-ui-kit',
   publicDir: 'public',
   build: {
     outDir: 'build',


### PR DESCRIPTION
## Summary

- **PR deploy previews**: Every PR automatically gets a deploy preview at `/pr/<number>/`. A comment with the preview link is posted on the PR and updated on each push. Preview is cleaned up when the PR is closed.
- **Branch deploy previews**: Non-main branches (e.g. `demo`, `deploy-test3`) now deploy to `/branch/<name>/` instead of overwriting production. Adding a new branch just requires adding it to the trigger list.
- **Production safety**: Production deploys from `main` preserve all `/pr/` and `/branch/` subdirectories. A shared concurrency group serializes all gh-pages pushes to prevent race conditions.
- **GitHub Environments**: Each deploy creates a GitHub deployment environment with a clickable URL.
- **Dynamic base path**: All hardcoded `/scorer-ui-kit/` asset references replaced with `BASE_PATH` (from Vite's `import.meta.env.BASE_URL`) so assets resolve correctly on any deploy target.

## URL scheme

| Source | URL |
|--------|-----|
| `main` | `…/scorer-ui-kit/` |
| `demo` branch | `…/scorer-ui-kit/branch/demo/` |
| PR #123 | `…/scorer-ui-kit/pr/123/` |

## Changes

- `.github/workflows/pr-deploy.yml` — new workflow for PR previews (deploy + cleanup)
- `.github/workflows/deploy.yml` — branch-aware deploys, preserves preview subdirs, deployment environments
- `packages/example/vite.config.ts` — base path configurable via `VITE_BASE_PATH` env var
- `packages/example/src/basePath.ts` — shared `BASE_PATH` constant
- `packages/example/src/pages/*.tsx` — replaced hardcoded `/scorer-ui-kit/` paths
- `packages/example/src/svg/login-screen.svg` — font URLs changed to relative paths

## Test plan

- [ ] Merge this PR and push to `main` — verify production deploy still works at root
- [ ] Push to `demo` branch — verify it deploys to `/branch/demo/`
- [ ] Open a test PR — verify preview comment appears with working link
- [ ] Close the test PR — verify `/pr/<number>/` is cleaned up from gh-pages
- [ ] Push to `main` after PR previews exist — verify `/pr/` and `/branch/` dirs survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)