### PR TITLE
Move PR preview cleanup into main deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   deployments: write
+  pull-requests: read
 
 # Share concurrency group with PR deploys to avoid push races
 concurrency:
@@ -77,6 +78,8 @@ jobs:
         npm run build-storybook
 
     - name: Deploy GH Pages
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         git config user.name "github-actions-bot"
         git config user.email "support+actions@github.com"
@@ -105,6 +108,21 @@ jobs:
               mv "$dir" gh-pages-dir/
             fi
           done
+
+          # Clean up previews for PRs that are no longer open
+          if [ -d "gh-pages-dir/pr" ]; then
+            OPEN_PRS=$(gh pr list --state open --json number --jq '.[].number' || echo "")
+            for pr_dir in gh-pages-dir/pr/*/; do
+              [ -d "$pr_dir" ] || continue
+              pr_num=$(basename "$pr_dir")
+              if ! echo "$OPEN_PRS" | grep -qx "$pr_num"; then
+                echo "Removing stale preview for PR #${pr_num}"
+                rm -rf "$pr_dir"
+              fi
+            done
+            # Remove pr/ directory itself if empty
+            rmdir gh-pages-dir/pr 2>/dev/null || true
+          fi
         else
           # Branch deploy: only replace this branch's subdirectory
           rm -rf "gh-pages-dir/${DEST_DIR}"

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -2,7 +2,7 @@ name: PR Deploy Preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
@@ -114,32 +114,3 @@ jobs:
               body,
             });
           }
-
-  cleanup-preview:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Remove preview from gh-pages
-      run: |
-        PR_NUM=${{ github.event.pull_request.number }}
-
-        git config user.name "github-actions-bot"
-        git config user.email "support+actions@github.com"
-
-        git fetch origin gh-pages
-
-        git worktree add gh-pages-dir origin/gh-pages
-
-        if [ -d "gh-pages-dir/pr/${PR_NUM}" ]; then
-          rm -rf "gh-pages-dir/pr/${PR_NUM}"
-          cd gh-pages-dir
-          git add .
-          git commit -m "Remove preview for PR ${PR_NUM}"
-          git push origin HEAD:gh-pages
-          echo "Cleaned up preview for PR ${PR_NUM}"
-        else
-          echo "No preview found for PR ${PR_NUM}, nothing to clean up"
-        fi


### PR DESCRIPTION
## Summary
- Removes the `cleanup-preview` job from `pr-deploy.yml` — it shared a concurrency group with the main deploy and got cancelled on merge (e.g. PR #633's preview was never cleaned up)
- Main deploy now queries open PRs and removes any stale `pr/` directories on every push to main — self-healing
- Adds `pull-requests: read` permission to `deploy.yml` for `gh pr list`

## Test plan
- [ ] Merge a PR that has a deploy preview and verify the next push to main removes its `pr/N` directory from gh-pages
- [ ] Verify `pr/633` gets cleaned up on next main deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)