### PR TITLE
Release v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.7",
+      "version": "3.0.0",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -329,9 +329,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -349,9 +346,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -369,9 +363,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -389,9 +380,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -10206,7 +10194,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0-beta.7",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
## Description

### Bump version to 3.0.0

**Features**

- **LineUIVideo:** Added optional HLS playback support via `hls.js` as an optional peer dependency. Safari uses native HLS; other browsers dynamically load `hls.js` only when an `.m3u8` source is provided. [PR #640](https://github.com/future-standard/scorer-ui-kit/pull/640)
- **Type exports:** Re-exported missing type interfaces from the main entry point so consumers can import them directly from `scorer-ui-kit` instead of deep paths. Newly accessible types include `IVector2`, `IPointSet`, `LineUIOptions`, `ITableColumnConfig`, `IRowData`, `ITypeTableData`, `IMenuTop`, `ITopBar`, and `TypeButtonDesigns`. Subpath exports for `./dist/Tables`, `./dist/LineUI`, `./dist/Global`, and `./dist/Form` are preserved for backward compatibility. [PR #606](https://github.com/future-standard/scorer-ui-kit/pull/606)
- **ThemeType:** Exported `ThemeType` (derived from `typeof defaultTheme`) so consumers can import it directly instead of writing `typeof defaultTheme`. [PR #612](https://github.com/future-standard/scorer-ui-kit/pull/612)
- **FilterDropdown:** Extended `IFilterDropdown` with `Omit<HTMLAttributes<HTMLDivElement>, keyof IFilterDropdownOwn>` so valid DOM props (such as `className` and `style`) pass through while invalid props are caught at the type level. [PR #619](https://github.com/future-standard/scorer-ui-kit/pull/619)

**Fixes**

- **Notification:** Fixed double slide-in flash, double `closeCallback` invocation, and slide-out animation jump under React 19 StrictMode. The module-level notification queue was moved into a `useRef` inside the provider, the slide-in keyframe animation was replaced with a CSS transition gated by `requestAnimationFrame`, and the close path now uses the same transition for consistency. [PR #614](https://github.com/future-standard/scorer-ui-kit/pull/614)
- **usePoll:** Fixed a regression where polling silently stopped after the first cycle in development under React 18/19 StrictMode. The `canceled` ref is now reset on each effect run so a fresh mount always starts cleanly. [PR #615](https://github.com/future-standard/scorer-ui-kit/pull/615)
- **FilterBar:** Fixed selected filter item labels not updating when `dropdownsConfig` changed after mount (for example, on a language switch). The translation-sync `useEffect` now depends on `dropdownsConfig` directly instead of a ref. Consumers should memoize their `dropdownsConfig` to avoid unnecessary re-syncs. [PR #616](https://github.com/future-standard/scorer-ui-kit/pull/616)
- **WebRTCClient:** Fixed StrictMode double-mount issues including timer leaks, stale WebSocket close/error events from previous connections disrupting active sockets, and duplicate concurrent reconnect calls. Reconnect timeouts and hello intervals are now tracked in refs and cleared on cleanup, and a stale `enabled` closure was replaced with a synced ref. [PR #599](https://github.com/future-standard/scorer-ui-kit/pull/599) [PR #637](https://github.com/future-standard/scorer-ui-kit/pull/637)
- **LineUI:** Fixed leaked `mousemove`/`mouseup` window listeners when `HandleUnit` or `LineUnit` unmounted mid-drag. Replaced `React.createRef()` with `useRef()` in `HandleUnit` to prevent a new ref being created on every render. Out-of-bounds line points are now clamped to video dimensions when boundaries first become valid. [PR #599](https://github.com/future-standard/scorer-ui-kit/pull/599)
- **Button:** Fixed `styled(Button)` wrappers losing the internal `button-design-{design}` and `button-size-{size}` class names. The internal classes are now merged with any externally passed `className` so design variants survive a styled-components wrapper. [PR #632](https://github.com/future-standard/scorer-ui-kit/pull/632)
- **SplitLayout:** Fixed misaligned drag handle and arrow icons in the horizontal drag handles in both drag and closed states. [PR #638](https://github.com/future-standard/scorer-ui-kit/pull/638)
- **AvatarUploader:** Fixed a placeholder flash on StrictMode double-mount caused by an unnecessary cleanup. [PR #637](https://github.com/future-standard/scorer-ui-kit/pull/637)
- **FilterDropdown / DropdownDatePicker:** Removed dead synchronous guard flags (`isActive`, `canUnmount`) that were always true and could mask real issues. [PR #637](https://github.com/future-standard/scorer-ui-kit/pull/637)
- **Transient props:** Renamed all custom styled-component props internally with a `$` prefix to prevent React 19 from forwarding them to the DOM as unknown attributes. Affected groups include `PTZControl`, `Alerts`, `Icons`, `Indicators`, `Tabs`, `Pages`, `Modals`, `CameraPanels`, `Global`, `Tables`, `Filters`, `Form`, `LineUI`, `UserMenu`, and `SplitButtonOption`. Valid DOM attributes (`disabled`, `readOnly`, `r`) are unprefixed. See the breaking-changes section if your code passes these props directly to library components. [PR #611](https://github.com/future-standard/scorer-ui-kit/pull/611) [PR #619](https://github.com/future-standard/scorer-ui-kit/pull/619)
- **MediaBox:** Fixed a React empty-string warning by passing `undefined` instead of `''` to `src` on load failure. [PR #648](https://github.com/future-standard/scorer-ui-kit/pull/648)
- **SelectField:** Fixed `defaultValue` and `value` being set together on the inner `<select>`. `defaultValue` is now only emitted when `value` is not provided. [PR #648](https://github.com/future-standard/scorer-ui-kit/pull/648)
- **FilterLayout:** Stopped passing both `value` and `defaultValue` to the inner `SelectField`; the component is controlled. [PR #648](https://github.com/future-standard/scorer-ui-kit/pull/648)
- **PageHeader:** Fixed a broken interpolation in tag keys introduced by formatter auto-fixes. [PR #648](https://github.com/future-standard/scorer-ui-kit/pull/648)
- **UserMenu:** Fixed key collisions when submenu items shared the placeholder `href='#'` and corrected `icon` prop forwarding to the DOM via the `$icon` transient prefix. [PR #619](https://github.com/future-standard/scorer-ui-kit/pull/619) [PR #648](https://github.com/future-standard/scorer-ui-kit/pull/648)
- **MobileTab:** Added `customComponent` to `IMobileTab` to resolve a TypeScript error and stopped leaking the prop to the DOM. [PR #611](https://github.com/future-standard/scorer-ui-kit/pull/611) [PR #619](https://github.com/future-standard/scorer-ui-kit/pull/619)
- **SplitButtonOption:** Stopped leaking the `size` prop to the DOM by using the `$size` transient prefix on the inner `StyledButton`. [PR #619](https://github.com/future-standard/scorer-ui-kit/pull/619)

**Dependencies**

- **React:** Bumped peer dependency to React 19. React 17 and 18 are no longer supported. [PR #595](https://github.com/future-standard/scorer-ui-kit/pull/595) [PR #637](https://github.com/future-standard/scorer-ui-kit/pull/637)
- **styled-components:** Bumped peer dependency from v5 to v6.
- **react-i18next / i18next:** Bumped to `react-i18next` v14 and `i18next` v23.
- **@future-standard/icons:** Bumped peer dependency from v2 to v3.
- **Build toolchain:** Migrated the library build from `microbundle-crl` / `react-scripts` to Vite (library mode) with Vitest, and Storybook from `@storybook/react-webpack5` to `@storybook/react-vite`. The library is now built with Vite 8 (Rolldown). [PR #595](https://github.com/future-standard/scorer-ui-kit/pull/595) [PR #628](https://github.com/future-standard/scorer-ui-kit/pull/628)
- **Node engines:** Added Node 24 to the supported engines for `ui-lib`. [PR #608](https://github.com/future-standard/scorer-ui-kit/pull/608)
- **react-use-websocket:** Removed as a peer dependency. It was previously used only by the PTZ module. See breaking changes below.

**Deprecated Features and Breaking Changes**

- **React 17 / 18 support:** Dropped. The library now requires React 19 as a peer dependency. Consumers must upgrade their app to React 19 before installing this version. [PR #595](https://github.com/future-standard/scorer-ui-kit/pull/595) [PR #637](https://github.com/future-standard/scorer-ui-kit/pull/637)
- **PTZ module:** Removed in full. The following exports are no longer available from `scorer-ui-kit`:
  - `Controls`
  - `PTZProvider`
  - `PTZContext`
  - `PTZReducer`
  - `usePTZ`

  The exclusive `react-use-websocket` peer dependency was also removed. No replacement is provided — consumers needing PTZ camera control should implement their own WebSocket hook or integrate a third-party PTZ SDK. [PR #631](https://github.com/future-standard/scorer-ui-kit/pull/631)
- **`forwardRef` removed from `FilterDropHandler` and `SplitLayout`:** React 19 passes `ref` as a regular prop natively. Existing usage that passes `ref` directly continues to work. The exposed handle types `FilterDropHandlerRef` and `ISplitLayoutHandles` are unchanged. [PR #637](https://github.com/future-standard/scorer-ui-kit/pull/637)
- **styled-components transient props (`$`-prefix):** All custom props passed to internal styled components are now prefixed with `$` (for example, `isOutline` → `$isOutline`, `loading` → `$loading`). This change is internal to the library and consumer code that uses the documented component props is unaffected. However, any consuming code that bypassed the public API and passed these props directly to library-internal styled components must update to the new names. [PR #611](https://github.com/future-standard/scorer-ui-kit/pull/611)
- **styled-components v6:** Peer dependency bumped from v5 to v6. Consumers must upgrade their own `styled-components` install to v6. [PR #595](https://github.com/future-standard/scorer-ui-kit/pull/595)
