### PR TITLE
SplitLayout - Drag handle and arrow alignment fix

### DIFF
--- a/packages/ui-lib/src/Layouts/atoms/ResizeLine.tsx
+++ b/packages/ui-lib/src/Layouts/atoms/ResizeLine.tsx
@@ -20,6 +20,8 @@ const Line  = styled.div`
 
 const IconContainer = styled.div`
   flex: 0 0 20px;
+  display: flex;
+  align-items: center;
   svg {
     path {
       stroke: var(--grey-11);


### PR DESCRIPTION
On the horizontal drag handles, in both drag and closed states, the icons were out of place. Uses flex now to position these correctly.

Before: 
<img width="434" height="200" alt="image" src="https://github.com/user-attachments/assets/65d6322a-89cd-4f6b-ab01-94501125afc1" />

After:
<img width="445" height="236" alt="image" src="https://github.com/user-attachments/assets/24c60acf-785f-4b28-9f60-aa61da49c90d" />
