### PR TITLE
Release Skill for non beta versions

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: release
+description: Create release of scorer-ui-kit (3.x.y). Bumps the version in the root and packages/ui-lib, opens a release PR, then tags and pushes after the user merges.
+when_to_use: Use when the user wants to create a release, release a new version, or update 3.x.y. Do not invoke automatically, the user always triggers this.
+argument-hint: "[3.x.y or patch | minor | major]"
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash(git *) Bash(gh *) Bash(npm *)
+---
+
+# Release skill for scorer-ui-kit
+
+This skill automates the full release process. The user may pass a version like `/release 3.1.0` or `/release patch` or just `/release` to auto-detect the next version.
+
+Do not improvise. If any command fails or any expected condition is not met, stop immediately and report the issue.
+
+When this skill says "stop": halt automatic progression, tell the user exactly what happened and which command produced it, and wait for instructions. The user may fix the issue and ask the skill to continue, or abort entirely. "Stop" never means "silently abort" — always tell the user first.
+
+## Core rules
+
+- Do not merge the PR.
+- Do not push the release tag until the user confirms the PR has been merged.
+- Do not run `npm publish` manually.
+- Always use `npm run` for npm scripts. Never use `npx` directly.
+- The root `package.json` and `packages/ui-lib/package.json` must have matching versions.
+- If the working tree is dirty before starting, stop.
+- If the release branch or tag already exists, stop.
+- If GitHub CLI is unavailable or unauthenticated, stop.
+- If CI checks fail, stop.
+- After the version bump, only `package.json`, `packages/ui-lib/package.json`, and `package-lock.json` may change. If `node_modules` or any unrelated files change, stop.
+
+## Steps
+
+1. **Preflight checks**
+
+   ```bash
+   git status --short
+   git branch --show-current
+   git fetch origin main --tags
+   git rev-list --count main..origin/main
+   gh auth status
+   ```
+
+   Stop if:
+   - `git status --short` produces any output (working tree is dirty).
+   - `git branch --show-current` is not `main`.
+   - `git rev-list --count main..origin/main` is not `0` (local `main` is behind `origin/main`).
+   - `gh auth status` exits non-zero.
+
+2. **Determine the version**
+   - Get the latest **published** stable tag from origin:
+
+     ```bash
+     git ls-remote --tags --sort=-v:refname origin "v3.*" | grep -E 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 | sed 's|.*refs/tags/v||'
+     ```
+
+     The output is `<PREV_TAG>` (e.g., `3.0.3`). The `v` is added back wherever a tag form is needed (`v<PREV_TAG>`). The grep filter ensures only stable tags are considered (excludes `-beta`, `-rc`, etc.).
+
+     If the command returns nothing (no published stable tags), stop and ask the user to pass a version argument explicitly. Do not guess a starting version.
+
+   - Check if local has a newer stable tag that hasn't been published:
+
+     ```bash
+     git tag --list "v3.*" --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 | sed 's/^v//'
+     ```
+
+     If this output differs from `<PREV_TAG>` (i.e., local has a newer tag than origin), show both to the user and ask which to use as the previous tag. Wait for explicit confirmation before continuing.
+
+   - Gather and classify the changes since `<PREV_TAG>`. Get the commit list:
+
+     ```bash
+     git log v<PREV_TAG>..main --oneline
+     ```
+
+     For each PR referenced in the commit list (the `(#NNN)` suffix), fetch the full description:
+
+     ```bash
+     gh pr view <PR-NUM>
+     ```
+
+     Classify each change using these rules (used both for the release notes content and for the version recommendation below):
+     - **Components**: new components or substantial component additions.
+     - **Features**: new capabilities, enhancements, new props, new behaviors, UX improvements.
+     - **Hooks**: new hooks or meaningful hook updates.
+     - **Icons**: new icons, icon library updates, icon behavior/design changes.
+     - **Fixes**: bug fixes, layout fixes, behavior corrections, visual corrections.
+     - **Dependencies**: dependency additions, upgrades, tooling changes relevant to consumers or maintainers.
+     - **Deprecated features and breaking changes**: anything requiring consumer attention, migration, renamed props/interfaces, removed behavior.
+
+     Do not invent changes that aren't supported by the PRs. Make breaking changes / migrations explicit. Avoid raw PR implementation language. Consolidate overlapping PRs into a single bullet.
+
+   - Compute `<RECOMMENDED_VERSION>` from the classified content using these rules:
+     - **Patch**: the consumer does not need to change their code. Includes new components, features, hooks, icons, and fixes — anything that doesn't break or alter existing usage. Bump patch (e.g., `3.0.3` → `3.0.4`).
+     - **Minor**: existing consumer code still works, but the consumer must update their usage to benefit from refactors or API/design changes. Bump minor, reset patch (e.g., `3.0.3` → `3.1.0`).
+     - **Major**: existing consumer code will break — migration required (breaking changes, removed or renamed APIs). Bump major, reset minor and patch (e.g., `3.0.3` → `4.0.0`).
+
+   - Determine `<VERSION>`:
+     - If the user passed a full semver like `3.0.4`, use it as-is.
+     - If the user passed a partial semver, fill in zeros for the missing parts (e.g., `3.1` → `3.1.0`, `3` → `3.0.0`).
+     - If the user passed a keyword (`patch`, `minor`, `major`), apply that bump to `<PREV_TAG>`.
+     - Otherwise, use `<RECOMMENDED_VERSION>`.
+
+   - Compute `<BUMP_TYPE>` from how `<VERSION>` differs from `<PREV_TAG>`:
+     - `major` if the major number changed (e.g., `3.0.3` → `4.0.0`).
+     - `minor` if only the minor number changed (e.g., `3.0.3` → `3.1.0`).
+     - `patch` if only the patch number changed (e.g., `3.0.3` → `3.0.4`).
+
+   - Verify the target tag and release branch don't already exist:
+
+     ```bash
+     git tag -l "v<VERSION>"
+     git branch --list "release/v<VERSION>"
+     git ls-remote --heads origin "release/v<VERSION>"
+     ```
+
+     Stop if any command produces output:
+     - First: tag `v<VERSION>` already exists.
+     - Second: local branch `release/v<VERSION>` already exists.
+     - Third: remote branch `release/v<VERSION>` already exists.
+
+   - Save the classified content to a release notes file. Compute today's date and write the file:
+
+     ```bash
+     date +%Y%m%d
+     ```
+
+     Save to `release_scorer-ui-kit_<TODAY>.md` at the project root, using this template (omit any section that has no entries):
+
+     ```markdown
+     ## Components
+     - <change> (#<PR>)
+
+     ## Features
+     - <change> (#<PR>)
+
+     ## Hooks
+     - <change> (#<PR>)
+
+     ## Icons
+     - <change> (#<PR>)
+
+     ## Fixes
+     - <change> (#<PR>)
+
+     ## Dependencies
+     - <change> (#<PR>)
+
+     ## Deprecated features and breaking changes
+     - <change> (#<PR>)
+     ```
+
+   - Show the user the resolved values and the path to the release notes draft:
+
+     ```
+     Target version:       <VERSION>
+     Previous tag:         v<PREV_TAG>
+     Bump type:            <BUMP_TYPE>
+     Recommended version:  <RECOMMENDED_VERSION>
+     Release branch:       release/v<VERSION>
+
+     Release notes draft:  ./release_scorer-ui-kit_<TODAY>.md
+     ```
+
+     Always show `Recommended version` even if it matches `Target version` — for transparency. If `<VERSION>` differs from `<RECOMMENDED_VERSION>`, also state the reason briefly (e.g., "user requested minor; analysis suggests major because of removed API in #631").
+
+     Wait for explicit confirmation before continuing to step 3. The user may edit the release notes file or override the version. (If the version is overridden, no file update is needed — the file no longer contains the version.)
+
+3. **Create the release branch**
+   - Ensure you're on `main` and up to date: `git checkout main && git pull`
+   - Create branch: `git checkout -b release/v<VERSION>` (e.g. `release/v3.0.1`)
+
+4. **Update version in files**
+
+   ```bash
+   npm pkg set version=<VERSION>
+   npm pkg set version=<VERSION> -w packages/ui-lib
+   npm install --package-lock-only
+   ```
+
+   Verify that only the expected files were modified — anything other than `package.json`, `packages/ui-lib/package.json`, or `package-lock.json` is unexpected:
+
+   ```bash
+   git diff --name-only | grep -v -x -E '(package\.json|packages/ui-lib/package\.json|package-lock\.json)'
+   ```
+
+   Stop if the command produces any output (those would be the unexpected files).
+
+5. **Commit and push**
+
+   ```bash
+   git add package.json packages/ui-lib/package.json package-lock.json
+   git commit -m "Bump version to <VERSION>"
+   git push -u origin release/v<VERSION>
+   ```
+
+6. **Create PR**
+   - The release notes file from step 2 is the PR body. Create the PR using `--body-file`:
+
+     ```bash
+     gh pr create \
+       --base main \
+       --head "release/v<VERSION>" \
+       --title "Release v<VERSION>" \
+       --body-file release_scorer-ui-kit_<TODAY>.md
+     ```
+
+7. **Wait for CI and the user's merge**
+   - Share the PR URL with the user.
+   - Wait for CI checks to complete on the release branch:
+
+     ```bash
+     gh pr checks --watch
+     ```
+
+     This blocks until all checks finish. If it exits non-zero (any check failed), stop and report the failure — do not let the user merge a failing PR.
+
+   - Once CI is green, tell the user to merge the PR themselves.
+   - Do NOT merge the PR. Wait for the user to confirm they have merged it before proceeding.
+
+8. **Tag and push**
+
+   ```bash
+   git checkout main && git pull
+   git tag v<VERSION>
+   git push origin v<VERSION>
+
+   # Verify the tag is on the remote
+   git ls-remote --exit-code --tags origin "v<VERSION>"
+   ```
+
+9. **Clean up the release notes file**
+   - Ask the user whether to keep or delete `release_scorer-ui-kit_<TODAY>.md`.
+   - If delete:
+
+     ```bash
+     rm -f release_scorer-ui-kit_<TODAY>.md
+     ```
+
+   - If keep: tell the user the file is gitignored, so committing it requires `git add -f release_scorer-ui-kit_<TODAY>.md`.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -48,20 +48,20 @@ When this skill says "stop": halt automatic progression, tell the user exactly w
    - `gh auth status` exits non-zero.
 
 2. **Determine the version**
-   - Get the latest **published** stable tag from origin:
+   - Get the latest **published** stable tag from origin (across any major version):
 
      ```bash
-     git ls-remote --tags --sort=-v:refname origin "v3.*" | grep -E 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 | sed 's|.*refs/tags/v||'
+     git ls-remote --tags --sort=-v:refname origin "v*" | grep -E 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 | sed 's|.*refs/tags/v||'
      ```
 
-     The output is `<PREV_TAG>` (e.g., `3.0.3`). The `v` is added back wherever a tag form is needed (`v<PREV_TAG>`). The grep filter ensures only stable tags are considered (excludes `-beta`, `-rc`, etc.).
+     The output is `<PREV_TAG>` (e.g., `2.10.4`). The `v` is added back wherever a tag form is needed (`v<PREV_TAG>`). The grep filter ensures only stable tags are considered (excludes `-beta`, `-rc`, etc.). The version-aware sort returns the highest stable version regardless of major.
 
-     If the command returns nothing (no published stable tags), stop and ask the user to pass a version argument explicitly. Do not guess a starting version.
+     If the command returns nothing (the repository has no stable tags at all), stop and ask the user to pass a starting version explicitly. Do not guess.
 
    - Check if local has a newer stable tag that hasn't been published:
 
      ```bash
-     git tag --list "v3.*" --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 | sed 's/^v//'
+     git tag --list "v*" --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 | sed 's/^v//'
      ```
 
      If this output differs from `<PREV_TAG>` (i.e., local has a newer tag than origin), show both to the user and ask which to use as the previous tag. Wait for explicit confirmation before continuing.
@@ -78,16 +78,7 @@ When this skill says "stop": halt automatic progression, tell the user exactly w
      gh pr view <PR-NUM>
      ```
 
-     Classify each change using these rules (used both for the release notes content and for the version recommendation below):
-     - **Components**: new components or substantial component additions.
-     - **Features**: new capabilities, enhancements, new props, new behaviors, UX improvements.
-     - **Hooks**: new hooks or meaningful hook updates.
-     - **Icons**: new icons, icon library updates, icon behavior/design changes.
-     - **Fixes**: bug fixes, layout fixes, behavior corrections, visual corrections.
-     - **Dependencies**: dependency additions, upgrades, tooling changes relevant to consumers or maintainers.
-     - **Deprecated features and breaking changes**: anything requiring consumer attention, migration, renamed props/interfaces, removed behavior.
-
-     Do not invent changes that aren't supported by the PRs. Make breaking changes / migrations explicit. Avoid raw PR implementation language. Consolidate overlapping PRs into a single bullet.
+     Classify each change and write the bullets following [references/RELEASE_NOTES_STYLE_GUIDE.md](references/RELEASE_NOTES_STYLE_GUIDE.md). The style guide defines the section names, bullet structure, voice, capitalization, and formatting conventions — apply them as written. Do not invent changes that aren't supported by the PRs. Consolidate overlapping PRs into a single bullet.
 
    - Compute `<RECOMMENDED_VERSION>` from the classified content using these rules:
      - **Patch**: the consumer does not need to change their code. Includes new components, features, hooks, icons, and fixes — anything that doesn't break or alter existing usage. Bump patch (e.g., `3.0.3` → `3.0.4`).
@@ -124,30 +115,7 @@ When this skill says "stop": halt automatic progression, tell the user exactly w
      date +%Y%m%d
      ```
 
-     Save to `release_scorer-ui-kit_<TODAY>.md` at the project root, using this template (omit any section that has no entries):
-
-     ```markdown
-     ## Components
-     - <change> (#<PR>)
-
-     ## Features
-     - <change> (#<PR>)
-
-     ## Hooks
-     - <change> (#<PR>)
-
-     ## Icons
-     - <change> (#<PR>)
-
-     ## Fixes
-     - <change> (#<PR>)
-
-     ## Dependencies
-     - <change> (#<PR>)
-
-     ## Deprecated features and breaking changes
-     - <change> (#<PR>)
-     ```
+     Save to `release_scorer-ui-kit_<TODAY>.md` at the project root. The file's structure, section names, and formatting are defined in [references/RELEASE_NOTES_STYLE_GUIDE.md](references/RELEASE_NOTES_STYLE_GUIDE.md). Follow that guide.
 
    - Show the user the resolved values and the path to the release notes draft:
 

--- a/.claude/skills/release/references/RELEASE_NOTES_STYLE_GUIDE.md
+++ b/.claude/skills/release/references/RELEASE_NOTES_STYLE_GUIDE.md
@@ -1,0 +1,241 @@
+# Release Notes Style Guide
+
+This document defines the style and structure for release notes published on GitHub releases for `scorer-ui-kit`. The conventions here are derived from past releases authored by the maintainer (43 releases reviewed), with inconsistencies resolved into a single going-forward standard.
+
+This is the single source of truth for how release notes should look. The release skill at `.claude/skills/release/SKILL.md` references this file when generating notes.
+
+## Core principles
+
+1. **Write for consumers, not contributors.** Release notes describe user-facing impact, not internal refactors or implementation details.
+2. **Be concise.** Prefer one-line bullets unless a change genuinely needs multi-line explanation (props, migration steps).
+3. **Mention the affected component or feature first, then the change.** Readers scan for the name they care about.
+4. **Past tense, declarative.** "Added X", "Fixed Y", "Updated Z" — not "Adds" or "Add".
+5. **Don't paste PR descriptions verbatim.** Rewrite for the consumer's perspective. Avoid engineering jargon.
+6. **Be consistent within a release.** Pick one capitalization, one link style, one backticking rule, and stick to it.
+
+## Section structure
+
+A release uses bold paragraph headers (not markdown `##` headings) for sections. Each section has bullets describing individual changes.
+
+```markdown
+**Components**
+
+- **NewComponent:** description of the new component. [View in Storybook](url)
+
+**Features**
+
+- **ExistingComponent:** description of the new capability or enhancement.
+
+**Fixes**
+
+- **ExistingComponent:** description of the bug or issue that was fixed.
+
+**Deprecated Features and Breaking Changes**
+
+- **ComponentOrProp:** what changed and how consumers should migrate.
+```
+
+Omit any section that has no entries. Order sections as shown above (Components → Features → Fixes → Deprecated Features and Breaking Changes).
+
+## Section names
+
+Use these section names exactly as written (capitalization matters). Use only the sections that have content for this release.
+
+| Section | When to use |
+| --- | --- |
+| `Components` | New components or substantial component additions. |
+| `Features` | New capabilities, new props, new behaviors, UX improvements on existing components. Hook additions and small icon additions also go here unless they warrant their own section. |
+| `Fixes` | Bug fixes, layout corrections, behavior corrections, visual corrections. |
+| `Hooks` | **Standalone hooks** that consumers can import and use independently of any component (e.g., `useTitle`, `useDebounce`). Component-utility hooks (hooks tied to a specific component's internal behavior) are not listed here — they belong with the component under `Features` or `Components`. |
+| `Icons` | **Standalone icon additions, icon library changes, or icon behavior/design changes** that aren't attached to a specific feature or component (e.g., new icons added to the library, changes to icon weights/sizing, design refresh). Icons added as part of a feature or component update belong with that feature, not here. |
+| `Dependencies` | Dependency upgrades or tooling changes that affect consumers or maintainers (e.g., React version bump). |
+| `Deprecated Features and Breaking Changes` | Anything requiring consumer attention: removed APIs, renamed props, changed behavior that may break existing usage, required migrations. |
+| `Other` | Catch-all for consumer-facing changes that genuinely don't fit any section above. Use sparingly. |
+
+In past practice, `Features`, `Fixes`, and `Deprecated Features and Breaking Changes` are the most common sections. `Hooks` has not been used as a top-level section to date — standalone hook additions have historically been listed under `Features` — but the section exists for releases that include meaningful standalone-hook work.
+
+### When a change doesn't fit a section
+
+First, check whether the change has consumer-facing impact. If it doesn't — **omit it**. Internal refactors, documentation, tests, and build/CI changes that don't affect consumer projects don't belong in release notes.
+
+If the change does affect consumers but no canonical section fits, put it under `Other`.
+
+If the same kind of change keeps appearing under `Other` across multiple releases, that's a signal to promote it to its own canonical section in this style guide.
+
+## Header format
+
+Use **bold paragraph headers** (`**Section Name**`) — not markdown headings (`## Section Name`).
+
+```markdown
+**Features**
+
+- ...
+```
+
+Do NOT:
+- Use `## Features` (markdown heading).
+- Merge the header into the first bullet (`- **Features:** ...`).
+- Leave the header unformatted (`Fixes` with no `**`).
+
+## Bullet structure
+
+The standard pattern is:
+
+```
+- **ComponentName:** description ending with a period.
+```
+
+- The component or feature name comes first, in `**bold**`.
+- Followed by a colon and one space.
+- Description starts with a capital letter and ends with a period.
+- One bullet per visible change.
+
+For complex changes that need multiple sub-points, use nested bullets:
+
+```markdown
+- **ComponentName:**
+  - Description of the first sub-change.
+  - Description of the second sub-change.
+  - Description of the third sub-change.
+```
+
+The introductory bullet may include an opening sentence before the nested bullets if that helps:
+
+```markdown
+- **Switch:** Updated to match the new theme style with full integration of CSS variables, making it fully compatible with light and dark modes.
+  - Introduced size-related CSS variables, allowing easy resizing.
+  - The label now uses the `Label` component to ensure consistency.
+```
+
+## Voice and tense
+
+Use past tense for both new capabilities and fixes:
+
+- ✅ "Added a new `contentDays` prop."
+- ✅ "Fixed an issue where the required indicator was missing a space."
+- ✅ "Updated to support theme-based CSS."
+- ❌ "Adds a new `contentDays` prop."
+- ❌ "Allows passing a base color..."
+- ❌ "Add a new prop." (imperative)
+
+Be declarative. Avoid hedging ("might", "should", "could").
+
+## Capitalization
+
+- One-word section names are always capitalized: `Features`, `Fixes`, `Components`, `Icons`, `Dependencies`, `Hooks`.
+- Multi-word section names use **title case** with major words capitalized: `Deprecated Features and Breaking Changes` (not `Deprecated features and breaking changes`).
+- Component names match the source (`DatePicker`, `AlertBar`, `Switch`).
+- Inside descriptions: regular sentence case.
+
+## Code formatting
+
+Use the formatting that matches what the reader will type or see:
+
+| Item | Format | Example |
+| --- | --- | --- |
+| Component name | `**bold**` | `**DatePicker**` |
+| Prop name | `` `backticks` `` | `` `contentDays` `` |
+| Type alias | `` `backticks` `` | `` `IFeedbackColor` `` |
+| String literal value | `` `backticks` `` | `` `'row-reverse'` `` |
+| Function or hook name | `` `backticks` `` | `` `useTitle` `` |
+| File path | `` `backticks` `` | `` `src/index.tsx` `` |
+
+Within a single release, apply these rules consistently. Don't backtick a prop in one bullet and leave it bare in another.
+
+## Links
+
+Three kinds of links may appear:
+
+### Storybook live views
+
+Use the standard label `[View in Storybook](url)`. Link to the specific story page.
+
+```markdown
+- **AlertBar:** Added a new `direction` prop. [View in Storybook](https://future-standard.github.io/scorer-ui-kit/storybook/?path=/story/alerts-atoms--alert-bar)
+```
+
+Do NOT use varying labels like `[Live view]`, `[Live Example]`, `[New Design Live view]`. Pick one label and stick to it.
+
+### PR references (optional)
+
+If a change benefits from linking to its PR for full context, use the standard markdown link format:
+
+```markdown
+- **ComponentName:** Brief description. [PR #541](https://github.com/future-standard/scorer-ui-kit/pull/541)
+```
+
+PR links are not required for every bullet. Add them when the PR has meaningful design notes, screenshots, or migration guidance the reader might want.
+
+### Documentation / migration links
+
+For breaking changes, link to a migration guide or repo file:
+
+```markdown
+- **OldProp:** Removed in favor of `newProp`. See the [migration guide](url).
+```
+
+## Section ordering
+
+Use this order when multiple sections appear:
+
+1. `Components`
+2. `Features`
+3. `Hooks` (rarely used)
+4. `Icons` (rarely used)
+5. `Fixes`
+6. `Dependencies` (rarely used)
+7. `Other` (rarely used)
+8. `Deprecated Features and Breaking Changes`
+
+## Bullet length guidance
+
+- **Patch releases**: most bullets fit one line each.
+- **Minor releases**: bullets often need 2–4 lines or nested sub-bullets to explain a new prop, behavior, or migration.
+- **Major releases**: multi-line bullets are common; consider including a code block to illustrate prop migrations.
+
+## Examples to study
+
+These releases follow the canon and are good models when in doubt:
+
+- **[v2.7.0](https://github.com/future-standard/scorer-ui-kit/releases/tag/v2.7.0)** — cleanest full-shape release. Three sections (Features, Fixes, Deprecated Features and Breaking Changes), multi-line bullets with nested sub-bullets, Storybook live-view links, backticked props, past-tense voice.
+- **[v2.6.7](https://github.com/future-standard/scorer-ui-kit/releases/tag/v2.6.7)** — solid Features-with-nested-detail example, plus a Fixes section. Backticks used consistently. Standard `[View in Storybook]` link form.
+- **[v2.6.6](https://github.com/future-standard/scorer-ui-kit/releases/tag/v2.6.6)** — concise example with a `Components` section (introducing a new component) alongside `Features` (enhancing existing). Demonstrates the Components-vs-Features split.
+- **[v2.8.0](https://github.com/future-standard/scorer-ui-kit/releases/tag/v2.8.0)** — best example of a breaking-change release. Includes a code block showing the prop migration shape.
+- **[v2.6.0](https://github.com/future-standard/scorer-ui-kit/releases/tag/v2.6.0)** — full minor release with multiple sub-bullets, required-prop migration explanation, and `Deprecated Features and Breaking Changes`.
+
+## Common mistakes to avoid
+
+These antipatterns appear in past releases. Don't repeat them.
+
+- ❌ **Markdown heading style for sections** (`## Features`). Use bold paragraph (`**Features**`).
+- ❌ **Section header merged into the first bullet** (`- **Features:** ...`). Section header must be its own paragraph.
+- ❌ **Plain-text section headers** (`Fixes` with no `**` formatting).
+- ❌ **Inconsistent capitalization** (`Deprecated features and breaking changes` vs `Deprecated Features and Breaking Changes`). Use title case.
+- ❌ **Stray leading spaces inside backticks** (e.g., `` ` row` `` with a leading space inside the backticks). Strip whitespace from code spans.
+- ❌ **Reversed link bracket order** (`(text)[url]` instead of `[text](url)`).
+- ❌ **Typo "Feature" (singular) as a section header.** Section is always `Features`.
+- ❌ **Inconsistent backticking within a release** — backticking a prop in one bullet and leaving it bare in another.
+- ❌ **Tense slips into present** (`Adds`, `Allows`). Stick to past tense.
+- ❌ **Missing component-name bolding** in a section that otherwise uses bold. Either bold all component names or none, within a release.
+- ❌ **Section ordering changes between releases** without reason. Follow the canonical order above.
+
+## Consistency checklist
+
+Before publishing a release, verify:
+
+- [ ] All section headers use bold paragraph format (`**Name**`), not markdown headings.
+- [ ] Section names use the canonical capitalization (title case for multi-word).
+- [ ] Sections appear in the canonical order; empty sections are omitted.
+- [ ] Every bullet starts with a bolded component or feature name (where applicable), followed by a colon and a space.
+- [ ] All descriptions use past tense.
+- [ ] Backticking is consistent across the release (props, types, string literals, file paths).
+- [ ] Storybook links use the standard `[View in Storybook]` label.
+- [ ] PR links use `[PR #NNN](url)` format (only where helpful).
+- [ ] Breaking changes are explicit and include migration guidance.
+- [ ] No PR-implementation jargon, no internal refactor noise.
+- [ ] Bullets read as user-facing release notes, not as a changelog dump.
+
+---
+
+**Last updated:** 2026-04-29
+**Maintained by:** Isabel Anguiano

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log*
 storybook-static/
 packages/example/public/storybook/
 packages/storybook/build/
+
+# Release notes drafts (created by .claude/skills/release; user decides to keep or delete)
+release_scorer-ui-kit_*.md


### PR DESCRIPTION
## Description

This PR adds a new user-invocable Claude Code skill that automates the full stable-release process for `scorer-ui-kit` (3.x.y), along with a companion style guide that defines how release notes should be written for the project.

- **What does this PR do?**
  - Adds `.claude/skills/release/SKILL.md` — a new `/release` skill that walks through preflight checks, version determination (auto-detected, keyword-based, or explicit), release-branch creation, version bumping in both the root and `packages/ui-lib` package files, PR creation, CI gating, tag-and-push, and release-notes file cleanup.
  - Adds `.claude/skills/release/references/RELEASE_NOTES_STYLE_GUIDE.md` — the single source of truth for release-note formatting (section names, bullet structure, voice, capitalization, link conventions, common mistakes). Derived from a review of 43 prior releases, with inconsistencies resolved into a single going-forward standard.
  - Updates `.gitignore` to exclude the `release_scorer-ui-kit_*.md` drafts the skill creates while running, so they don't get committed by accident.

- **Background context**
  - This is the stable-release counterpart to the existing beta-release skill (`#624`, merged in `260cdf91`). It targets the `3.x.y` line and is explicitly user-triggered (`disable-model-invocation: true`, `user-invocable: true`).
  - The skill is intentionally strict: any unexpected condition (dirty tree, wrong branch, behind origin, missing `gh` auth, unexpected files modified by the version bump, failing CI) causes it to stop and report rather than proceed.

## Considerations on Implementation

A few decisions worth a reviewer's eye:

- **Allowed tools.** The skill frontmatter restricts execution to `Bash(git *)`, `Bash(gh *)`, and `Bash(npm *)`. Anything else will require approval, which is the intended safety net.
- **Never merges, never publishes, never tags before merge.** The skill explicitly waits for the user to merge the PR before tagging and pushing `vX.Y.Z`. It also never runs `npm publish` directly. These are core rules listed at the top of `SKILL.md`.
- **Version determination.** The "previous tag" is sourced from the highest published stable tag on `origin` (filtered to `v<major>.<minor>.<patch>`, excluding `-beta`/`-rc`). If a local stable tag is newer than origin, the skill stops and asks the user which to use — it does not silently pick one.
- **Bump classification rules.** `patch` = no consumer code change required, `minor` = consumer code still works but should be updated to benefit, `major` = breaking. The skill computes a recommended version from PR analysis and always shows it to the user, even when it matches the user's requested version, for transparency.
- **Version-bump safety check.** After running `npm pkg set version` and `npm install --package-lock-only`, the skill diffs the working tree and stops if anything other than `package.json`, `packages/ui-lib/package.json`, or `package-lock.json` changed. This protects against `node_modules` accidentally landing in the commit.
- **Release-notes drafts are gitignored.** The skill writes `release_scorer-ui-kit_<TODAY>.md` at the repo root and uses it as the PR body via `--body-file`. After the release, the user is asked whether to keep or delete the file; the gitignore entry means committing it requires `git add -f`.
- **Style guide co-location.** `RELEASE_NOTES_STYLE_GUIDE.md` lives under the skill's `references/` folder rather than at the repo root. This keeps it tightly coupled to the skill and avoids cluttering the project root, but it does mean contributors who don't use the skill won't stumble across it organically. Happy to move it if reviewers prefer a more discoverable location.
- **No code paths exercised.** This PR adds documentation/tooling files only — there is nothing to unit-test. Validation is by running the skill against a real release (see steps below).

## Reviewing/Testing steps

There is no library code change, so existing CI/tests are not exercised by this PR. To validate the skill itself:

1. **Read-through review.** Read `.claude/skills/release/SKILL.md` end-to-end and confirm the steps, stop conditions, and command sequence match the team's expectations for a stable release.
2. **Style-guide review.** Read `.claude/skills/release/references/RELEASE_NOTES_STYLE_GUIDE.md` and confirm the section names, ordering, voice, and formatting rules match how we want release notes to look going forward. Spot-check the linked exemplar releases (v2.7.0, v2.6.7, v2.6.6, v2.8.0, v2.6.0) for agreement with the rules.
3. **Gitignore check.** Confirm `release_scorer-ui-kit_*.md` is correctly ignored:
   ```bash
   touch release_scorer-ui-kit_test.md
   git status   # should NOT show the file
   rm release_scorer-ui-kit_test.md
   ```
4. **Dry-run the skill against a real release.** After merging this PR, the next stable release is the live test. Invoke `/release` (or `/release patch` / `/release 3.x.y`) on `main` and verify:
   - Preflight checks correctly detect a clean tree, the `main` branch, parity with origin, and a valid `gh auth status`.
   - The "previous tag" lookup returns the expected highest stable tag.
   - The recommended version matches the team's read of the PRs since the previous tag.
   - Only `package.json`, `packages/ui-lib/package.json`, and `package-lock.json` change after the version bump.
   - The PR is created with the release-notes draft as its body.
   - The skill waits on `gh pr checks --watch` and does not auto-merge.
   - After merge, the tag is pushed and verified on origin.
5. **Stop-condition spot checks (optional).** Intentionally trigger one or two failure modes to confirm the skill stops cleanly:
   - Run the skill from a non-`main` branch → should stop at preflight.
   - Run with a dirty working tree → should stop at preflight.
   - Run with an existing `release/v<VERSION>` branch → should stop at the branch-existence check.
