### PR TITLE
Fix React 19 remaining issues and WebRTC StrictMode (#627)

### DIFF
--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -21,6 +21,7 @@ import Layouts from './pages/Layouts';
 import SplitLayouts from './pages/SplitLayout';
 import SwitchWithAPI from './pages/SwitchTest';
 import UsePollTestPage from './pages/UsePollTestPage';
+import WebRTCStrictModeTestPage from './pages/WebRTCStrictModeTestPage';
 
 const App: React.FC<{}> = () => {
   return (
@@ -42,6 +43,7 @@ const App: React.FC<{}> = () => {
         <Route path='/split-layouts' element={<SplitLayouts />} />
         <Route path='/switch-test' element={<SwitchWithAPI />} />
         <Route path='/usepoll-test' element={<UsePollTestPage />} />
+        <Route path='/webrtc-strictmode-test' element={<WebRTCStrictModeTestPage />} />
       </Routes>
     </Router>
   )

--- a/packages/example/src/pages/Index.tsx
+++ b/packages/example/src/pages/Index.tsx
@@ -190,6 +190,13 @@ const LinksPage : React.FC = () => {
             <FilenameTag>UsePollTestPage.tsx</FilenameTag>
           </Link>
         </Item>
+        <Item>
+          <Link to={`/webrtc-strictmode-test`}>
+            <Title>WebRTC — StrictMode Double-Mount</Title>
+            <Description>Verifies WebRTCPlayer mounts without WebSocket errors in StrictMode.</Description>
+            <FilenameTag>WebRTCStrictModeTestPage.tsx</FilenameTag>
+          </Link>
+        </Item>
       </List>
     </Section>
 

--- a/packages/example/src/pages/WebRTCStrictModeTestPage.tsx
+++ b/packages/example/src/pages/WebRTCStrictModeTestPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styled from 'styled-components';
-import { PageHeader, Button, WebRTCPlayer, Tag } from 'scorer-ui-kit';
+import { PageHeader, Button, WebRTCClient, Tag } from 'scorer-ui-kit';
 import ExamplesFilename from '../components/ExamplesFilename';
 
 // ─── Styled components ───────────────────────────────────────────────────────
@@ -253,13 +253,14 @@ const WebRTCStrictModeTestPage: React.FC = () => {
 
       {mounted && (
         <HiddenPlayer>
-          <WebRTCPlayer
+          <WebRTCClient
             enabled
             peerAddress='ws://localhost:1/'
             maxConnectionAttempts={2}
             setStatus={setStatus}
             setError={setError}
           />
+
         </HiddenPlayer>
       )}
 

--- a/packages/example/src/pages/WebRTCStrictModeTestPage.tsx
+++ b/packages/example/src/pages/WebRTCStrictModeTestPage.tsx
@@ -1,0 +1,288 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import styled from 'styled-components';
+import { PageHeader, Button, WebRTCPlayer, Tag } from 'scorer-ui-kit';
+import ExamplesFilename from '../components/ExamplesFilename';
+
+// ─── Styled components ───────────────────────────────────────────────────────
+
+const Container = styled.div`
+  padding: 50px;
+`;
+
+const ExplanationBlock = styled.div`
+  margin: 8px 0 24px;
+  padding: 16px 20px;
+  background: var(--grey-2);
+  border-radius: 4px;
+  border-left: 3px solid var(--primary-7);
+  font-family: var(--font-data);
+  font-size: 13px;
+  line-height: 1.8;
+  color: var(--grey-11);
+`;
+
+const ExParagraph = styled.p`
+  margin: 0 0 10px;
+  &:last-child { margin-bottom: 0; }
+`;
+
+const CodeBlock = styled.code`
+  color: var(--primary-9);
+  font-family: var(--font-data);
+`;
+
+const StepList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin-top: 6px;
+`;
+
+const StepRow = styled.div`
+  display: grid;
+  grid-template-columns: 90px 1fr;
+`;
+
+const StepNum = styled.span`
+  font-weight: 600;
+  color: var(--grey-12);
+`;
+
+const StepContent = styled.span`
+  color: var(--grey-11);
+`;
+
+const ControlBar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+`;
+
+const StatusRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+`;
+
+const StatusLabel = styled.span`
+  font-family: var(--font-ui);
+  font-size: 13px;
+  color: var(--grey-9);
+  min-width: 60px;
+`;
+
+const ConsolePanel = styled.div`
+  background: var(--grey-1);
+  border: 1px solid var(--grey-4);
+  border-radius: 4px;
+  padding: 16px;
+  margin-top: 20px;
+  max-height: 300px;
+  overflow-y: auto;
+  font-family: var(--font-data);
+  font-size: 12px;
+`;
+
+const ConsoleLine = styled.div<{ $level: 'error' | 'debug' | 'info' }>`
+  padding: 2px 0;
+  color: ${({ $level }) =>
+    $level === 'error' ? 'var(--danger-9)' :
+    $level === 'debug' ? 'var(--grey-8)' :
+    'var(--grey-11)'};
+`;
+
+const ConsoleHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+`;
+
+const ConsoleTitle = styled.span`
+  font-family: var(--font-ui);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--grey-12);
+`;
+
+const HiddenPlayer = styled.div`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+`;
+
+// ─── Console capture hook ────────────────────────────────────────────────────
+
+interface LogEntry {
+  level: 'error' | 'debug' | 'info';
+  message: string;
+  timestamp: string;
+}
+
+const useConsoleCapture = () => {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const originalError = useRef<typeof console.error | null>(null);
+  const originalDebug = useRef<typeof console.debug | null>(null);
+
+  useEffect(() => {
+    originalError.current = console.error;
+    originalDebug.current = console.debug;
+
+    const addLog = (level: LogEntry['level'], args: unknown[]) => {
+      const message = args.map(a =>
+        typeof a === 'object' ? JSON.stringify(a, null, 0) : String(a)
+      ).join(' ');
+      // Only capture WebSocket / WebRTC related messages
+      if (message.toLowerCase().includes('websocket') ||
+          message.toLowerCase().includes('webrtc') ||
+          message.toLowerCase().includes('connect') ||
+          message.toLowerCase().includes('cleanup') ||
+          message.toLowerCase().includes('server') ||
+          message.toLowerCase().includes('peer') ||
+          message.toLowerCase().includes('hello') ||
+          message.toLowerCase().includes('canceled')) {
+        setLogs(prev => [...prev, {
+          level,
+          message,
+          timestamp: new Date().toLocaleTimeString(),
+        }]);
+      }
+    };
+
+    console.error = (...args: unknown[]) => {
+      addLog('error', args);
+      originalError.current?.(...args);
+    };
+
+    console.debug = (...args: unknown[]) => {
+      addLog('debug', args);
+      originalDebug.current?.(...args);
+    };
+
+    return () => {
+      if (originalError.current) console.error = originalError.current;
+      if (originalDebug.current) console.debug = originalDebug.current;
+    };
+  }, []);
+
+  const clearLogs = useCallback(() => setLogs([]), []);
+
+  return { logs, clearLogs };
+};
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+const WebRTCStrictModeTestPage: React.FC = () => {
+  const [mounted, setMounted] = useState(false);
+  const [status, setStatus] = useState('Not connected');
+  const [error, setError] = useState<string | null>(null);
+  const { logs, clearLogs } = useConsoleCapture();
+
+  const errorCount = logs.filter(l => l.level === 'error').length;
+
+  return (
+    <Container>
+      <PageHeader
+        title='WebRTCPlayer — StrictMode Double-Mount'
+        introductionText='Tests that mounting WebRTCPlayer in StrictMode does not produce WebSocket console errors. The connection is pointed at a non-routable address to trigger fast failure.'
+      />
+
+      <ExplanationBlock>
+        <ExParagraph>
+          <strong>Bug (issue #627):</strong> In React 18+ StrictMode, components are double-mounted
+          (mount → cleanup → remount). <CodeBlock>WebRTCPlayer</CodeBlock> created a WebSocket
+          immediately in <CodeBlock>useEffect</CodeBlock>. StrictMode&apos;s cleanup closed it before
+          the connection was established, producing browser-level errors:
+        </ExParagraph>
+        <ExParagraph>
+          <CodeBlock>WebSocket connection to &apos;ws://...&apos; failed: WebSocket is closed before the connection is established.</CodeBlock>
+        </ExParagraph>
+        <ExParagraph>
+          <strong>Fix:</strong> Defer <CodeBlock>connectToPeer()</CodeBlock> with{' '}
+          <CodeBlock>setTimeout(fn, 0)</CodeBlock> so StrictMode&apos;s synchronous cleanup cancels
+          the timeout before a WebSocket is ever created. The second mount proceeds normally.
+        </ExParagraph>
+        <ExParagraph><strong>Steps to test:</strong></ExParagraph>
+        <StepList>
+          <StepRow>
+            <StepNum>1.</StepNum>
+            <StepContent>Click Mount below — the WebRTCPlayer component will mount in StrictMode</StepContent>
+          </StepRow>
+          <StepRow>
+            <StepNum>2.</StepNum>
+            <StepContent>Check the console capture panel — there should be no red error lines</StepContent>
+          </StepRow>
+          <StepRow>
+            <StepNum>3.</StepNum>
+            <StepContent>Try Unmount → Mount cycle to verify repeated mounts are clean</StepContent>
+          </StepRow>
+        </StepList>
+      </ExplanationBlock>
+
+      <ControlBar>
+        <Button
+          design={mounted ? 'secondary' : 'primary'}
+          size='small'
+          onClick={() => { setMounted(m => !m); setError(null); }}
+        >
+          {mounted ? 'Unmount' : 'Mount'}
+        </Button>
+        <Button
+          design='secondary'
+          size='small'
+          onClick={() => { setMounted(false); setError(null); setTimeout(() => setMounted(true), 50); }}
+        >
+          Remount
+        </Button>
+      </ControlBar>
+
+      <StatusRow>
+        <StatusLabel>Status:</StatusLabel>
+        <Tag tagSize='compact' label={status} />
+      </StatusRow>
+      {error && (
+        <StatusRow>
+          <StatusLabel>Error:</StatusLabel>
+          <Tag tagSize='compact' label={error} />
+        </StatusRow>
+      )}
+
+      {mounted && (
+        <HiddenPlayer>
+          <WebRTCPlayer
+            enabled
+            peerAddress='ws://localhost:1/'
+            maxConnectionAttempts={2}
+            setStatus={setStatus}
+            setError={setError}
+          />
+        </HiddenPlayer>
+      )}
+
+      <ConsolePanel>
+        <ConsoleHeader>
+          <ConsoleTitle>
+            Console Capture {errorCount > 0 ? `(${errorCount} error${errorCount > 1 ? 's' : ''})` : '(clean)'}
+          </ConsoleTitle>
+          <Button design='secondary' size='small' onClick={clearLogs}>Clear</Button>
+        </ConsoleHeader>
+        {logs.length === 0 && (
+          <ConsoleLine $level='info'>No WebSocket/WebRTC messages captured yet. Click Mount to start.</ConsoleLine>
+        )}
+        {logs.map((log, i) => (
+          <ConsoleLine key={i} $level={log.level}>
+            [{log.timestamp}] [{log.level.toUpperCase()}] {log.message}
+          </ConsoleLine>
+        ))}
+      </ConsolePanel>
+
+      <ExamplesFilename>WebRTCStrictModeTestPage.tsx</ExamplesFilename>
+    </Container>
+  );
+};
+
+export default WebRTCStrictModeTestPage;

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -55,8 +55,8 @@
     "link": "npm link && npm link react && npm link react-dom && npm link react-router-dom && npm link styled-components"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-router": "^7.0.0",
     "react-router-dom": "^7.0.0",
     "styled-components": "^6.1.0"

--- a/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
+++ b/packages/ui-lib/src/Filters/atoms/FilterDropHandler.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
+import React, { useState, useRef, useCallback, useImperativeHandle } from 'react';
 import styled, { css } from 'styled-components';
 import FilterButton from '../atoms/FilterButton';
 import { useClickOutside } from '../../hooks/useClickOutside';
@@ -88,30 +88,28 @@ interface IFilterDropHandler {
   onToggleOpenCallback?: (isOpen: boolean) => void
   onCloseCallback?: () => void
   children?: React.ReactNode;
+  ref?: React.Ref<FilterDropHandlerRef>
 }
 
 export interface FilterDropHandlerRef {
   imperativeClose: () => void;
 }
 
-const FilterDropHandler = forwardRef<FilterDropHandlerRef, IFilterDropHandler>(
-  (
-    {
-      buttonIcon,
-      buttonText,
-      disabled = false,
-      minWidth = 270,
-      minHeight = 190,
-      isSortAscending,
-      design = 'default',
-      noCloseOnClickOutside,
-      children,
-      onToggleOpenCallback = () => { },
-      onCloseCallback = () => { },
-      ...props
-    },
-    imperativeRef
-  ) => {
+const FilterDropHandler: React.FC<IFilterDropHandler> = ({
+  buttonIcon,
+  buttonText,
+  disabled = false,
+  minWidth = 270,
+  minHeight = 190,
+  isSortAscending,
+  design = 'default',
+  noCloseOnClickOutside,
+  children,
+  onToggleOpenCallback = () => { },
+  onCloseCallback = () => { },
+  ref,
+  ...props
+}) => {
 
     const [openState, setOpenState] = useState<IDropOpen>({
       isOpen: false,
@@ -161,7 +159,7 @@ const FilterDropHandler = forwardRef<FilterDropHandlerRef, IFilterDropHandler>(
     }, []);
 
     // Expose imperativeClose method via ref
-    useImperativeHandle(imperativeRef, () => ({
+    useImperativeHandle(ref, () => ({
       imperativeClose: handleImperativeClose,
     }));
 
@@ -182,7 +180,6 @@ const FilterDropHandler = forwardRef<FilterDropHandlerRef, IFilterDropHandler>(
         </ContentBox>
       </Container>
     );
-  }
-);
+};
 
 export default FilterDropHandler;

--- a/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DropdownDatePicker.tsx
@@ -111,15 +111,10 @@ const DropdownDatePicker: React.FC<IDropdownDatePicker> = ({
    * Caching the selected null /clear flag for this picker from parent component
    */
   useEffect(() => {
-    let canUnmount = true;
-
-    if (canUnmount && selected === null && pickerValue.current !== null) {
+    if (selected === null && pickerValue.current !== null) {
       pickerValue.current = selected;
       setMountedPicker({ initialValue: undefined, isMount: false });
     }
-    return () => {
-      canUnmount = false;
-    };
   }, [selected]);
 
   return (

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -400,16 +400,8 @@ const handleApply = useCallback(() => {
 
   // This UseEffect ensures visible list is updated when toggling language
   useEffect(() => {
-    let isActive = true;
-    if (isActive) {
-      setSearchText(''); // clears searchText if something was selected and the dropdown is still open
-      setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, isSortAscending));
-    }
-
-    return () => {
-      isActive = false;
-    };
-
+    setSearchText(''); // clears searchText if something was selected and the dropdown is still open
+    setVisibleList(selectedOrderList(list, maxDisplayedItems, tempSelected, isSortAscending));
   }, [isSortAscending, list, maxDisplayedItems, tempSelected]);
 
   useEffect(() => {

--- a/packages/ui-lib/src/Form/organisms/AvatarUploader.tsx
+++ b/packages/ui-lib/src/Form/organisms/AvatarUploader.tsx
@@ -167,9 +167,6 @@ const AvatarUploader: React.FC<IAvatar> = ({
 
   useEffect(() => {
     setAvatarImg(currentImg);
-    return () => {
-      setAvatarImg('');
-    };
   }, [currentImg]);
 
   const handleRemove = useCallback(() => {

--- a/packages/ui-lib/src/Layouts/index.ts
+++ b/packages/ui-lib/src/Layouts/index.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, Ref } from 'react';
 import ContentLayout from './organisms/ContentLayout';
 import FullWidthContentBlock from './atoms/FullWidthContentBlock';
 import UtilityHeader from './molecules/UtilityHeader';
@@ -70,6 +70,7 @@ export interface ISplitLayoutProps {
   persist?: boolean;
   persistenceKey?: string;
   showDebug?: boolean;
+  ref?: Ref<ISplitLayoutHandles>;
 }
 
 export interface ISplitLayoutHandles {

--- a/packages/ui-lib/src/Layouts/molecules/SplitLayout.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/SplitLayout.tsx
@@ -1,8 +1,8 @@
-import React, { PointerEvent, useState, useCallback, useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
+import React, { PointerEvent, useState, useCallback, useEffect, useRef, useImperativeHandle } from 'react';
 import styled, { css } from "styled-components";
 import ResizeLine, { TResizeLineDirection, TResizeLineStates } from '../atoms/ResizeLine';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
-import { ISideAreaState, ISplitLayoutHandles, ISplitLayoutProps } from '..';
+import { ISideAreaState, ISplitLayoutProps } from '..';
 
 interface IPosition {
   x: number;
@@ -164,7 +164,7 @@ const Container = styled.section<{$initialised?: 'true' | 'false', $layout?: Lay
 // A flex container where the two internal areas can be adjusted with a drag handle.
 // The main area has a minimum size - it flexes to the available space.
 // The secondary side area has more restraints and is the part that is actively resized.
-const SplitLayout = forwardRef<ISplitLayoutHandles, ISplitLayoutProps>(({ mainArea, sideArea, layout = 'horizontal', reverse, dividerSize = 16, persist = false, persistenceKey = 'resizable_ui', showDebug }, controlRef) => {
+const SplitLayout: React.FC<ISplitLayoutProps> = ({ mainArea, sideArea, layout = 'horizontal', reverse, dividerSize = 16, persist = false, persistenceKey = 'resizable_ui', showDebug, ref: controlRef }) => {
 
   const componentKey : string = 'resizable_layout_';
   const referenceKey : string = componentKey + persistenceKey;
@@ -482,7 +482,7 @@ const SplitLayout = forwardRef<ISplitLayoutHandles, ISplitLayoutProps>(({ mainAr
       {showDebug ? debugData : null}
     </Container>
   );
-});
+};
 
 
 /**

--- a/packages/ui-lib/src/WebRTCClient.tsx
+++ b/packages/ui-lib/src/WebRTCClient.tsx
@@ -161,11 +161,11 @@ const WebRTCPlayer: React.FC<Props> = ({
   };
 
   function onServerClose(event: CloseEvent) {
-    console.debug('serverClose');
     // Ignore close events from stale WebSocket connections (e.g. StrictMode cleanup)
     if(!webSocket.current || event.target !== webSocket.current){
       return;
     }
+    console.debug('serverClose');
     setStatus('Disconnected from server');
     closePeerConnection();
     if (event.code !== 1000 && enabledRef.current && mountedRef.current) {
@@ -179,7 +179,7 @@ const WebRTCPlayer: React.FC<Props> = ({
   function onServerError(event: Event) {
     // Ignore errors from stale WebSocket connections
     if(event.target !== webSocket.current){ return; }
-    console.debug(event);
+    console.debug('serverError', event);
     setError('Unable to connect to server');
     closeWebSocket();
   }
@@ -286,18 +286,29 @@ const WebRTCPlayer: React.FC<Props> = ({
 
   useEffect(() => {
     mountedRef.current = true;
+    let connectTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
     if (enabled === true) {
-      connectToPeer();
+      // Defer connection so StrictMode's synchronous cleanup cancels it
+      // before a WebSocket is ever created, avoiding the browser-level
+      // "WebSocket is closed before the connection is established" error.
+      connectTimeoutId = setTimeout(() => {
+        connectTimeoutId = null;
+        if (mountedRef.current) {
+          connectToPeer();
+        }
+      }, 0);
     } else {
       if (webSocket.current) {
         webSocket.current.close(1000, 'WebRTC Disabled');
       }
     }
     return ()=>{
-      console.debug('cleanup');
       mountedRef.current = false;
 
+      if(connectTimeoutId !== null){
+        clearTimeout(connectTimeoutId);
+      }
       if(reconnectTimeoutRef.current !== null){
         clearTimeout(reconnectTimeoutRef.current);
         reconnectTimeoutRef.current = null;


### PR DESCRIPTION
## Summary

- **Remove deprecated `forwardRef`** from `FilterDropHandler` and `SplitLayout` — React 19 passes `ref` as a regular prop natively
- **Remove unnecessary `AvatarUploader` cleanup** that caused a placeholder flash in StrictMode double-mount
- **Remove dead guard flags** (`isActive` in `FilterDropdown`, `canUnmount` in `DropdownDatePicker`) — synchronous guards that were always true
- **Fix WebRTCPlayer StrictMode double-mount** (#627) — defer `connectToPeer()` so StrictMode cleanup cancels the timeout before a WebSocket is ever created; moves debug logging after stale-connection checks
- **Drop React 17/18 support** — tighten `peerDependencies` to `^19.0.0` (required for forwardRef removal)
- Adds `WebRTCStrictModeTestPage` example page with inline console capture for verifying the WebSocket fix

## Test plan

- [x] `npm run test` passes (unit tests + lint + build)
- [x] Storybook: FilterDropdown, SplitLayout, AvatarUploader, FilterBar stories render with zero console warnings
- [x] Storybook: No `forwardRef` deprecation warnings in console
- [x] Example app: `/webrtc-strictmode-test` page shows no WebSocket errors on mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)