### PR TITLE
Release v3.0.0-beta.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.6",
+      "version": "3.0.0-beta.7",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -11014,7 +11014,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.6",
+      "version": "3.0.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps version to `3.0.0-beta.7`.

### Changes since v3.0.0-beta.6
- Fix styled buttons class issues (#632)
- Add deploy previews for PRs and branches (#633)
- Remove all PTZ related code from UI Kit (#631)
- Fix examples page, package-lock had some react18 transitive added (#630)
- Create React App artifacts removal (#629)
- Vite 8 upgrade (#628)

## After merge

Run the following to tag and publish:

```bash
git checkout main && git pull
git tag v3.0.0-beta.7
git push origin v3.0.0-beta.7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)