### PR TITLE
Fix 42 noArrayIndexKey warnings (closes #646)

### DIFF
--- a/packages/example/src/components/StatusComponent.tsx
+++ b/packages/example/src/components/StatusComponent.tsx
@@ -44,6 +44,7 @@ export const StatusComponent: React.FC<IStatusBundle> = ({ statusList }) => {
       {statusList.map(
         ({ type, tooltipMessage, tooltipIcon, tooltipType, tooltipPosition }, index) => {
           return (
+            // biome-ignore lint/suspicious/noArrayIndexKey: index is also used to look up the parallel statusRefs.current[index] ref array — it has structural meaning. #646.
             <Fragment key={index}>
               <StatusDot
                 ref={statusRefs.current[index]}

--- a/packages/example/src/pages/WebRTCStrictModeTestPage.tsx
+++ b/packages/example/src/pages/WebRTCStrictModeTestPage.tsx
@@ -303,6 +303,7 @@ const WebRTCStrictModeTestPage: React.FC = () => {
           </ConsoleLine>
         )}
         {logs.map((log, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: log entries are append-only, no reordering — index is stable for this list. #646.
           <ConsoleLine key={i} $level={log.level}>
             [{log.timestamp}] [{log.level.toUpperCase()}] {log.message}
           </ConsoleLine>

--- a/packages/ui-lib/src/CameraPanels/organisms/CameraPanels.tsx
+++ b/packages/ui-lib/src/CameraPanels/organisms/CameraPanels.tsx
@@ -16,6 +16,7 @@ const CameraPanels: React.FC<ICameraPanels> = ({ panels }) => {
   return (
     <CameraGrid>
       {panels.map((props, index) => {
+        // biome-ignore lint/suspicious/noArrayIndexKey: ICameraPanel has no stable identifier field — streamProps is itself an object, panelMetaData is optional. #646.
         return <CameraPanel key={index} {...props} />;
       })}
     </CameraGrid>

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -600,27 +600,27 @@ const DatePicker: React.FC<IDatePicker> = ({
         </CalendarHeader>
 
         <CalHRow>
-          {dayGuide.map((day, index) => {
-            return <CalHCell key={index}>{day}</CalHCell>;
+          {dayGuide.map((day) => {
+            return <CalHCell key={day}>{day}</CalHCell>;
           })}
         </CalHRow>
 
         <CalBody>
-          {weeksOfMonth.map((week, index) => {
+          {weeksOfMonth.map((week) => {
             const days = eachDayOfInterval({
               start: week,
               end: endOfWeek(week),
             });
 
             return (
-              <CalRow key={index}>
-                {days.map((day, index) => {
+              <CalRow key={+week}>
+                {days.map((day) => {
                   const dayState = cellState(day, selectedRange);
                   const isTodayValue = isToday(day);
 
                   return (
                     <CalCellB
-                      key={index}
+                      key={+day}
                       disabled={isDayOutOfRange(day, availableRange)}
                       onClick={() => onCellClick(day)}
                       $state={dayState}

--- a/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterDropdown.tsx
@@ -477,12 +477,12 @@ const FilterDropdown: React.FC<IFilterDropdown> = ({
               )}
               <OptionList $moreItem={list.length > 5}>
                 {visibleList.length > 0 ? (
-                  visibleList.map((item: IFilterItem, index) => {
+                  visibleList.map((item: IFilterItem) => {
                     const value = item.value;
                     const text = item.text;
                     return (
                       <StyledFilterOption
-                        key={index}
+                        key={String(value)}
                         title={text}
                         onClick={() => handleSelection(item)}
                         selected={isValueSelected(item, tempSelected)}

--- a/packages/ui-lib/src/Filters/molecules/FilterLayout.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FilterLayout.tsx
@@ -311,7 +311,7 @@ const FilterLayout: React.FC<IProps> = ({
               {contentArray.map((item, index) => {
                 return (
                   <ContextActionButton
-                    key={index}
+                    key={item.id}
                     $isInnerContextButton={index !== contentArray.length - 1}
                     $isActive={isGridLayout === item.id}
                     onClick={() => switchLayout(item.id)}
@@ -340,8 +340,8 @@ const FilterLayout: React.FC<IProps> = ({
                       isCompact
                       value={pageSize}
                     >
-                      {pageSizeOptions.map((size: number, index: number) => (
-                        <option key={index} value={size}>
+                      {pageSizeOptions.map((size: number) => (
+                        <option key={size} value={size}>
                           {size}
                         </option>
                       ))}

--- a/packages/ui-lib/src/Filters/molecules/FiltersResults.tsx
+++ b/packages/ui-lib/src/Filters/molecules/FiltersResults.tsx
@@ -163,9 +163,9 @@ const FiltersResults: React.FC<IFilterResults> = ({
     <Container {...props}>
       <ResultsTextWrapper>{renderResults(resultTextTemplate, totalResults)}</ResultsTextWrapper>
       <FilterLabelsGroup>
-        {labelLists.map(({ icon, item, filterName, filterId, type }, index) => {
+        {labelLists.map(({ icon, item, filterName, filterId, type }) => {
           return (
-            <FilterLabel key={`Filter-Label-id-${index}`}>
+            <FilterLabel key={`Filter-Label-id-${filterId}`}>
               {icon && <Icon icon={icon} color='dimmed' size={10} weight='light' />}
               {renderLabel(item, resultsDateFormat, icon, filterName)}
               <RemoveButton onClick={() => onRemoveFilter(filterId, type, item)}>

--- a/packages/ui-lib/src/Filters/molecules/SortDropdown.tsx
+++ b/packages/ui-lib/src/Filters/molecules/SortDropdown.tsx
@@ -142,10 +142,10 @@ const SortDropdown: React.FC<ISortDropdown> = ({
             <LoadingBox {...{ loadingText }} />
           ) : (
             <OptionList>
-              {list.map((item, index) => {
+              {list.map((item) => {
                 return (
                   <StyledFilterOption
-                    key={index}
+                    key={String(item.value)}
                     title={item.text}
                     optionType='radio'
                     selected={selected.value === item.value}

--- a/packages/ui-lib/src/Form/atoms/SliderInput.tsx
+++ b/packages/ui-lib/src/Form/atoms/SliderInput.tsx
@@ -188,7 +188,7 @@ const renderMarks = (
     listOptions.push(<option key={`option-${value}`}>{value}</option>);
 
     return (
-      <Fragment key={`mark-${index}`}>
+      <Fragment key={`mark-${value}`}>
         <Mark data-leftvalue={`${left}%`} $leftValue={left} />
         <MarkLabel
           $leftValue={left}

--- a/packages/ui-lib/src/Form/molecules/DurationSlider.tsx
+++ b/packages/ui-lib/src/Form/molecules/DurationSlider.tsx
@@ -96,16 +96,22 @@ const getValueTitle = (value: number, timeUnit: ITimeUnit | string, timeFormat?:
   const updatedTitle = timeFormat.split(/(\[H+\]|\[M+\]|\[S+\])/).map((part, index) => {
     switch (part) {
       case '[HH]':
+        // biome-ignore lint/suspicious/noArrayIndexKey: parts come from timeFormat.split() — order is fixed and tokens may repeat (e.g. '[HH]:[HH]'), so index is the right key. #646.
         return <span key={index}>{timeValues.hours.toString().padStart(2, '0')}</span>;
       case '[H]':
+        // biome-ignore lint/suspicious/noArrayIndexKey: see above. #646.
         return <span key={index}>{timeValues.hours}</span>;
       case '[MM]':
+        // biome-ignore lint/suspicious/noArrayIndexKey: see above. #646.
         return <span key={index}>{timeValues.minutes.toString().padStart(2, '0')}</span>;
       case '[M]':
+        // biome-ignore lint/suspicious/noArrayIndexKey: see above. #646.
         return <span key={index}>{timeValues.minutes}</span>;
       case '[SS]':
+        // biome-ignore lint/suspicious/noArrayIndexKey: see above. #646.
         return <span key={index}>{timeValues.seconds.toString().padStart(2, '0')}</span>;
       case '[S]':
+        // biome-ignore lint/suspicious/noArrayIndexKey: see above. #646.
         return <span key={index}>{timeValues.seconds}</span>;
       default: {
         const preserveSpacesInPart = part.replace(/\s+/g, '\u00A0');

--- a/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
+++ b/packages/ui-lib/src/Global/atoms/NavigationItem.tsx
@@ -215,6 +215,7 @@ const generateSubmenus = (
       // Treat as menu item/
       if (isExternalLink) {
         grouping[grouping.length - 1].push(
+          // biome-ignore lint/suspicious/noArrayIndexKey: forEach iterates a static submenu config that doesn't reorder; submenu items aren't all guaranteed to have a unique field. #646.
           <SubmenuItem key={key} $isActive={false}>
             <SubmenuItemAnchor href={href} target='_blank'>
               {title}
@@ -226,6 +227,7 @@ const generateSubmenus = (
         );
       } else {
         grouping[grouping.length - 1].push(
+          // biome-ignore lint/suspicious/noArrayIndexKey: see above. #646.
           <SubmenuItem key={key} $isActive={false}>
             <SubmenuItemLink to={href} onClick={() => onClickCallback?.(-1)}>
               {title}
@@ -239,6 +241,7 @@ const generateSubmenus = (
         grouping.push([]);
       }
       grouping[grouping.length - 1].push(
+        // biome-ignore lint/suspicious/noArrayIndexKey: see above. #646.
         <SubmenuHeader key={key}>
           <SubmenuItemTitle>{title}</SubmenuItemTitle>
         </SubmenuHeader>
@@ -247,6 +250,7 @@ const generateSubmenus = (
   });
 
   grouping.forEach((group, key) => {
+    // biome-ignore lint/suspicious/noArrayIndexKey: grouping is built in this same function; the index is the only identity. #646.
     output.push(<Submenu key={key}>{group}</Submenu>);
   });
 

--- a/packages/ui-lib/src/Global/molecules/NotificationsHistory.tsx
+++ b/packages/ui-lib/src/Global/molecules/NotificationsHistory.tsx
@@ -24,9 +24,9 @@ const NotificationWrapper = styled.div`
 `;
 
 const renderNotifications = (items: INotificationItem[], type: string) =>
-  items.map((item, index) => {
+  items.map((item) => {
     return (
-      <NotificationWrapper key={`alert-${type}-${index}`}>
+      <NotificationWrapper key={`alert-${type}-${item.time}-${item.title}`}>
         <NotificationItem {...item} />
       </NotificationWrapper>
     );

--- a/packages/ui-lib/src/Global/molecules/UserMenu.tsx
+++ b/packages/ui-lib/src/Global/molecules/UserMenu.tsx
@@ -215,6 +215,7 @@ const UserMenu: React.FC<IUserMenu> = ({
               return (
                 <UserDetails
                   onUserDrawerMetaClick={onUserDrawerMetaClick}
+                  // biome-ignore lint/suspicious/noArrayIndexKey: IUserDrawerMeta has only optional fields (title/icon/subTitle/notes) — no guaranteed stable identifier. #646.
                   key={key}
                   {...{ item, includeCopyTitle, copySuccessMessage }}
                 />
@@ -227,9 +228,9 @@ const UserMenu: React.FC<IUserMenu> = ({
           <UserOptions>
             <DrawerHeader>{accountOptionText}</DrawerHeader>
             <LinkMenu>
-              {userSubmenu.map(({ text, href }, index) => {
+              {userSubmenu.map(({ text, href }) => {
                 return (
-                  <LinkMenuItem key={index}>
+                  <LinkMenuItem key={href}>
                     <LinkMenuItemA to={href} onClick={handleCloseWhenClick}>
                       {text}
                     </LinkMenuItemA>

--- a/packages/ui-lib/src/Global/organisms/MainMenu.tsx
+++ b/packages/ui-lib/src/Global/organisms/MainMenu.tsx
@@ -200,6 +200,7 @@ const MainMenu: React.FC<IMenu> = ({
                 return (
                   <NavigationItem
                     topLevelPath={getTopLevelPath(location.pathname)}
+                    // biome-ignore lint/suspicious/noArrayIndexKey: index is also passed as contextKey and compared against focusedContext — index has structural meaning here. #646.
                     key={key}
                     contextKey={key}
                     menuOpen={menuState.isMenuOpen}

--- a/packages/ui-lib/src/Global/organisms/MobileMenu.tsx
+++ b/packages/ui-lib/src/Global/organisms/MobileMenu.tsx
@@ -57,6 +57,7 @@ const MobileMenu: React.FC<IMobileMenu> = ({
     <Container>
       {content.items.map((item, key) => {
         return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: index is also used as data-key and contextKey, and compared against focusedContext — structural meaning. #646.
           <ItemWrapper key={key} data-key={key}>
             <NavigationItem
               mobileMenu

--- a/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
+++ b/packages/ui-lib/src/Layouts/molecules/UtilityHeader.tsx
@@ -143,7 +143,7 @@ const UtilityHeader: React.FC<IUtilityHeader> = ({
               );
 
               return (
-                <React.Fragment key={index}>
+                <React.Fragment key={text}>
                   <Breadcrumb>
                     {onClick ? (
                       <BreadcrumbButton onClick={onClick} type='button'>

--- a/packages/ui-lib/src/LineUI/Control.tsx
+++ b/packages/ui-lib/src/LineUI/Control.tsx
@@ -74,6 +74,7 @@ export const Control: React.FC = () => {
         </button>
 
         {state.map((_lineSet, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: index IS the lineSetId — used in dispatch payloads ({type: 'REMOVE_SET', index}). #646.
           <div key={index}>
             <h5>Set {index}</h5>
             <button type='button' onClick={() => dispatch({ type: 'REMOVE_SET', index: index })}>

--- a/packages/ui-lib/src/LineUI/LineSet.tsx
+++ b/packages/ui-lib/src/LineUI/LineSet.tsx
@@ -278,6 +278,7 @@ const LineSet: React.FC<ILineSetProps> = ({
     (lineSetData?.showPointHandle === undefined || lineSetData?.showPointHandle) &&
     lineSetData.points.map(({ x, y }, index) => (
       <HandleUnit
+        // biome-ignore lint/suspicious/noArrayIndexKey: points have only {x,y} (no id) and index is meaningful — used to look up handleAngles[index] and as the index prop. #646.
         key={index + lineSetId}
         lineSetId={lineSetId}
         rotate={lineSetData.rotate}
@@ -300,6 +301,7 @@ const LineSet: React.FC<ILineSetProps> = ({
   const points =
     options.showPoint &&
     lineSetData.points.map(({ x, y }, index) => (
+      // biome-ignore lint/suspicious/noArrayIndexKey: points have only {x,y} — index is the only stable identity. #646.
       <Point $styling={lineSetData.styling || 'primary'} key={index} r={unit} cx={x} cy={y} />
     ));
 
@@ -315,6 +317,7 @@ const LineSet: React.FC<ILineSetProps> = ({
 
     return (
       <LineUnit
+        // biome-ignore lint/suspicious/noArrayIndexKey: lines connect adjacent points (via nextIndex math); index is structural. #646.
         key={index}
         moveEndCB={onLineMoveEnd}
         lineSetId={lineSetId}

--- a/packages/ui-lib/src/LineUI/LineUI.tsx
+++ b/packages/ui-lib/src/LineUI/LineUI.tsx
@@ -218,6 +218,7 @@ const LineUI: React.FC<LineUIProps> = ({
             <LineSet
               hasClickSensingBorder={hasClickSensingBorder}
               lineClickSensingBorder={lineClickSensingBorder}
+              // biome-ignore lint/suspicious/noArrayIndexKey: index IS the lineSetId, also passed to LineSet as the prop of the same name. #646.
               key={index}
               onLineMoveEnd={onLineMoveEnd}
               onLineClick={onLineClick}

--- a/packages/ui-lib/src/LineUI/LineUIRTC.tsx
+++ b/packages/ui-lib/src/LineUI/LineUIRTC.tsx
@@ -225,6 +225,7 @@ const LineUI: React.FC<LineUIProps> = ({
         >
           {state.map((lineSet, index) => (
             <LineSet
+              // biome-ignore lint/suspicious/noArrayIndexKey: index IS the lineSetId, also passed to LineSet as the prop of the same name. #646.
               key={index}
               hasClickSensingBorder={hasClickSensingBorder}
               lineClickSensingBorder={lineClickSensingBorder}

--- a/packages/ui-lib/src/LineUI/LineUIVideoBase.tsx
+++ b/packages/ui-lib/src/LineUI/LineUIVideoBase.tsx
@@ -224,6 +224,7 @@ const LineUIVideoBase: React.FC<LineUIVideoBaseProps> = ({
         >
           {state.map((lineSet, index) => (
             <LineSet
+              // biome-ignore lint/suspicious/noArrayIndexKey: index IS the lineSetId, also passed to LineSet as the prop of the same name. #646.
               key={index}
               hasClickSensingBorder={hasClickSensingBorder}
               lineClickSensingBorder={lineClickSensingBorder}

--- a/packages/ui-lib/src/LineUI/LineUIVideoBase.tsx
+++ b/packages/ui-lib/src/LineUI/LineUIVideoBase.tsx
@@ -125,7 +125,7 @@ const LineUIVideoBase: React.FC<LineUIVideoBaseProps> = ({
     }
   }, [videoSize.h, videoSize.w, unit, onSizeChange, videoRef]);
 
-  const handlePositionTipShow = (e: any) => {
+  const handlePositionTipShow = (e: React.PointerEvent<SVGSVGElement>) => {
     if (e.target === frame.current) {
       setHandleFinder(!handleFinder === false && true);
     }
@@ -142,6 +142,7 @@ const LineUIVideoBase: React.FC<LineUIVideoBaseProps> = ({
     return frame.current.getScreenCTM();
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: videoSize is a trigger dep — flows into <Frame> viewBox attr, so the effect must re-run after React applies the new viewBox. Same pattern as LineUI's imgSize. See #645.
   useEffect(() => {
     if (!frame.current || !loaded) {
       return;

--- a/packages/ui-lib/src/LineUIHls/LineUIVideoHLS.tsx
+++ b/packages/ui-lib/src/LineUIHls/LineUIVideoHLS.tsx
@@ -26,7 +26,7 @@ const LineUIVideoHLS: React.FC<LineUIProps> = (props) => {
 
     const tryAutoplay = () => {
       const el = videoRef.current;
-      if (!el || !el.autoplay) {
+      if (!el?.autoplay) {
         return;
       }
       const result = el.play();

--- a/packages/ui-lib/src/Misc/atoms/ActionsBar.tsx
+++ b/packages/ui-lib/src/Misc/atoms/ActionsBar.tsx
@@ -68,10 +68,10 @@ const ActionsBar: React.FC<IActionsBar> = ({
       <Title>{title}</Title>
       <ButtonsWrapper>
         <LeftButtons>
-          {actionButtons.map(({ design, size, position, text, ...props }, index) => {
+          {actionButtons.map(({ design, size, position, text, ...props }) => {
             return (
               <ButtonWithIcon
-                key={index}
+                key={text}
                 design={design || 'secondary'}
                 size={size || 'small'}
                 position={position || 'left'}

--- a/packages/ui-lib/src/Misc/molecules/Pagination.tsx
+++ b/packages/ui-lib/src/Misc/molecules/Pagination.tsx
@@ -294,8 +294,8 @@ const Pagination: React.FC<IPagination> = (props) => {
           defaultValue={itemsDefaultValue ? itemsDefaultValue : itemsOptions[0].value || 1}
           changeCallback={onItemsSelectChange}
         >
-          {itemsOptions.map(({ value, textValue }, index) => (
-            <option key={index} value={value}>
+          {itemsOptions.map(({ value, textValue }) => (
+            <option key={value} value={value}>
               {textValue}
             </option>
           ))}

--- a/packages/ui-lib/src/Misc/molecules/TagList.tsx
+++ b/packages/ui-lib/src/Misc/molecules/TagList.tsx
@@ -20,6 +20,7 @@ const TagList: React.FC<ITagList> = ({ tagsConfig }) => {
   return (
     <TagListWrapper>
       {tagsConfig.map((tagProps, index) => {
+        // biome-ignore lint/suspicious/noArrayIndexKey: ITag has only optional fields (label, linkTo, icon) and labels may repeat — index is the only stable identity for this list. #646.
         return <Tag key={`tag-${index}`} {...tagProps} />;
       })}
     </TagListWrapper>

--- a/packages/ui-lib/src/Pages/molecules/MultilineContent.tsx
+++ b/packages/ui-lib/src/Pages/molecules/MultilineContent.tsx
@@ -18,6 +18,7 @@ const MultilineContent: React.FC<IMultiContent> = ({ contentArray }) => {
   return (
     <Container>
       {contentArray.map((element, index) => {
+        // biome-ignore lint/suspicious/noArrayIndexKey: contentArray entries are arbitrary ReactNodes (string | JSX | etc) with no stable identity. #646.
         return <div key={`element-${index}`}>{element}</div>;
       })}
     </Container>

--- a/packages/ui-lib/src/Tables/atoms/TypeTableRow.tsx
+++ b/packages/ui-lib/src/Tables/atoms/TypeTableRow.tsx
@@ -90,6 +90,7 @@ const TypeTableRow: React.FC<IProps> = ({
         const { unit, status, text, customComponent } = cell;
         return (
           <TypeTableCell
+            // biome-ignore lint/suspicious/noArrayIndexKey: cells are positional and index is used to look up the parallel columnConfig[key]. #646.
             key={key}
             href={cell.href}
             {...{

--- a/packages/ui-lib/src/Tables/molecules/TypeTableHeader.tsx
+++ b/packages/ui-lib/src/Tables/molecules/TypeTableHeader.tsx
@@ -258,6 +258,7 @@ const TypeTableHeader: React.FC<ITableHeader> = ({
         }: ITableColumnConfig = column;
         return (
           <HeaderItem
+            // biome-ignore lint/suspicious/noArrayIndexKey: ITableColumnConfig.columnId is optional; column position is the stable identity. #646.
             key={key}
             $alignment={alignment}
             $hasCopyButton={hasCopyButton}

--- a/packages/ui-lib/src/Tables/organisms/TypeTable.tsx
+++ b/packages/ui-lib/src/Tables/organisms/TypeTable.tsx
@@ -160,6 +160,7 @@ const TypeTable: React.FC<IProps> = ({
           const isLastRow = rows.length - 1 === key;
           return (
             <TypeTableRow
+              // biome-ignore lint/suspicious/noArrayIndexKey: IRowData.id is optional and consumers don't always set it; index is the safest fallback. #646.
               key={key}
               {...{
                 rowData,


### PR DESCRIPTION
Closes #646. Tackles all `lint/suspicious/noArrayIndexKey` warnings deferred from the Biome migration (#636), plus 3 incidental warnings exposed in the LineUI HLS-refactor files after rebase.

## Final state
- ✅ `npm run check` — 0 errors, **0 warnings** on this branch (was 47 → 0)
- ✅ `tsc --noEmit` (ui-lib + storybook) — 0 errors
- ✅ Smoke-tested in Storybook: DatePicker calendar render + click, TypeTable 11-row render — no console errors

## Approach (29 commits, one per file)

### Real key fixes — switched index → stable identifier (12 files)

| File | Key | Source of stability |
|---|---|---|
| DatePicker (3 hits) | `day` / `+week` / `+day` | string day name; Date epoch ms |
| FilterDropdown | `String(item.value)` | `IFilterItem.value` |
| FilterLayout (2) | `item.id` / `size` | layout option id; unique pageSizeOption |
| FiltersResults | `filterId` | already destructured |
| SortDropdown | `String(item.value)` | `IFilterItem.value` |
| SliderInput | `mark-${value}` | `mark.value` |
| Pagination | `value` | `IItemsOption.value` |
| ActionsBar | `text` | button label |
| UtilityHeader | `text` | breadcrumb text |
| UserMenu (submenu) | `href` | submenu href |
| NotificationsHistory | `alert-${type}-${time}-${title}` | composite |

### Suppressed with `biome-ignore` (16 sites)

**Index has structural meaning — coupling to parallel arrays:**
- **MainMenu / MobileMenu** — index is also passed as `contextKey` and compared against `focusedContext`
- **TypeTableRow** — `columnConfig[key]` parallel lookup
- **StatusComponent** — `statusRefs.current[index]` parallel ref array
- **LineSet (3)** — `handleAngles[index]` lookup + `nextIndex` math for line endpoints
- **LineUI / LineUIRTC / LineUIVideoBase / Control** — index doubles as `lineSetId` prop

**No stable identity on the data type:**
- **TagList** — `ITag` has only optional fields; labels can repeat
- **CameraPanels** — `ICameraPanel` has no id field
- **MultilineContent** — array of arbitrary `ReactNode`
- **UserMenu (drawer)** — `IUserDrawerMeta` is all-optional
- **TypeTable / TypeTableHeader** — `IRowData.id` and `ITableColumnConfig.columnId` are optional
- **NavigationItem (4 sites)** — submenu mixes link items / group headers / outer wrappers; not all have unique fields
- **DurationSlider (6)** — split format tokens may legitimately repeat (e.g. `[HH]:[HH]`)
- **WebRTCStrictModeTestPage** — append-only log entries

### Incidental warnings cleared (final commit)

After rebasing onto post-#636 main, 3 warnings surfaced in files that landed via the LineUI HLS refactor (#640 / #642):

- **`LineUIVideoBase.tsx`** — `handlePositionTipShow` typed `e: any` → `React.PointerEvent<SVGSVGElement>` (same fix Isabel applied in LineUI.tsx during the Biome migration).
- **`LineUIVideoBase.tsx`** — added `biome-ignore` for the boundary effect's `videoSize` trigger dep, same pattern as LineUI's `imgSize`. Tracked in #645.
- **`LineUIVideoHLS.tsx`** — `!el || !el.autoplay` → `!el?.autoplay` (optional chain, Biome auto-fixable).

## Worth a second look in review

These four pick a real value as key but rely on practical uniqueness. If a consumer ever passes duplicates the items will collapse:

- **NotificationsHistory** — composite `time + title`. Two notifications with both fields equal would collide.
- **ActionsBar** — keyed by `text`. Two buttons with the same label would collide.
- **UtilityHeader** — keyed by breadcrumb `text`.
- **UserMenu submenu** — keyed by `href`.

Fallback if any prove fragile: `${stableField}-${idx}` composite + `biome-ignore`. Composite still includes index but it becomes the disambiguator only.

## Follow-up (separate PR / future work)

After this lands, consider promoting `noArrayIndexKey` from `warn` to `error` in `biome.json` to prevent regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)