### PR TITLE
feat: React Hook Form PoC — FormField molecule, RHF spike page, Playw…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,9 @@ storybook-static/
 packages/example/public/storybook/
 packages/storybook/build/
 
+# Playwright test artifacts
+packages/example/test-results/
+playwright-report/
+
 # Release notes drafts (created by .claude/skills/release; user decides to keep or delete)
 release_scorer-ui-kit_*.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "concurrently": "^9.2.1",
         "gh-pages": "^6.3.0",
         "jsdom": "^26.1.0",
-        "playwright": "^1.59.1",
+        "playwright": "^1.60.0",
         "vite": "^8.0.5"
       }
     },
@@ -1444,53 +1444,6 @@
       },
       "bin": {
         "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -6973,13 +6926,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6992,9 +6945,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,6 +1433,69 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
@@ -7146,6 +7209,22 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.0.tgz",
+      "integrity": "sha512-eKtLGgFeSgkHqQD8J59AMZ9a4uD1D83iSIzt4YlTGD7liDen5rrjcUO1rVIGd9yC1gofryjtHbv+4ny4hkLWlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-i18next": {
       "version": "16.5.5",
       "license": "MIT",
@@ -9331,11 +9410,13 @@
         "i18next-browser-languagedetector": "^8.2.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.76.0",
         "react-i18next": "^16",
         "react-router-dom": "^7.0.0",
         "styled-components": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.1",
@@ -10217,6 +10298,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-hook-form": "^7.76.0",
         "react-router": "^7.13.1",
         "react-router-dom": "^7.13.1",
         "styled-components": "^6.3.11",
@@ -10231,6 +10313,7 @@
         "hls.js": "^1.6.16",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.76.0",
         "react-router": "^7.0.0",
         "react-router-dom": "^7.0.0",
         "styled-components": "^6.1.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "concurrently": "^9.2.1",
     "gh-pages": "^6.3.0",
     "jsdom": "^26.1.0",
-    "playwright": "^1.59.1",
+    "playwright": "^1.60.0",
     "vite": "^8.0.5"
   },
   "overrides": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -9,11 +9,13 @@
     "i18next-browser-languagedetector": "^8.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.76.0",
     "react-i18next": "^16",
     "react-router-dom": "^7.0.0",
     "styled-components": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
@@ -24,7 +26,8 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "description": "SCORER UI Kit Example Application",
   "repository": {

--- a/packages/example/playwright.config.ts
+++ b/packages/example/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -19,6 +19,7 @@ import TablePage from './pages/TablePage';
 import TabsPage from './pages/TabsPage';
 import UsePollTestPage from './pages/UsePollTestPage';
 import WebRTCStrictModeTestPage from './pages/WebRTCStrictModeTestPage';
+import RHFSpikePage from './pages/RHFSpikePage';
 
 const App: React.FC = () => {
   return (
@@ -41,6 +42,7 @@ const App: React.FC = () => {
         <Route path='/switch-test' element={<SwitchWithAPI />} />
         <Route path='/usepoll-test' element={<UsePollTestPage />} />
         <Route path='/webrtc-strictmode-test' element={<WebRTCStrictModeTestPage />} />
+        <Route path='/rhf-spike' element={<RHFSpikePage />} />
       </Routes>
     </Router>
   );

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -13,13 +13,13 @@ import LinePage from './pages/LinePage';
 import LineRTCPage from './pages/LineRTCPage';
 import LineVideoPage from './pages/LineVideoPage';
 import LoginPage from './pages/Login';
+import RHFSpikePage from './pages/RHFSpikePage';
 import SplitLayouts from './pages/SplitLayout';
 import SwitchWithAPI from './pages/SwitchTest';
 import TablePage from './pages/TablePage';
 import TabsPage from './pages/TabsPage';
 import UsePollTestPage from './pages/UsePollTestPage';
 import WebRTCStrictModeTestPage from './pages/WebRTCStrictModeTestPage';
-import RHFSpikePage from './pages/RHFSpikePage';
 
 const App: React.FC = () => {
   return (

--- a/packages/example/src/pages/Index.tsx
+++ b/packages/example/src/pages/Index.tsx
@@ -192,8 +192,8 @@ const LinksPage: React.FC = () => {
             <Link to={`/rhf-spike`}>
               <Title>React Hook Form</Title>
               <Description>
-                React Hook Form wired to UI Kit components through the FormField molecule.
-                Spike PoC covering text, email, select, radio, and checkbox group fields.
+                React Hook Form wired to UI Kit components through the FormField molecule. Spike PoC
+                covering text, email, select, radio, and checkbox group fields.
               </Description>
               <FilenameTag>RHFSpikePage.tsx</FilenameTag>
             </Link>

--- a/packages/example/src/pages/Index.tsx
+++ b/packages/example/src/pages/Index.tsx
@@ -189,6 +189,16 @@ const LinksPage: React.FC = () => {
             </Link>
           </Item>
           <Item>
+            <Link to={`/rhf-spike`}>
+              <Title>React Hook Form</Title>
+              <Description>
+                React Hook Form wired to UI Kit components through the FormField molecule.
+                Spike PoC covering text, email, select, radio, and checkbox group fields.
+              </Description>
+              <FilenameTag>RHFSpikePage.tsx</FilenameTag>
+            </Link>
+          </Item>
+          <Item>
             <Link to={`/login`}>
               <Title>Login</Title>
               <Description>A code sample of our commonly used login view.</Description>

--- a/packages/example/src/pages/RHFSpikePage.tsx
+++ b/packages/example/src/pages/RHFSpikePage.tsx
@@ -9,7 +9,7 @@ type FormValues = {
   name: string;
   colour: string;
   email: string;
-  preference?: string;
+  preference: string;
   flavours: string[];
 };
 
@@ -28,7 +28,7 @@ const RHFSpikePage: React.FC = () => {
   const [submittedData, setSubmittedData] = useState<FormValues | null>(null);
   const methods = useForm<FormValues>({
     mode: 'onTouched',
-    defaultValues: { name: '', colour: '', flavours: [] },
+    defaultValues: { name: '', colour: '', email: '', preference: '', flavours: [] },
   });
   const { handleSubmit } = methods;
 

--- a/packages/example/src/pages/RHFSpikePage.tsx
+++ b/packages/example/src/pages/RHFSpikePage.tsx
@@ -1,0 +1,174 @@
+import type React from 'react';
+import { useState } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { Button, Checkbox, FormField, Input, RadioButton, SelectField } from 'scorer-ui-kit';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type FormValues = {
+  name: string;
+  colour: string;
+  email: string;
+  preference?: string;
+  flavours: string[];
+};
+
+const PREFERENCE_OPTIONS = [
+  { value: 'mountain', label: 'Mountain' },
+  { value: 'ocean', label: 'Ocean' },
+] as const;
+
+const FLAVOUR_OPTIONS = [
+  { value: 'vanilla', label: 'Vanilla' },
+  { value: 'chocolate', label: 'Chocolate' },
+  { value: 'strawberry', label: 'Strawberry' },
+] as const;
+
+const RHFSpikePage: React.FC = () => {
+  const [submittedData, setSubmittedData] = useState<FormValues | null>(null);
+  const methods = useForm<FormValues>({
+    mode: 'onTouched',
+    defaultValues: { name: '', colour: '', flavours: [] },
+  });
+  const { handleSubmit } = methods;
+
+  const onSubmit = (data: FormValues) => {
+    setSubmittedData(data);
+  };
+
+  return (
+    <div style={{ padding: '32px', maxWidth: '400px' }}>
+      <h1>React Hook Form</h1>
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)} noValidate>
+          <FormField
+            name='name'
+            label='Name'
+            required
+            rules={{ required: 'Name is required' }}
+          >
+            {({ field, fieldState, id, errorId, 'aria-invalid': ariaInvalid }) => (
+              <Input
+                {...field}
+                id={id}
+                fieldState={fieldState}
+                aria-invalid={ariaInvalid}
+                aria-describedby={errorId}
+              />
+            )}
+          </FormField>
+          <FormField
+            name='colour'
+            label='Favourite colour'
+            required
+            rules={{ required: 'Favourite colour is required' }}
+          >
+            {({ field, fieldState, id, errorId, 'aria-invalid': ariaInvalid }) => (
+              <SelectField
+                ref={field.ref}
+                id={id}
+                fieldState={fieldState}
+                aria-invalid={ariaInvalid}
+                aria-describedby={errorId}
+                value={field.value}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                name={field.name}
+                placeholder='Select a colour'
+              >
+                <option value='red'>Red</option>
+                <option value='green'>Green</option>
+                <option value='blue'>Blue</option>
+              </SelectField>
+            )}
+          </FormField>
+          <FormField
+            name='email'
+            label='Email'
+            required
+            hint='We never share your email.'
+            rules={{
+              required: 'Email is required',
+              pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
+            }}
+          >
+            {({ field, fieldState, id, errorId, 'aria-invalid': ariaInvalid }) => (
+              <Input
+                {...field}
+                id={id}
+                type='email'
+                fieldState={fieldState}
+                aria-invalid={ariaInvalid}
+                aria-describedby={errorId}
+              />
+            )}
+          </FormField>
+          <FormField name='preference' label='Mountain or ocean' variant='group'>
+            {({ field }) => (
+              <div style={{ display: 'flex', gap: '16px', marginTop: '4px' }}>
+                {PREFERENCE_OPTIONS.map(({ value, label }) => (
+                  <label
+                    key={value}
+                    htmlFor={`preference-${value}`}
+                    style={{ display: 'flex', alignItems: 'center', gap: '6px', cursor: 'pointer' }}
+                  >
+                    <RadioButton
+                      id={`preference-${value}`}
+                      name='preference'
+                      value={value}
+                      currentChecked={field.value}
+                      onChangeCallback={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            )}
+          </FormField>
+          <FormField
+            name='flavours'
+            label='Favourite ice cream flavours'
+            variant='group'
+            rules={{
+              validate: (v: string[]) => (v ?? []).length > 0 || 'Pick at least one flavour',
+            }}
+          >
+            {({ field }) => (
+              <div style={{ display: 'flex', gap: '16px', marginTop: '4px', flexWrap: 'wrap' }}>
+                {FLAVOUR_OPTIONS.map(({ value, label }) => (
+                  <div key={value} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    <Checkbox
+                      id={`flavour-${value}`}
+                      controlled
+                      checked={(field.value as string[]).includes(value)}
+                      onChangeCallback={(isChecked) => {
+                        const current: string[] = field.value ?? [];
+                        field.onChange(
+                          isChecked ? [...current, value] : current.filter((v) => v !== value)
+                        );
+                      }}
+                    />
+                    <label htmlFor={`flavour-${value}`} style={{ cursor: 'pointer' }}>
+                      {label}
+                    </label>
+                  </div>
+                ))}
+              </div>
+            )}
+          </FormField>
+          <div style={{ marginTop: '24px' }}>
+            <Button type='submit'>Submit</Button>
+          </div>
+        </form>
+      </FormProvider>
+      {submittedData !== null && (
+        <pre data-testid='submitted' style={{ marginTop: '16px', whiteSpace: 'pre-wrap' }}>
+          {JSON.stringify(submittedData, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default RHFSpikePage;

--- a/packages/example/src/pages/RHFSpikePage.tsx
+++ b/packages/example/src/pages/RHFSpikePage.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { useState } from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { Button, Checkbox, FormField, Input, RadioButton, SelectField } from 'scorer-ui-kit';
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -41,12 +41,7 @@ const RHFSpikePage: React.FC = () => {
       <h1>React Hook Form</h1>
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(onSubmit)} noValidate>
-          <FormField
-            name='name'
-            label='Name'
-            required
-            rules={{ required: 'Name is required' }}
-          >
+          <FormField name='name' label='Name' required rules={{ required: 'Name is required' }}>
             {({ field, fieldState, id, errorId, 'aria-invalid': ariaInvalid }) => (
               <Input
                 {...field}

--- a/packages/example/test-results/.last-run.json
+++ b/packages/example/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/packages/example/test-results/.last-run.json
+++ b/packages/example/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/packages/example/tests/rhf-spike-keyboard.spec.ts
+++ b/packages/example/tests/rhf-spike-keyboard.spec.ts
@@ -1,10 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 // Tab order in the DOM:
 // Name → Colour select → Email → Radio group (Mountain/Ocean) → Checkboxes → Submit
 // No page.click() or page.fill() — keyboard-only interactions throughout.
 
-test('keyboard-only: full form submission using tab, arrows, space, and enter', async ({ page }) => {
+test('keyboard-only: full form submission using tab, arrows, space, and enter', async ({
+  page,
+}) => {
   await page.goto('/#/rhf-spike');
 
   // Focus Name field

--- a/packages/example/tests/rhf-spike-keyboard.spec.ts
+++ b/packages/example/tests/rhf-spike-keyboard.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+// Tab order in the DOM:
+// Name → Colour select → Email → Radio group (Mountain/Ocean) → Checkboxes → Submit
+// No page.click() or page.fill() — keyboard-only interactions throughout.
+
+test('keyboard-only: full form submission using tab, arrows, space, and enter', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  // Focus Name field
+  await page.keyboard.press('Tab');
+  await page.keyboard.type('Alice');
+
+  // Focus Colour select; ArrowDown moves from placeholder to first real option (Red)
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('ArrowDown');
+
+  // Focus Email field
+  await page.keyboard.press('Tab');
+  await page.keyboard.type('alice@example.com');
+
+  // Tab into radio group — Mountain gets focus (none checked yet)
+  // ArrowDown moves to Ocean and checks it (standard browser radio-group navigation)
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('ArrowDown');
+
+  // Tab exits the checked-radio's group; Vanilla checkbox gets focus
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Space');
+
+  // Tab past Chocolate and Strawberry checkboxes, then reach Submit
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+
+  // Submit via Enter
+  await page.keyboard.press('Enter');
+
+  const submitted = page.getByTestId('submitted');
+  await expect(submitted).toBeVisible();
+
+  const text = await submitted.textContent();
+  const payload = JSON.parse(text ?? '{}');
+  expect(payload.name).toBe('Alice');
+  expect(payload.email).toBe('alice@example.com');
+  expect(payload.colour).toBe('red');
+  expect(payload.preference).toBe('ocean');
+  expect(payload.flavours).toContain('vanilla');
+});

--- a/packages/example/tests/rhf-spike.spec.ts
+++ b/packages/example/tests/rhf-spike.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('submitting empty form shows both required errors', async ({ page }) => {
   await page.goto('/#/rhf-spike');
@@ -27,7 +27,9 @@ test('submitting with name filled but no colour shows colour required error', as
   await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
   await page.getByRole('button', { name: 'Submit' }).click();
 
-  await expect(page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })).toBeVisible();
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })
+  ).toBeVisible();
 });
 
 test('selecting a colour after error clears the colour error', async ({ page }) => {
@@ -36,11 +38,15 @@ test('selecting a colour after error clears the colour error', async ({ page }) 
   await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
   await page.getByRole('button', { name: 'Submit' }).click();
 
-  await expect(page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })).toBeVisible();
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })
+  ).toBeVisible();
 
   await page.getByRole('combobox').selectOption('red');
 
-  await expect(page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })).not.toBeVisible();
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })
+  ).not.toBeVisible();
 });
 
 test('email field aria wiring is correct when invalid', async ({ page }) => {
@@ -63,7 +69,9 @@ test('valid name and invalid email shows only email format error', async ({ page
   await page.getByRole('textbox', { name: 'Email' }).fill('not-an-email');
   await page.getByRole('button', { name: 'Submit' }).click();
 
-  await expect(page.getByRole('alert').filter({ hasText: 'Enter a valid email address' })).toBeVisible();
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Enter a valid email address' })
+  ).toBeVisible();
   await expect(page.getByRole('alert').filter({ hasText: 'Name is required' })).not.toBeVisible();
 });
 
@@ -107,7 +115,9 @@ test('submitting with no flavours checked shows group-level flavour error', asyn
   await page.getByRole('combobox').selectOption('red');
   await page.getByRole('button', { name: 'Submit' }).click();
 
-  await expect(page.getByRole('alert').filter({ hasText: 'Pick at least one flavour' })).toBeVisible();
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Pick at least one flavour' })
+  ).toBeVisible();
 });
 
 test('checking one flavour and submitting valid form shows no flavour error', async ({ page }) => {
@@ -119,7 +129,9 @@ test('checking one flavour and submitting valid form shows no flavour error', as
   await page.getByLabel('Vanilla').click();
   await page.getByRole('button', { name: 'Submit' }).click();
 
-  await expect(page.getByRole('alert').filter({ hasText: 'Pick at least one flavour' })).not.toBeVisible();
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Pick at least one flavour' })
+  ).not.toBeVisible();
 });
 
 test('happy-path submit records correct payload', async ({ page }) => {

--- a/packages/example/tests/rhf-spike.spec.ts
+++ b/packages/example/tests/rhf-spike.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test';
+
+test('submitting empty form shows both required errors', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Name is required' })).toBeVisible();
+  await expect(page.getByRole('alert').filter({ hasText: 'Email is required' })).toBeVisible();
+});
+
+test('name field aria wiring is correct when invalid', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const nameError = page.getByRole('alert').filter({ hasText: 'Name is required' });
+  await expect(nameError).toBeVisible();
+
+  const nameInput = page.getByRole('textbox', { name: 'Name' });
+  const errorId = await nameError.getAttribute('id');
+  const describedBy = await nameInput.getAttribute('aria-describedby');
+  expect(describedBy).toBe(errorId);
+});
+
+test('submitting with name filled but no colour shows colour required error', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })).toBeVisible();
+});
+
+test('selecting a colour after error clears the colour error', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })).toBeVisible();
+
+  await page.getByRole('combobox').selectOption('red');
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })).not.toBeVisible();
+});
+
+test('email field aria wiring is correct when invalid', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const emailError = page.getByRole('alert').filter({ hasText: 'Email is required' });
+  await expect(emailError).toBeVisible();
+
+  const emailInput = page.getByRole('textbox', { name: 'Email' });
+  const errorId = await emailError.getAttribute('id');
+  const describedBy = await emailInput.getAttribute('aria-describedby');
+  expect(describedBy).toBe(errorId);
+});
+
+test('valid name and invalid email shows only email format error', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('textbox', { name: 'Email' }).fill('not-an-email');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Enter a valid email address' })).toBeVisible();
+  await expect(page.getByRole('alert').filter({ hasText: 'Name is required' })).not.toBeVisible();
+});
+
+test('radio group renders with visible legend and both options', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await expect(page.getByText('Mountain or ocean')).toBeVisible();
+  await expect(page.getByLabel('Mountain')).toBeVisible();
+  await expect(page.getByLabel('Ocean')).toBeVisible();
+});
+
+test('selecting a radio option and submitting a valid form raises no error', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('textbox', { name: 'Email' }).fill('alice@example.com');
+  await page.getByRole('combobox').selectOption('red');
+  await page.getByLabel('Mountain').click();
+  await page.getByLabel('Vanilla').click();
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert')).not.toBeVisible();
+});
+
+test('radio group can be interacted with via the mouse', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByLabel('Mountain').click();
+  await expect(page.getByLabel('Mountain')).toBeChecked();
+
+  await page.getByLabel('Ocean').click();
+  await expect(page.getByLabel('Ocean')).toBeChecked();
+  await expect(page.getByLabel('Mountain')).not.toBeChecked();
+});
+
+test('submitting with no flavours checked shows group-level flavour error', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('textbox', { name: 'Email' }).fill('alice@example.com');
+  await page.getByRole('combobox').selectOption('red');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Pick at least one flavour' })).toBeVisible();
+});
+
+test('checking one flavour and submitting valid form shows no flavour error', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('textbox', { name: 'Email' }).fill('alice@example.com');
+  await page.getByRole('combobox').selectOption('red');
+  await page.getByLabel('Vanilla').click();
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Pick at least one flavour' })).not.toBeVisible();
+});
+
+test('happy-path submit records correct payload', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('textbox', { name: 'Email' }).fill('alice@example.com');
+  await page.getByRole('combobox').selectOption('red');
+  await page.getByLabel('Vanilla').click();
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const submitted = page.getByTestId('submitted');
+  await expect(submitted).toBeVisible();
+  const text = await submitted.textContent();
+  const payload = JSON.parse(text ?? '{}');
+  expect(payload.name).toBe('Alice');
+  expect(payload.email).toBe('alice@example.com');
+  expect(payload.colour).toBe('red');
+  expect(payload.flavours).toEqual(['vanilla']);
+});
+
+test('name field shows error on blur after touch without submit', async ({ page }) => {
+  await page.goto('/#/rhf-spike');
+
+  await page.getByRole('textbox', { name: 'Name' }).focus();
+  await page.getByRole('textbox', { name: 'Name' }).blur();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Name is required' })).toBeVisible();
+});

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -64,6 +64,7 @@
     "hls.js": "^1.6.16",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.76.0",
     "react-router": "^7.0.0",
     "react-router-dom": "^7.0.0",
     "styled-components": "^6.1.0"
@@ -87,6 +88,7 @@
     "npm-run-all": "^4.1.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hook-form": "^7.76.0",
     "react-router": "^7.13.1",
     "react-router-dom": "^7.13.1",
     "styled-components": "^6.3.11",

--- a/packages/ui-lib/src/Form/atoms/Checkbox.tsx
+++ b/packages/ui-lib/src/Form/atoms/Checkbox.tsx
@@ -11,7 +11,15 @@ enum CheckboxState {
 }
 
 const RealInput = styled.input`
-  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  cursor: pointer;
 `;
 const CheckboxOuter = styled.div`
   cursor: pointer;
@@ -58,6 +66,7 @@ const IconWrapper = styled.div<{ $color: ISvgIcons['color'] }>`
 
 const Container = styled.label<{ $visualState?: CheckboxState; $disabled?: boolean }>`
   display: inline-block;
+  position: relative;
   user-select: none;
   ${CheckboxOuter}{
     border: var(--input-toggle-unchecked-border-color) 2px solid;
@@ -165,17 +174,23 @@ const Container = styled.label<{ $visualState?: CheckboxState; $disabled?: boole
 `;
 
 interface IProps {
+  id?: string;
   checked?: boolean;
   disabled?: boolean;
   indeterminate?: boolean;
   onChangeCallback?: (checked: boolean, indeterminate?: boolean) => void;
+  // When true, `checked` prop is authoritative and internal state is bypassed.
+  // Use this for RHF/controlled-form integration to avoid stale-state fights.
+  controlled?: boolean;
 }
 
 const Checkbox: React.FC<IProps> = ({
+  id,
   indeterminate: _indeterminate = false,
   disabled,
   checked = false,
   onChangeCallback,
+  controlled = false,
 }) => {
   const [isChecked, setIsChecked] = useState<boolean>(checked);
   const [visualState, setVisualState] = useState<CheckboxState>(
@@ -183,11 +198,11 @@ const Checkbox: React.FC<IProps> = ({
   );
 
   const customOnChange = (e: React.ChangeEvent<HTMLLabelElement>) => {
-    const checked = (e.target as unknown as HTMLInputElement).checked;
+    const newChecked = (e.target as unknown as HTMLInputElement).checked;
 
-    setIsChecked(checked);
+    setIsChecked(newChecked);
     if (onChangeCallback) {
-      onChangeCallback(checked);
+      onChangeCallback(newChecked);
     }
   };
 
@@ -202,13 +217,18 @@ const Checkbox: React.FC<IProps> = ({
     setIsChecked(checked);
   }, [checked]);
 
+  const effectiveChecked = controlled ? checked : isChecked;
+  const effectiveVisualState = controlled
+    ? checked ? CheckboxState.On : CheckboxState.Off
+    : visualState;
+
   const iconWeight: number = dimensions.icons.weights.regular;
 
   return (
-    <Container onChange={customOnChange} $disabled={disabled} $visualState={visualState}>
+    <Container onChange={customOnChange} $disabled={disabled} $visualState={effectiveVisualState}>
       <CheckboxOuter>
         <CheckboxInner>
-          {visualState === CheckboxState.On ? (
+          {effectiveVisualState === CheckboxState.On ? (
             <IconWrapper $color='input-toggle-icon-color'>
               <CheckMark
                 color='input-toggle-icon-color'
@@ -220,7 +240,7 @@ const Checkbox: React.FC<IProps> = ({
           ) : null}
         </CheckboxInner>
       </CheckboxOuter>
-      <RealInput type='checkbox' checked={isChecked} readOnly {...{ disabled }} />
+      <RealInput type='checkbox' id={id} checked={effectiveChecked} readOnly {...{ disabled }} />
     </Container>
   );
 };

--- a/packages/ui-lib/src/Form/atoms/Checkbox.tsx
+++ b/packages/ui-lib/src/Form/atoms/Checkbox.tsx
@@ -219,7 +219,9 @@ const Checkbox: React.FC<IProps> = ({
 
   const effectiveChecked = controlled ? checked : isChecked;
   const effectiveVisualState = controlled
-    ? checked ? CheckboxState.On : CheckboxState.Off
+    ? checked
+      ? CheckboxState.On
+      : CheckboxState.Off
     : visualState;
 
   const iconWeight: number = dimensions.icons.weights.regular;

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -1,4 +1,4 @@
-import type React from 'react';
+import React from 'react';
 import type { InputHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import { removeAutoFillStyle } from '../../common';
@@ -169,7 +169,7 @@ interface OwnProps {
 
 export type InputProps = OwnProps & InputHTMLAttributes<HTMLInputElement>;
 
-const Input: React.FC<InputProps> = ({
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({
   type = 'text',
   placeholder = '',
   defaultValue,
@@ -182,7 +182,7 @@ const Input: React.FC<InputProps> = ({
   children,
   formAction,
   ...props
-}) => {
+}, ref) => {
   const isActionButton = actionCallback !== undefined;
 
   const feedbackIcon = (fieldState: TypeFieldState) => {
@@ -206,6 +206,7 @@ const Input: React.FC<InputProps> = ({
     <Container $fieldState={fieldState || 'default'} $showFeedback={showFeedback}>
       <InputContainer $hasAction={isActionButton}>
         <StyledInput
+          ref={ref}
           $fieldState={fieldState || 'default'}
           disabled={fieldState === 'disabled' || fieldState === 'processing'}
           type={type}
@@ -230,6 +231,8 @@ const Input: React.FC<InputProps> = ({
       ) : null}
     </Container>
   );
-};
+});
+
+Input.displayName = 'Input';
 
 export default Input;

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import type { InputHTMLAttributes } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 import { removeAutoFillStyle } from '../../common';
 import Icon, { IconWrapper } from '../../Icons/Icon';
@@ -169,69 +169,74 @@ interface OwnProps {
 
 export type InputProps = OwnProps & InputHTMLAttributes<HTMLInputElement>;
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(({
-  type = 'text',
-  placeholder = '',
-  defaultValue,
-  fieldState = 'default',
-  showFeedback = false,
-  feedbackMessage,
-  actionCallback,
-  actionIcon,
-  postfix,
-  children,
-  formAction,
-  ...props
-}, ref) => {
-  const isActionButton = actionCallback !== undefined;
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      type = 'text',
+      placeholder = '',
+      defaultValue,
+      fieldState = 'default',
+      showFeedback = false,
+      feedbackMessage,
+      actionCallback,
+      actionIcon,
+      postfix,
+      children,
+      formAction,
+      ...props
+    },
+    ref
+  ) => {
+    const isActionButton = actionCallback !== undefined;
 
-  const feedbackIcon = (fieldState: TypeFieldState) => {
-    switch (fieldState) {
-      case 'default':
-        break;
-      case 'disabled':
-        break;
-      case 'required':
-        return <Icon icon='Required' size={16} />;
-      case 'valid':
-        return <Icon icon='Success' size={16} />;
-      case 'invalid':
-        return <Icon icon='Invalid' size={16} />;
-      case 'processing':
-        return <Spinner size='medium' styling='primary' />;
-    }
-  };
+    const feedbackIcon = (fieldState: TypeFieldState) => {
+      switch (fieldState) {
+        case 'default':
+          break;
+        case 'disabled':
+          break;
+        case 'required':
+          return <Icon icon='Required' size={16} />;
+        case 'valid':
+          return <Icon icon='Success' size={16} />;
+        case 'invalid':
+          return <Icon icon='Invalid' size={16} />;
+        case 'processing':
+          return <Spinner size='medium' styling='primary' />;
+      }
+    };
 
-  return (
-    <Container $fieldState={fieldState || 'default'} $showFeedback={showFeedback}>
-      <InputContainer $hasAction={isActionButton}>
-        <StyledInput
-          ref={ref}
-          $fieldState={fieldState || 'default'}
-          disabled={fieldState === 'disabled' || fieldState === 'processing'}
-          type={type}
-          placeholder={placeholder}
-          defaultValue={defaultValue}
-          {...props}
-        />
-        {isActionButton ? (
-          <ActionContainer>
-            <InputActionButton onClick={actionCallback}>
-              <Icon icon={actionIcon || 'NoIcon'} color='primary' />
-            </InputActionButton>
-          </ActionContainer>
+    return (
+      <Container $fieldState={fieldState || 'default'} $showFeedback={showFeedback}>
+        <InputContainer $hasAction={isActionButton}>
+          <StyledInput
+            ref={ref}
+            $fieldState={fieldState || 'default'}
+            disabled={fieldState === 'disabled' || fieldState === 'processing'}
+            type={type}
+            placeholder={placeholder}
+            defaultValue={defaultValue}
+            {...props}
+          />
+          {isActionButton ? (
+            <ActionContainer>
+              <InputActionButton onClick={actionCallback}>
+                <Icon icon={actionIcon || 'NoIcon'} color='primary' />
+              </InputActionButton>
+            </ActionContainer>
+          ) : null}
+        </InputContainer>
+
+        {fieldState && showFeedback ? (
+          <FeedbackContainer>
+            <FeedbackIcon>{feedbackIcon(fieldState)}</FeedbackIcon>
+            {feedbackMessage ? <FeedbackMessage>{feedbackMessage}</FeedbackMessage> : null}
+          </FeedbackContainer>
         ) : null}
-      </InputContainer>
-
-      {fieldState && showFeedback ? (
-        <FeedbackContainer>
-          <FeedbackIcon>{feedbackIcon(fieldState)}</FeedbackIcon>
-          {feedbackMessage ? <FeedbackMessage>{feedbackMessage}</FeedbackMessage> : null}
-        </FeedbackContainer>
-      ) : null}
-    </Container>
-  );
-});
+      </Container>
+    );
+  }
+);
 
 Input.displayName = 'Input';
 

--- a/packages/ui-lib/src/Form/atoms/RadioButton.tsx
+++ b/packages/ui-lib/src/Form/atoms/RadioButton.tsx
@@ -117,6 +117,7 @@ const RadioButton: React.FC<IRadioButton> = ({
   disabled = false,
   required,
   onChangeCallback = () => {},
+  onBlur,
 }) => {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -135,6 +136,7 @@ const RadioButton: React.FC<IRadioButton> = ({
         {...{ id, name, disabled, required, value }}
         checked={isChecked}
         onChange={handleChange}
+        onBlur={onBlur}
       />
       <OuterRadio $isChecked={isChecked} $disabled={disabled}>
         <InnerRadio />

--- a/packages/ui-lib/src/Form/atoms/RadioButton.tsx
+++ b/packages/ui-lib/src/Form/atoms/RadioButton.tsx
@@ -11,28 +11,19 @@ const InnerRadio = styled.div`
 
 const OuterRadio = styled.div<{ $isChecked: boolean; $disabled: boolean }>`
   position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  width: 100%;
   border-radius: 50%;
   border-width: 2px;
   border-style: solid;
+  box-sizing: border-box;
+  pointer-events: none;
   user-select: none;
 
   ${({ $isChecked, $disabled }) => css`
     border-color: var(--input-toggle-unchecked-border-color);
-
-    ${
-      !$disabled &&
-      css`
-      &:hover {
-        cursor: pointer;
-        border-color: var(--input-toggle-unchecked-hover-border-color);
-      }
-    `
-    };
 
     ${
       $isChecked &&
@@ -47,22 +38,8 @@ const OuterRadio = styled.div<{ $isChecked: boolean; $disabled: boolean }>`
 
     ${
       $isChecked &&
-      !$disabled &&
-      css`
-      &:hover {
-        border-color: var(--input-toggle-checked-hover-border-color);
-        ${InnerRadio} {
-          background-color: var(--input-toggle-checked-hover-background-color);
-        }
-      }
-    `
-    };
-
-    ${
-      $isChecked &&
       $disabled &&
       css`
-      cursor: not-allowed;
       border-color: var(--input-toggle-checked-disabled-border-color);
       ${InnerRadio} {
         background-color: var(--input-toggle-checked-disabled-background-color);
@@ -74,7 +51,6 @@ const OuterRadio = styled.div<{ $isChecked: boolean; $disabled: boolean }>`
       !$isChecked &&
       $disabled &&
       css`
-      cursor: not-allowed;
       border-color: var(--input-toggle-unchecked-disabled-border-color);
       ${InnerRadio} {
         background-color: var(--input-toggle-unchecked-disabled-background-color);
@@ -86,11 +62,28 @@ const OuterRadio = styled.div<{ $isChecked: boolean; $disabled: boolean }>`
 
 const HiddenInput = styled.input`
   position: absolute;
-  height: 100%;
-  width: 100%;
+  inset: 0;
   margin: 0;
-  padding:0;
+  padding: 0;
   opacity: 0;
+  cursor: pointer;
+  z-index: 1;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) + ${OuterRadio} {
+    border-color: var(--input-toggle-unchecked-hover-border-color);
+  }
+
+  &:checked:hover:not(:disabled) + ${OuterRadio} {
+    border-color: var(--input-toggle-checked-hover-border-color);
+
+    ${InnerRadio} {
+      background-color: var(--input-toggle-checked-hover-background-color);
+    }
+  }
 `;
 
 const Container = styled.div`

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { type SelectHTMLAttributes, useCallback, useState } from 'react';
+import { type SelectHTMLAttributes, forwardRef, useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';
 import Icon from '../../Icons/Icon';
 import type { TypeFieldState, TypeLabelDirection } from '..';
@@ -124,7 +124,7 @@ interface OwnProps {
 
 type ISelect = OwnProps & SelectHTMLAttributes<HTMLSelectElement>;
 
-const SelectField: React.FC<ISelect> = ({
+const SelectField = forwardRef<HTMLSelectElement, ISelect>(({
   fieldState = 'default',
   placeholder,
   label,
@@ -132,9 +132,10 @@ const SelectField: React.FC<ISelect> = ({
   isCompact,
   defaultValue,
   changeCallback = () => {},
+  onChange,
   children,
   ...props
-}) => {
+}, ref) => {
   if (label?.isSameRow) {
     console.warn(
       'Deprecation warning: `SelectField` is deprecating `label.isSameRow`, please update this to use `label.direction` set to `row`.'
@@ -154,8 +155,9 @@ const SelectField: React.FC<ISelect> = ({
         return prev;
       });
       changeCallback(value);
+      onChange?.(e);
     },
-    [changeCallback]
+    [changeCallback, onChange]
   );
 
   const iconColor = useCallback(() => {
@@ -175,6 +177,7 @@ const SelectField: React.FC<ISelect> = ({
           </SubjectIcon>
         )}
         <StyledSelect
+          ref={ref}
           $withIcon={!!icon}
           id={htmlFor}
           $fieldState={fieldState}
@@ -196,6 +199,7 @@ const SelectField: React.FC<ISelect> = ({
       </SelectWrapper>
     ),
     [
+      ref,
       children,
       defaultValue,
       handleOnChange,
@@ -224,6 +228,8 @@ const SelectField: React.FC<ISelect> = ({
       )}
     </Container>
   );
-};
+});
+
+SelectField.displayName = 'SelectField';
 
 export default SelectField;

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { type SelectHTMLAttributes, forwardRef, useCallback, useState } from 'react';
+import { forwardRef, type SelectHTMLAttributes, useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';
 import Icon from '../../Icons/Icon';
 import type { TypeFieldState, TypeLabelDirection } from '..';
@@ -124,138 +124,143 @@ interface OwnProps {
 
 type ISelect = OwnProps & SelectHTMLAttributes<HTMLSelectElement>;
 
-const SelectField = forwardRef<HTMLSelectElement, ISelect>(({
-  fieldState = 'default',
-  placeholder,
-  label,
-  icon,
-  isCompact,
-  defaultValue,
-  changeCallback = () => {},
-  onChange,
-  onKeyDown,
-  children,
-  ...props
-}, ref) => {
-  if (label?.isSameRow) {
-    console.warn(
-      'Deprecation warning: `SelectField` is deprecating `label.isSameRow`, please update this to use `label.direction` set to `row`.'
+const SelectField = forwardRef<HTMLSelectElement, ISelect>(
+  (
+    {
+      fieldState = 'default',
+      placeholder,
+      label,
+      icon,
+      isCompact,
+      defaultValue,
+      changeCallback = () => {},
+      onChange,
+      onKeyDown,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    if (label?.isSameRow) {
+      console.warn(
+        'Deprecation warning: `SelectField` is deprecating `label.isSameRow`, please update this to use `label.direction` set to `row`.'
+      );
+    }
+
+    const [activePlaceholder, setPlaceholderStatus] = useState<boolean>(!defaultValue);
+
+    const handleOnChange = useCallback(
+      (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const { value } = e.target;
+
+        setPlaceholderStatus((prev) => {
+          if (prev) {
+            return false;
+          }
+          return prev;
+        });
+        changeCallback(value);
+        onChange?.(e);
+      },
+      [changeCallback, onChange]
+    );
+
+    const handleOnKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLSelectElement>) => {
+        onKeyDown?.(e);
+
+        if (e.defaultPrevented || e.key !== 'ArrowDown' || e.currentTarget.value !== '') {
+          return;
+        }
+
+        // In placeholder mode the empty option is reserved for the placeholder.
+        const nextOption = Array.from(e.currentTarget.options).find(
+          (option) => !option.disabled && !option.hidden && option.value !== ''
+        );
+
+        if (!nextOption) {
+          return;
+        }
+
+        e.preventDefault();
+        e.currentTarget.value = nextOption.value;
+        e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
+      },
+      [onKeyDown]
+    );
+
+    const iconColor = useCallback(() => {
+      if (props.disabled || fieldState === 'disabled') {
+        return 'input-disabled-lead-icon';
+      } else {
+        return 'input-lead-icon';
+      }
+    }, [fieldState, props.disabled]);
+
+    const renderSelect = useCallback(
+      (htmlFor?: string) => (
+        <SelectWrapper>
+          {icon && (
+            <SubjectIcon $isCompact={isCompact}>
+              <Icon icon={icon} color={iconColor()} size={isCompact ? 12 : 12} weight='regular' />
+            </SubjectIcon>
+          )}
+          <StyledSelect
+            ref={ref}
+            $withIcon={!!icon}
+            id={htmlFor}
+            $fieldState={fieldState}
+            $isCompact={isCompact}
+            {...props}
+            {...(props.value === undefined ? { defaultValue: defaultValue ?? '' } : {})}
+            onChange={handleOnChange}
+            onKeyDown={handleOnKeyDown}
+          >
+            {!defaultValue && (
+              <option value='' disabled hidden>
+                {placeholder}
+              </option>
+            )}
+            {children}
+          </StyledSelect>
+          <OpenIcon $isCompact={isCompact}>
+            <Icon icon='Down' color={iconColor()} weight='regular' size={isCompact ? 8 : 10} />
+          </OpenIcon>
+        </SelectWrapper>
+      ),
+      [
+        ref,
+        children,
+        defaultValue,
+        handleOnChange,
+        handleOnKeyDown,
+        placeholder,
+        // biome-ignore lint/correctness/useExhaustiveDependencies: props is the rest object from the destructuring of OwnProps & SelectHTMLAttributes — its identity changes every render. Stabilising requires an API change to forward props explicitly. See #644.
+        props,
+        fieldState,
+        icon,
+        iconColor,
+        isCompact,
+      ]
+    );
+
+    return (
+      <Container {...{ $isCompact: isCompact, $activePlaceholder: activePlaceholder }}>
+        {label ? (
+          <Label
+            htmlFor={label.htmlFor}
+            labelText={label.text}
+            direction={label.isSameRow ? 'row' : label.direction}
+          >
+            {renderSelect(label.htmlFor)}
+          </Label>
+        ) : (
+          renderSelect()
+        )}
+      </Container>
     );
   }
-
-  const [activePlaceholder, setPlaceholderStatus] = useState<boolean>(!defaultValue);
-
-  const handleOnChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const { value } = e.target;
-
-      setPlaceholderStatus((prev) => {
-        if (prev) {
-          return false;
-        }
-        return prev;
-      });
-      changeCallback(value);
-      onChange?.(e);
-    },
-    [changeCallback, onChange]
-  );
-
-  const handleOnKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLSelectElement>) => {
-      onKeyDown?.(e);
-
-      if (e.defaultPrevented || e.key !== 'ArrowDown' || e.currentTarget.value !== '') {
-        return;
-      }
-
-      // In placeholder mode the empty option is reserved for the placeholder.
-      const nextOption = Array.from(e.currentTarget.options).find(
-        (option) => !option.disabled && !option.hidden && option.value !== ''
-      );
-
-      if (!nextOption) {
-        return;
-      }
-
-      e.preventDefault();
-      e.currentTarget.value = nextOption.value;
-      e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
-    },
-    [onKeyDown]
-  );
-
-  const iconColor = useCallback(() => {
-    if (props.disabled || fieldState === 'disabled') {
-      return 'input-disabled-lead-icon';
-    } else {
-      return 'input-lead-icon';
-    }
-  }, [fieldState, props.disabled]);
-
-  const renderSelect = useCallback(
-    (htmlFor?: string) => (
-      <SelectWrapper>
-        {icon && (
-          <SubjectIcon $isCompact={isCompact}>
-            <Icon icon={icon} color={iconColor()} size={isCompact ? 12 : 12} weight='regular' />
-          </SubjectIcon>
-        )}
-        <StyledSelect
-          ref={ref}
-          $withIcon={!!icon}
-          id={htmlFor}
-          $fieldState={fieldState}
-          $isCompact={isCompact}
-          {...props}
-          {...(props.value === undefined ? { defaultValue: defaultValue ?? '' } : {})}
-          onChange={handleOnChange}
-          onKeyDown={handleOnKeyDown}
-        >
-          {!defaultValue && (
-            <option value='' disabled hidden>
-              {placeholder}
-            </option>
-          )}
-          {children}
-        </StyledSelect>
-        <OpenIcon $isCompact={isCompact}>
-          <Icon icon='Down' color={iconColor()} weight='regular' size={isCompact ? 8 : 10} />
-        </OpenIcon>
-      </SelectWrapper>
-    ),
-    [
-      ref,
-      children,
-      defaultValue,
-      handleOnChange,
-      handleOnKeyDown,
-      placeholder,
-      // biome-ignore lint/correctness/useExhaustiveDependencies: props is the rest object from the destructuring of OwnProps & SelectHTMLAttributes — its identity changes every render. Stabilising requires an API change to forward props explicitly. See #644.
-      props,
-      fieldState,
-      icon,
-      iconColor,
-      isCompact,
-    ]
-  );
-
-  return (
-    <Container {...{ $isCompact: isCompact, $activePlaceholder: activePlaceholder }}>
-      {label ? (
-        <Label
-          htmlFor={label.htmlFor}
-          labelText={label.text}
-          direction={label.isSameRow ? 'row' : label.direction}
-        >
-          {renderSelect(label.htmlFor)}
-        </Label>
-      ) : (
-        renderSelect()
-      )}
-    </Container>
-  );
-});
+);
 
 SelectField.displayName = 'SelectField';
 

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -133,6 +133,7 @@ const SelectField = forwardRef<HTMLSelectElement, ISelect>(({
   defaultValue,
   changeCallback = () => {},
   onChange,
+  onKeyDown,
   children,
   ...props
 }, ref) => {
@@ -160,6 +161,30 @@ const SelectField = forwardRef<HTMLSelectElement, ISelect>(({
     [changeCallback, onChange]
   );
 
+  const handleOnKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLSelectElement>) => {
+      onKeyDown?.(e);
+
+      if (e.defaultPrevented || e.key !== 'ArrowDown' || e.currentTarget.value !== '') {
+        return;
+      }
+
+      // In placeholder mode the empty option is reserved for the placeholder.
+      const nextOption = Array.from(e.currentTarget.options).find(
+        (option) => !option.disabled && !option.hidden && option.value !== ''
+      );
+
+      if (!nextOption) {
+        return;
+      }
+
+      e.preventDefault();
+      e.currentTarget.value = nextOption.value;
+      e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
+    },
+    [onKeyDown]
+  );
+
   const iconColor = useCallback(() => {
     if (props.disabled || fieldState === 'disabled') {
       return 'input-disabled-lead-icon';
@@ -185,6 +210,7 @@ const SelectField = forwardRef<HTMLSelectElement, ISelect>(({
           {...props}
           {...(props.value === undefined ? { defaultValue: defaultValue ?? '' } : {})}
           onChange={handleOnChange}
+          onKeyDown={handleOnKeyDown}
         >
           {!defaultValue && (
             <option value='' disabled hidden>
@@ -203,6 +229,7 @@ const SelectField = forwardRef<HTMLSelectElement, ISelect>(({
       children,
       defaultValue,
       handleOnChange,
+      handleOnKeyDown,
       placeholder,
       // biome-ignore lint/correctness/useExhaustiveDependencies: props is the rest object from the destructuring of OwnProps & SelectHTMLAttributes — its identity changes every render. Stabilising requires an API change to forward props explicitly. See #644.
       props,

--- a/packages/ui-lib/src/Form/index.ts
+++ b/packages/ui-lib/src/Form/index.ts
@@ -16,11 +16,11 @@ import Switch, { type TypeSwitchState } from './atoms/Switch';
 import TextArea from './atoms/TextArea';
 import Form from './Form';
 import ActionButtons from './molecules/ActionButtons';
-import FormField from './molecules/FormField';
-import type { FormFieldProps, FormFieldRenderProps } from './molecules/FormField';
 import ButtonsStack, { type IButtonStack, type IButtonsStack } from './molecules/ButtonsStack';
 import CropTool from './molecules/CropTool';
 import DurationSlider from './molecules/DurationSlider';
+import type { FormFieldProps, FormFieldRenderProps } from './molecules/FormField';
+import FormField from './molecules/FormField';
 import PasswordField from './molecules/PasswordField';
 import PercentageSlider from './molecules/PercentageSlider';
 import SplitButton, { type ISplitButtonProps } from './molecules/SplitButton';
@@ -31,7 +31,6 @@ import AvatarUploader from './organisms/AvatarUploader';
 
 export {
   ActionButtons,
-  FormField,
   AreaUploadManager,
   AvatarUploader,
   Button,
@@ -43,6 +42,7 @@ export {
   DropArea,
   DurationSlider,
   Form,
+  FormField,
   IconButton,
   Input,
   InputFileButton,

--- a/packages/ui-lib/src/Form/index.ts
+++ b/packages/ui-lib/src/Form/index.ts
@@ -16,6 +16,8 @@ import Switch, { type TypeSwitchState } from './atoms/Switch';
 import TextArea from './atoms/TextArea';
 import Form from './Form';
 import ActionButtons from './molecules/ActionButtons';
+import FormField from './molecules/FormField';
+import type { FormFieldProps, FormFieldRenderProps } from './molecules/FormField';
 import ButtonsStack, { type IButtonStack, type IButtonsStack } from './molecules/ButtonsStack';
 import CropTool from './molecules/CropTool';
 import DurationSlider from './molecules/DurationSlider';
@@ -29,6 +31,7 @@ import AvatarUploader from './organisms/AvatarUploader';
 
 export {
   ActionButtons,
+  FormField,
   AreaUploadManager,
   AvatarUploader,
   Button,
@@ -86,6 +89,8 @@ interface ButtonProps {
 export type IButtonProps = ButtonProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export type {
+  FormFieldProps,
+  FormFieldRenderProps,
   IButtonStack,
   IButtonsStack,
   IconButtonData,

--- a/packages/ui-lib/src/Form/molecules/FormField.tsx
+++ b/packages/ui-lib/src/Form/molecules/FormField.tsx
@@ -1,0 +1,112 @@
+import type React from 'react';
+import styled from 'styled-components';
+import { useController } from 'react-hook-form';
+import type { ControllerRenderProps, RegisterOptions } from 'react-hook-form';
+import Label from '../atoms/Label';
+import type { TypeFieldState } from '..';
+
+const ErrorMessage = styled.span`
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--input-invalid-border-color, #e53935);
+`;
+
+const HintMessage = styled.span`
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--primary-7);
+`;
+
+const FieldWrapper = styled.div`
+  margin-bottom: 24px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+// fieldset reset — inherits font stack and colors from Label
+const Fieldset = styled.fieldset`
+  border: none;
+  padding: 0;
+  margin: 0;
+`;
+
+const Legend = styled.legend`
+  font-family: var(--font-ui);
+  color: var(--grey-11);
+  font-size: 14px;
+  font-weight: 500;
+  padding: 0;
+  margin-bottom: 8px;
+`;
+
+type FormFieldRenderProps = {
+  field: ControllerRenderProps;
+  fieldState: TypeFieldState;
+  id: string;
+  errorId: string;
+  'aria-invalid': boolean;
+};
+
+type FormFieldProps = {
+  name: string;
+  label: string;
+  required?: boolean;
+  hint?: string;
+  rules?: RegisterOptions;
+  // 'group' renders <fieldset>+<legend>; aria-describedby on fieldset (not each radio) — modern AT support sufficient, avoids per-radio repetition
+  variant?: 'group';
+  children: (renderProps: FormFieldRenderProps) => React.ReactNode;
+};
+
+const FormField: React.FC<FormFieldProps> = ({ name, label, required, hint, rules, variant, children }) => {
+  const { field, fieldState: rhfFieldState } = useController({ name, rules });
+  const hasError = !!rhfFieldState.error;
+  const errorId = `${name}-error`;
+  const fieldState: TypeFieldState = hasError ? 'invalid' : 'default';
+
+  const renderProps: FormFieldRenderProps = {
+    field,
+    fieldState,
+    id: name,
+    errorId,
+    'aria-invalid': hasError,
+  };
+
+  const errorNode = hasError && rhfFieldState.error?.message ? (
+    <ErrorMessage id={errorId} role='alert'>
+      {rhfFieldState.error.message}
+    </ErrorMessage>
+  ) : null;
+
+  const hintNode = hint && !hasError ? <HintMessage>{hint}</HintMessage> : null;
+
+  if (variant === 'group') {
+    return (
+      <FieldWrapper>
+        <Fieldset aria-describedby={hasError ? errorId : undefined}>
+          <Legend>{label}</Legend>
+          {children(renderProps)}
+          {hintNode}
+          {errorNode}
+        </Fieldset>
+      </FieldWrapper>
+    );
+  }
+
+  return (
+    <FieldWrapper>
+      <Label htmlFor={name} labelText={label} required={required}>
+        {children(renderProps)}
+      </Label>
+      {hintNode}
+      {errorNode}
+    </FieldWrapper>
+  );
+};
+
+export default FormField;
+export type { FormFieldProps, FormFieldRenderProps };

--- a/packages/ui-lib/src/Form/molecules/FormField.tsx
+++ b/packages/ui-lib/src/Form/molecules/FormField.tsx
@@ -1,9 +1,9 @@
 import type React from 'react';
-import styled from 'styled-components';
-import { useController } from 'react-hook-form';
 import type { ControllerRenderProps, RegisterOptions } from 'react-hook-form';
-import Label from '../atoms/Label';
+import { useController } from 'react-hook-form';
+import styled from 'styled-components';
 import type { TypeFieldState } from '..';
+import Label from '../atoms/Label';
 
 const ErrorMessage = styled.span`
   display: block;
@@ -62,7 +62,15 @@ type FormFieldProps = {
   children: (renderProps: FormFieldRenderProps) => React.ReactNode;
 };
 
-const FormField: React.FC<FormFieldProps> = ({ name, label, required, hint, rules, variant, children }) => {
+const FormField: React.FC<FormFieldProps> = ({
+  name,
+  label,
+  required,
+  hint,
+  rules,
+  variant,
+  children,
+}) => {
   const { field, fieldState: rhfFieldState } = useController({ name, rules });
   const hasError = !!rhfFieldState.error;
   const errorId = `${name}-error`;
@@ -76,11 +84,12 @@ const FormField: React.FC<FormFieldProps> = ({ name, label, required, hint, rule
     'aria-invalid': hasError,
   };
 
-  const errorNode = hasError && rhfFieldState.error?.message ? (
-    <ErrorMessage id={errorId} role='alert'>
-      {rhfFieldState.error.message}
-    </ErrorMessage>
-  ) : null;
+  const errorNode =
+    hasError && rhfFieldState.error?.message ? (
+      <ErrorMessage id={errorId} role='alert'>
+        {rhfFieldState.error.message}
+      </ErrorMessage>
+    ) : null;
 
   const hintNode = hint && !hasError ? <HintMessage>{hint}</HintMessage> : null;
 

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -25,6 +25,7 @@ import {
   IconButton,
   type IconButtonData,
   ActionButtons,
+  FormField,
   SmallInput,
   Input,
   Label,
@@ -54,6 +55,8 @@ import {
   type TypeSwitchState,
 } from './Form';
 import type {
+  FormFieldProps,
+  FormFieldRenderProps,
   TypeFieldState,
   TypeButtonDesigns,
   TypeButtonSizes,
@@ -257,6 +260,7 @@ export {
   ButtonWithLoading,
   IconButton,
   ActionButtons,
+  FormField,
   Input,
   SmallInput,
   Label,
@@ -378,6 +382,8 @@ export type IStatusDot = 'caution' | 'danger' | 'good' | 'neutral' | 'highlight'
 export type IWeight = 'light' | 'regular' | 'heavy' | 'strong';
 
 export type {
+  FormFieldProps,
+  FormFieldRenderProps,
   IModal,
   INotificationProps,
   IconButtonData,

--- a/packages/ui-lib/vite.config.ts
+++ b/packages/ui-lib/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig(() => {
           'react/jsx-runtime',
           'react-router',
           'react-router-dom',
+          'react-hook-form',
           'styled-components',
           'date-fns',
           'date-fns/locale',

--- a/rhf-spike-report.md
+++ b/rhf-spike-report.md
@@ -1,0 +1,250 @@
+# React Hook Form Integration Spike — Report
+
+Spike PRD: [issue #1](https://github.com/isacoder/scorer-ui-kit/issues/1) · Source PRD: `REACT_HOOK_FORM_SPIKE_PRD.md` · Slices: issues #2–#9 · Timebox: 2 days · Outcome: working PoC at `/rhf-spike` route, additive `FormField` molecule, 14 Playwright assertions.
+
+## TL;DR
+
+React Hook Form integrates cleanly with scorer-ui-kit v3 — no breaking changes, five input types working end-to-end, 14 Playwright assertions passing. `Input` works directly via `register` after a `forwardRef` addition; `SelectField`, `RadioButton`, and `Checkbox` need a `Controller` adapter, provided by the new `FormField` molecule.
+
+---
+
+## Recommendation
+
+**Adopt React Hook Form — with conditions.**
+
+The integration is cheap, no breaking changes were required, and the PoC drives a five-field form (text, email, select, radio group, checkbox group) end-to-end with validation, error rendering, and keyboard-only submission. The conditions are not blockers but they are real: before we recommend RHF to product teams, we should land the additive changes to `RadioButton` and `Checkbox`, fix the unconditional `aria-describedby` wiring in `FormField`, and decide whether `FormField` (or a thin per-product wrapper around it) is the canonical entry point. None of these are large pieces of work.
+
+The strongest evidence for "adopt": `Input` works through `register` after a single `forwardRef` change, and every other component composes cleanly through `useController` inside `FormField` without touching consumer code. The strongest evidence for "with conditions": `Checkbox` had a `display: none` hidden input that was preventing keyboard focus on the real control — a pre-existing accessibility regression the spike happened to surface. There are likely more of these in untested atoms (e.g. `Switch`, `SliderInput`) that an audit should catch before we tell product teams "RHF works with the kit."
+
+---
+
+## Required UI Kit component changes
+
+### Made during the spike (all additive, no breaking changes)
+
+| Component | Change | Rationale |
+| --- | --- | --- |
+| `Input` | Wrapped in `React.forwardRef<HTMLInputElement, InputProps>` | RHF needs a ref to focus the first invalid field and to manage uncontrolled inputs via `register` |
+| `SelectField` | Wrapped in `forwardRef<HTMLSelectElement, ISelect>`; native `onChange(event)` now forwarded alongside the existing `changeCallback(value)` | RHF passes its own `onChange` through `Controller.field` and expects a native event |
+| `RadioButton` | `onBlur` prop pass-through to the underlying `<input>` | RHF's `mode: 'onTouched'` keys on blur; without this the touched state never updates |
+| `Checkbox` | New `id` prop; new `controlled` boolean prop that bypasses internal `useState` when `true`; hidden input changed from `display: none` to absolutely-positioned `opacity: 0` so it is keyboard-focusable | The internal `useState` fought RHF's value as the source of truth; the `display: none` was masking a real a11y bug |
+| `FormField` (new molecule) | Render-prop component built on `useController`; renders `Label` (or `<fieldset>`+`<legend>`) and an error `<span role='alert'>`; exposes `id`, `errorId`, `aria-invalid`, and the RHF `field` object through render props | Single home for label association, error rendering, and a11y attribute wiring |
+
+### Recommended but not made (follow-up work)
+
+- **`RadioButton` and `Checkbox`: `forwardRef`**, native `onChange(event)` alongside the existing `onChangeCallback`, and `aria-invalid` / `aria-describedby` pass-through. Without `forwardRef`, RHF can't focus an invalid field. Without native `onChange`, consumers always need a `Controller` adapter even where `register` would otherwise suffice.
+- **`Checkbox`: native `onBlur` pass-through** (same reason as RadioButton — `onTouched` mode).
+- **`Checkbox`, `RadioButton`: an `invalid` prop** (or accept `fieldState='invalid'` to match `Input`/`SelectField`). The PoC has no visual invalid state on these controls because the kit gives no way to render one.
+- **`TextField` molecule audit.** The PoC used `Input` directly; `TextField` was not exercised. Likely needs the same `forwardRef`/`onBlur` treatment.
+- **`FormField`: fix `aria-describedby` to be conditional.** Today the render-prop hands back an `errorId` unconditionally and consumers wire it unconditionally, so `aria-describedby='name-error'` points to a non-existent element when the field is valid. Browsers tolerate it; screen readers can warn. Fix is one line — return `errorId` only when `hasError`.
+- **`--input-hint-color` theme token.** `FormField` references it for hint text but it is not defined in `Colors.ts` — falls back to a hardcoded grey. Either add the token or pick an existing one (e.g. `--grey-9`).
+- **`required` indicator on group legends.** `Label` shows the `*` for required single fields; `<legend>` in `variant='group'` does not. Cosmetic but inconsistent.
+- **Label atom for radio/checkbox options.** The PoC writes its own `<label htmlFor=...>` for each radio/checkbox option because the kit has no equivalent atom. A `CheckboxLabel`/`RadioLabel` (or extending `Label`) would close this gap.
+
+---
+
+## Effort estimate
+
+**Moderate** for kit-wide form support.
+
+Reasoning:
+- Per-component changes are individually small (a `forwardRef`, an event pass-through, an `invalid` prop). For the four atoms touched in the PoC plus `TextField`, this is maybe a day each including stories, tests, and docs.
+- The work multiplies across the form-component count. The kit lists ~28 form components in `AGENTS.md`. Most won't need RHF wiring (`ButtonWithIcon`, `Spinner`, etc.) but a Switch/Slider/DatePicker pass is plausibly needed if those are to be used in RHF forms, and each will surface its own quirks.
+- `FormField` itself is done and the API is small. The biggest documentation chunk is a migration / usage guide aimed at product teams.
+- **Not small**: it touches public API across multiple components.
+- **Not significant**: no breaking changes, no schema layer, no architectural rewrite. The kit's existing `fieldState` enum already covers the visual states RHF needs to map to.
+
+---
+
+## Per-component compatibility table
+
+| Component | Status | Path used in PoC | Notes |
+| --- | --- | --- | --- |
+| `Input` | **Works directly** after `forwardRef` | `useController` via `FormField` (would also work with `register`) | The cleanest integration of the bunch |
+| `SelectField` | **Needs adapter** (provided by `FormField`) | `useController` via `FormField` | Custom `changeCallback(value)` shape coexists with the native `onChange(event)` now forwarded |
+| `RadioButton` | **Needs adapter** | `useController` via `FormField`; group rendered with `variant='group'` | `onBlur` pass-through is the only made change; native `onChange` and `forwardRef` recommended |
+| `Checkbox` | **Needs adapter** | `useController` via `FormField`; group rendered with `variant='group'`; consumer derives `checked` from array membership and writes back via the array | New `controlled` and `id` props were required to make this not fight RHF |
+| `TextField` (molecule) | **Untested — not blocked** | n/a | Plausibly the same shape as `Input`; needs an explicit pass |
+| `FormField` (new) | **Built for this spike** | The canonical entry point | Render-prop API; deep module owning label + error + a11y wiring |
+
+Legend: *works directly* = usable with `register` after additive changes only; *needs adapter* = requires `Controller` (or `useController`) to bridge the kit's callback shape to RHF.
+
+---
+
+## Recommended component API patterns
+
+### Where errors live
+
+Errors live in a wrapper component (`FormField` or successor), not on individual inputs. Per-input error props would duplicate the a11y wiring (`aria-invalid`, `aria-describedby`, the alert region) across every form atom and force consumers to choose between two error renderers per field. The spike's render-prop API keeps the inputs "dumb" and the wrapper authoritative.
+
+Concretely the next-generation API should keep this shape:
+
+```tsx
+<FormField
+  name='email'
+  label='Email'
+  required
+  hint='We never share your email.'
+  rules={{ required: 'Email is required', pattern: { value: EMAIL, message: 'Enter a valid email' } }}
+>
+  {({ field, fieldState, id, errorId, 'aria-invalid': ariaInvalid }) => (
+    <Input
+      {...field}
+      id={id}
+      type='email'
+      fieldState={fieldState}
+      aria-invalid={ariaInvalid}
+      aria-describedby={errorId}  // should be undefined when valid (see open items)
+    />
+  )}
+</FormField>
+```
+
+### Props that expose component state
+
+The kit already has a `fieldState: 'default' | 'invalid' | 'disabled' | 'processing'` enum on `Input` and `SelectField`. Adopt this consistently across `Checkbox`, `RadioButton`, `Switch`, etc., and map RHF state to it inside `FormField`:
+
+| RHF state | `fieldState` value |
+| --- | --- |
+| `error` is set | `invalid` |
+| `formState.isSubmitting` is true | `processing` |
+| `disabled` (prop) | `disabled` |
+| otherwise | `default` |
+
+Keep `required` as a separate prop (not a state) — it drives the visual `*` indicator and `aria-required`, independent of validity. `touched` is *not* a visual state; it only controls *when* the wrapper reveals an error, and `FormField` already encapsulates this via RHF's `mode`.
+
+---
+
+## Group-level error pattern
+
+**Chosen approach: `<fieldset>` + `<legend>` + `aria-describedby` on the fieldset.**
+
+`FormField`'s `variant='group'` renders:
+
+```html
+<fieldset aria-describedby='preference-error'>  <!-- only when invalid -->
+  <legend>Mountain or ocean</legend>
+  <!-- radio / checkbox children rendered by the consumer -->
+  <span id='preference-error' role='alert'>…</span>
+</fieldset>
+```
+
+Trade-offs considered:
+- **`aria-describedby` on each child input** vs **on the fieldset**: per-input would repeat the same error association on every option and over-announces in NVDA/JAWS. Modern AT supports `aria-describedby` on `<fieldset>` directly; one announcement, one source of truth.
+- **`role='group'` on a `<div>`** vs **native `<fieldset>`**: the spike chose native. `<fieldset>` gives screen readers the group context for free and avoids the `role='group' + aria-labelledby` boilerplate. The styled-component fieldset reset (`border: none; padding: 0; margin: 0;`) keeps the visual unchanged.
+
+Recommendation for the next-generation API: keep this exact pattern. The only change suggested is to render the `required` indicator on the `<legend>` to match the single-field `Label` behaviour.
+
+---
+
+## Validation mode
+
+**Chosen: `mode: 'onTouched'`.**
+
+Reasoning:
+- `onSubmit` (the default) waits until the user hits Submit, which is hostile for long forms where the user could correct earlier mistakes as they go.
+- `onChange` validates on every keystroke, which surfaces "Enter a valid email address" before the user has finished typing — noisy and feels accusatory.
+- `onBlur` validates on the first blur regardless of whether the field has been edited, which can fire errors on a field the user *intended* to come back to.
+- `onTouched` waits for the first blur of an edited (or focused-then-blurred) field, then re-validates on every change. The error appears at a moment the user expects ("I moved on from this field"), then keeps up with their corrections. This is the de-facto best-practice mode for RHF and matches the user-story 7 expectation that errors appear "at a predictable moment".
+
+The slice-6 happy-path Playwright spec confirms this empirically (`name field shows error on blur after touch without submit`).
+
+---
+
+## Accessibility observations
+
+Items the spike *surfaced*. "Surfaced ≠ fixed" — half of these are open follow-ups.
+
+| # | Observation | Severity | Fixed in spike? |
+| --- | --- | --- | --- |
+| 1 | `Checkbox`'s hidden `<input>` was `display: none`, removing it from the focus order entirely. Keyboard users could not tab to a checkbox. | **High** (pre-existing) | **Yes** — changed to absolute-positioned `opacity: 0` |
+| 2 | `aria-describedby` is wired to `errorId` unconditionally, even when no error element exists in the DOM | Low | No — one-line fix recommended |
+| 3 | `RadioButton` and `Checkbox` have no `aria-invalid` / `aria-describedby` pass-through; group-level association on the fieldset is the only path today | Medium | No |
+| 4 | `RadioButton` does not expose a native `onChange(event)` — consumers must use `onChangeCallback`. Doesn't break a11y but blocks `register` and forces every consumer into a `Controller` | Low (DX, not a11y) | No |
+| 5 | `Checkbox` `onChangeCallback(checked: boolean)` shape is similar — and `Checkbox` has no `onBlur` at all, so `mode: 'onTouched'` cannot fire on a single checkbox blur | Low | No |
+| 6 | `<legend>` does not render a `required` indicator the way `Label` does for single fields | Low | No |
+| 7 | The kit lacks a labelling atom for radio/checkbox options; the PoC writes its own `<label htmlFor=...>` per option | Low | No |
+| 8 | `--input-hint-color` is referenced in `FormField` but not defined in `Colors.ts`; hint text falls back to a hardcoded `#6b7280` | Low | No |
+| 9 | The error element uses `role='alert'` (live region) *and* is associated via `aria-describedby`. This is intentional — `role='alert'` announces on appearance, `aria-describedby` keeps the persistent association — but worth flagging because some teams prefer only one of the two | Informational | n/a |
+| 10 | Keyboard navigation works end-to-end (verified by `rhf-spike-keyboard.spec.ts`): Tab between fields, ArrowDown to change radio selection (and the browser auto-checks the focused radio), Space to toggle a checkbox, Enter on Submit | Pass | n/a |
+
+---
+
+## Open questions / non-goals reached
+
+- **Schema-resolver integration** (Zod / Yup / Valibot via `@hookform/resolvers`). Explicitly out of scope per the PRD ("the cost of the library itself is measured separately from the cost of a schema layer"). The most likely first follow-up.
+- **Async / server-side validation.** Out of scope. RHF supports it natively (async `validate`, `setError` from a server response), but the integration surface is the same as sync.
+- **Dynamic field arrays** (`useFieldArray`). Untested. The `FormField` render-prop API should compose with it but this is unverified.
+- **Multi-step forms.** Untested. RHF supports this via `FormProvider` + per-step components, which is the pattern the PoC already uses for a single step.
+- **`Switch`, `SliderInput`, `DatePicker`, `InputFileButton`.** None tested. Each will likely need a one-pass audit; `Switch` and `SliderInput` in particular wrap custom interaction models and are the most likely to have `Checkbox`-shaped surprises.
+- **Deprecating `*Callback` props.** Explicitly *not* recommended now. The spike's principle was "additive only, no breaking changes." A deprecation can happen later once `FormField` adoption is proven.
+- **A full a11y audit.** Out of scope per the PRD. The observations above are what the spike happened to surface, not what an audit would find.
+
+---
+
+## External references
+
+- React Hook Form docs — https://react-hook-form.com/
+- `Controller` API — https://react-hook-form.com/docs/usecontroller/controller
+- `useController` hook — https://react-hook-form.com/docs/usecontroller
+- `FormProvider` / `useFormContext` — https://react-hook-form.com/docs/formprovider
+- Validation modes — https://react-hook-form.com/docs/useform#mode
+- WAI-ARIA Authoring Practices, *Radio Group Pattern* — https://www.w3.org/WAI/ARIA/apg/patterns/radio/
+- WAI-ARIA Authoring Practices, *Checkbox Pattern* — https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
+- WAI-ARIA `aria-invalid` — https://www.w3.org/TR/wai-aria-1.2/#aria-invalid
+- WAI-ARIA `aria-describedby` — https://www.w3.org/TR/wai-aria-1.2/#aria-describedby
+- MDN, *`<fieldset>` and `<legend>`* — https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
+- WebAIM, *Creating Accessible Forms* — https://webaim.org/techniques/forms/
+
+---
+
+## Answers to the PRD's nine research questions
+
+### 1. Can React Hook Form work with UI Kit components without major rewrites?
+
+**Yes.** The PoC integrates RHF with five distinct input types after only additive changes — no public API was broken, no component was rewritten. The largest single change was adding a new molecule (`FormField`); per-atom changes were one to a dozen lines each.
+
+### 2. Which components need changes to support React Hook Form well?
+
+Made during the spike: `Input` (forwardRef), `SelectField` (forwardRef + native onChange forward), `RadioButton` (onBlur pass-through), `Checkbox` (id + `controlled` + focus-visible fix). Recommended but not made: `forwardRef` + native `onChange`/`onBlur` + `aria-invalid`/`aria-describedby` + an `invalid` prop on `RadioButton` and `Checkbox`; `TextField` molecule audit; theme token fixes; `required` on `<legend>`. See "Required UI Kit component changes."
+
+### 3. Are those changes small, moderate, or significant?
+
+**Moderate kit-wide.** Each individual change is small. The aggregate across the form-atom inventory plus documentation lands between small and significant. See "Effort estimate."
+
+### 4. Can simple inputs use React Hook Form's `register`, or do most UI Kit components require `Controller`?
+
+**Mixed.** `Input` could use `register` after the `forwardRef` change. `SelectField`, `RadioButton`, and `Checkbox` need `Controller` (or `useController`) today — `SelectField` because of the dual callback/event surface, `RadioButton`/`Checkbox` because their `onChangeCallback` shape is incompatible with RHF's native event flow. The PoC uses `useController` inside `FormField` for **all** fields uniformly so consumers don't have to think about which mode applies — this is itself a recommended pattern.
+
+### 5. Do components correctly expose or forward `name`, `value`, `checked`, `onChange`, `onBlur`, `ref`?
+
+| Component | name | value | checked | onChange | onBlur | ref |
+| --- | --- | --- | --- | --- | --- | --- |
+| `Input` | yes | yes | n/a | native | native | **yes (added)** |
+| `SelectField` | yes | yes | n/a | native (**now forwarded alongside** `changeCallback`) | native | **yes (added)** |
+| `RadioButton` | yes | yes | `currentChecked` (custom) | `onChangeCallback` only | **yes (added)** | no |
+| `Checkbox` | no | n/a | yes | `onChangeCallback(boolean)` only | no | no |
+
+### 6. How should React Hook Form validation state map to existing UI Kit component states?
+
+Map onto the existing `fieldState` enum: `error → invalid`, `isSubmitting → processing`, `disabled → disabled`, otherwise `default`. Keep `required` as a separate prop. Treat `touched` as an internal concern of `FormField` (it gates *when* `invalid` is exposed), not a visual state. See "Recommended component API patterns."
+
+### 7. How should error messages be surfaced when UI Kit does not currently have a complete error-message pattern?
+
+**In a wrapper, not per-input.** `FormField` owns the error text, the `role='alert'` live region, and the `aria-describedby` wiring. Consumers receive `errorId` and `aria-invalid` through render props and forward them to the input. This is the single biggest pattern recommendation from the spike.
+
+### 8. What accessibility gaps appear when wiring validation and errors into the existing components?
+
+Ten items captured in the Accessibility section. The headline is **the `Checkbox` `display: none` bug** the spike happened to fix — that's a pre-existing keyboard-accessibility regression in production. The rest are smaller (unconditional `aria-describedby`, missing per-component `aria-invalid` pass-through, missing labelling atoms for radio/checkbox options).
+
+### 9. Should React Hook Form be recommended for future projects using `scorer-ui-kit`, and under what conditions?
+
+**Yes, with conditions.** Recommend RHF as the standard form library. Conditions:
+1. Ship the recommended additive changes to `RadioButton` and `Checkbox` before promoting RHF to product teams.
+2. Establish `FormField` (or a thin per-product extension) as the canonical integration point so product code doesn't reimplement label / error / a11y wiring.
+3. Plan a follow-up spike for schema-resolver integration (Zod or Yup) since that is the most likely next ask once teams start adopting RHF in earnest.
+4. Audit `Switch`, `SliderInput`, `DatePicker`, and other untested form atoms for `Checkbox`-shaped a11y or callback-shape surprises before declaring kit-wide RHF support.
+
+---
+
+*End of report.*


### PR DESCRIPTION
## Description

This PR introduces a **proof of concept** for integrating [react-hook-form](https://react-hook-form.com/) (RHF) into `scorer-ui-kit`. It is the output of a timeboxed 2-day spike exploring whether RHF can adopt the kit's existing form atoms without breaking changes to their public APIs.

- **Scope:** Adds one new molecule (`FormField`), makes four atom updates that are strictly additive (no signatures removed or changed), wires a demo page into the example app, and lands a Playwright suite that exercises the integration end-to-end.
- **Documentation:** `rhf-spike-report.md` (committed in this branch) is the synthesized findings of the spike — adoption recommendation, evidence per component, gaps, and follow-up suggestions. It is the primary reading material for reviewers.
- **Background context:** The original PRD framed this as a "tracer-bullet" spike: one vertical slice through a representative form covering text, email, select, radio group, and checkbox group inputs, with `onTouched` validation and a keyboard-only happy path. The bulk of the work was produced by a Claude-based coding agent operating slice-by-slice; this PR is a single squashed commit of the net code change. Process artifacts (slice commits, PR/issue references, harness scaffolding, the pre-flight strip of CI/CD that was done in the private harness repo) have been intentionally stripped — only the code lands here.

### What's included

| Area | Change |
|---|---|
| `ui-lib/src/Form/molecules/FormField.tsx` | **New** render-prop adapter that wires kit atoms to RHF via `useController`. Owns label, error message, `htmlFor`/`aria-describedby`/`aria-invalid` wiring, and vertical rhythm. |
| `ui-lib/src/Form/atoms/Input.tsx` | Wrapped in `React.forwardRef<HTMLInputElement, InputProps>` to support RHF's `register` and `setFocus`. |
| `ui-lib/src/Form/atoms/SelectField.tsx` | `forwardRef<HTMLSelectElement, ISelect>` + native `onChange(event)` forwarded alongside the existing `changeCallback(value)`. |
| `ui-lib/src/Form/atoms/Checkbox.tsx` | New optional `id` prop, new `controlled` boolean prop to bypass internal state for RHF, and an a11y fix: the hidden input changed from `display:none` to absolute-positioned `opacity:0` so it remains keyboard-focusable. |
| `ui-lib/src/Form/atoms/RadioButton.tsx` | `onBlur` prop pass-through for RHF `onTouched` mode. |
| `ui-lib/src/Form/index.ts`, `ui-lib/src/index.tsx` | Re-export `FormField` and its types. |
| `ui-lib/vite.config.ts` | `react-hook-form` added to externals to prevent the bundled-duplicate-instance crash. |
| `ui-lib/package.json` | `react-hook-form` added to `peerDependencies` and dev deps. |
| `example/src/pages/RHFSpikePage.tsx` | **New** demo page at `/rhf-spike` showing a 5-field form (text, email, select, radio group, checkbox group). |
| `example/src/App.tsx`, `example/src/pages/Index.tsx` | Route + landing-page link to the demo. |
| `example/playwright.config.ts`, `example/tests/rhf-spike.spec.ts`, `example/tests/rhf-spike-keyboard.spec.ts` | **New** Playwright config + 14 specs covering required-field errors, format validation, group errors, happy-path submit, `onTouched` blur behavior, and a keyboard-only flow. |
| `example/package.json` | `react-hook-form`, `@playwright/test`, `test:e2e` script. |
| `package-lock.json` | Lockfile updates from the new deps. |
| `rhf-spike-report.md` | Spike report. |

## Considerations on Implementation

A few areas reviewers should focus on:

1. **`react-hook-form` as a peer dependency.** It is added to `peerDependencies` of `ui-lib` *and* externalized in `vite.config.ts`. This is intentional — bundling RHF caused a duplicate-React-context crash in early slices when consumers also installed it. Reviewers should confirm this is the convention they want, vs. making it a hard dependency.
2. **All atom changes are additive — no breaking changes.** No existing prop was renamed, removed, or had its type narrowed. The new props (`controlled`, `id` on `Checkbox`; `onBlur` on `RadioButton`) are optional. `forwardRef` additions are transparent to existing consumers.
3. **Checkbox a11y fix is a behavior change.** Pre-existing code used `display:none` on the hidden input, which removed it from the tab order. The spike replaced this with `opacity:0` + absolute positioning so the input is keyboard-focusable. This is a fix, but it's a behavior delta that consumers relying on the old (broken) focus behavior could notice. Worth a deliberate ack from a reviewer.
4. **Scope of validation is the spike PoC only.** Only `Input`, `SelectField`, `Checkbox`, and `RadioButton` were exercised. `TextField`, `Switch`, `SliderInput`, `DatePicker`, `InputFileButton` etc. are **untested** — see the "Gaps" section of `rhf-spike-report.md`. This PR should not be read as "the kit supports RHF" — it's "the kit *can* support RHF, here is one validated path."
5. **`rhf-spike-report.md` lives at the repo root.** If the team prefers it under `docs/` or out of the tracked tree entirely, easy to relocate / drop in a follow-up.
6. **Single squashed commit.** The original spike was 22 commits across 9 PRs in a private harness fork. This PR is one clean commit; if you want per-slice review, the harness repo can provide the original commit chain.

## Reviewing/Testing steps

### Pre-merge verification

All checks below were re-run on the latest tip of the branch (`feature/react-form-hooks-poc` at `01eb1299`, which is `eb051e23` + the accessibility fix commit `01eb1299` "Fixes of accessibility Radio and Select"). Environment: macOS Darwin 24.6.0, Node 24.14.0, npm 11.9.0.

| Check                                                                | Result |
|----------------------------------------------------------------------|:------:|
| `npm run lint` (biome at root, 326 files)                            | ✅ PASS — no fixes applied, 76ms |
| `npm --workspace=packages/ui-lib run build`                          | ✅ PASS — 183 modules transformed, built in 9.45s. Only warning is a generic `vite:dts` plugin-timing notice (not code-related). |
| `npm --workspace=packages/example run build`                         | ✅ PASS — 950 modules transformed, built in 752ms. Chunk-size warning on `index-*.js` is pre-existing baseline (unrelated to this PR). |
| `npm --workspace=packages/example run test:e2e` (Playwright, 14 specs) | ✅ PASS — **14 / 14 passing in 4.9s** |
| Keyboard-only spec (`rhf-spike-keyboard.spec.ts`)                    | ✅ PASS — included in the 14/14 count |
| Manual smoke of `/rhf-spike` (Chrome DevTools MCP — empty submit, then full happy-path) | ✅ PASS — empty submit surfaced all 4 required-field errors with proper `aria-live` alerts; valid submit (`Isabel`, `green`, `isabel@example.com`, `mountain`, `chocolate`) rendered the expected JSON payload on the page |
| Browser console clean of new warnings/errors                         | ✅ PASS — see breakdown below |
| Unit tests                                                           | ⏭️ N/A — none added, only Playwright e2e |
| Docker / deploy artifact builds                                      | ⏭️ N/A — no infra change                  |


### Detailed steps to reproduce

**Setup**

```sh
git checkout feature/react-form-hooks-poc
npm install
# Playwright browsers (one-time, if not already installed)
npx playwright install --with-deps chromium
```

**Reproduction**

```sh
# Lint
npm run lint

# Build the kit, then the example app
npm --workspace=packages/ui-lib run build
npm --workspace=packages/example run build

# Run the dev server for manual smoke
npm --workspace=packages/example start
# → open http://localhost:3000/scorer-ui-kit/rhf-spike

# End-to-end (Playwright spins up its own dev server)
npm --workspace=packages/example run test:e2e
```

## Screenshots


### Error when touching a input but not filling
<img width="424" height="609" alt="Screenshot 2026-05-22 at 15 20 29" src="https://github.com/user-attachments/assets/b5a5d383-43a5-45e6-8c9e-01feaf27c3ca" />

### Error on submit
<img width="448" height="581" alt="Screenshot 2026-05-22 at 15 20 54" src="https://github.com/user-attachments/assets/80cb9d05-fdd2-4cb7-a43a-66c2a0765ef7" />


### Successful submit

<img width="430" height="691" alt="Screenshot 2026-05-22 at 15 21 05" src="https://github.com/user-attachments/assets/acfcb030-cc90-465e-acfa-2cabf1e39706" />