### PR TITLE
feat: RHF PoC round 2 — native Input/SelectField, drop forwardRef

### DIFF
--- a/findings-native-atoms.md
+++ b/findings-native-atoms.md
@@ -1,0 +1,191 @@
+# Native RHF Atoms — Findings (PoC Round 2)
+
+## Goal
+
+Round 1 (`feature/react-form-hooks-poc`) integrated `react-hook-form` (RHF) into `scorer-ui-kit` v3 via a `FormField` molecule wrapper. The team asked: **looking ahead to the AI-Native UI Kit, can the existing components themselves handle label/error/hint natively, without a wrapper?**
+
+This round (`feature/react-form-hooks-poc-2`) refactors **Input** and **SelectField** to support a native (no-wrapper) mode while staying backward-compatible with `FormField`. Checkbox and RadioButton were deferred as they involve group-level concerns.
+
+A second goal: remove `React.forwardRef`, which is deprecated in React 19. Both `packages/ui-lib` and `packages/example` are on React `^19.x`.
+
+## What changed per component
+
+### `Input` (`packages/ui-lib/src/Form/atoms/Input.tsx`)
+
+| Change | Reason |
+|---|---|
+| Added `label?: string` prop | When present, switches Input into native rendering mode (wraps in `<Label>` + error/hint shell). When absent, behavior is unchanged. |
+| Added `error?: string` prop | When truthy, forces `fieldState='invalid'`, renders `<ErrorMessage role='alert'>`, sets `aria-invalid={true}`. |
+| Added `hint?: string` prop | Renders `<HintMessage>` below the input; hidden when an error is present (one or the other, never both). |
+| Added `required?: boolean` prop | Pass-through to the underlying `<Label>` atom's required-dot indicator. |
+| Removed `React.forwardRef` | React 19 deprecated `forwardRef`. `ref` is now declared on the props type and destructured in the function signature. |
+| Removed `Input.displayName` | Unnecessary once forwardRef is gone — the function name is the display name. |
+| Auto-derived `id` from `name` | When in native mode, if the consumer doesn't pass `id`, Input uses `name` so `<Label htmlFor>` and `aria-describedby` can wire correctly. |
+| Auto-wired `aria-invalid` + `aria-describedby` | In native mode only. In wrapper mode the consumer (FormField) still passes these explicitly, and Input does not override. |
+
+**Native mode is opt-in by passing `label`.** Existing FormField-wrapped usage passes `aria-invalid`/`aria-describedby` directly and does *not* pass `label`, so it stays on the legacy path with no behavior change.
+
+### `SelectField` (`packages/ui-lib/src/Form/atoms/SelectField.tsx`)
+
+| Change | Reason |
+|---|---|
+| Extended `ILabel` with `required?: boolean` | The underlying `Label` atom already supports a required dot, but `ILabel` didn't expose it. SelectField now passes `label.required` through. |
+| Added top-level `error?: string` prop | When truthy, forces `fieldState='invalid'`, renders `<ErrorMessage role='alert'>`. |
+| Added top-level `hint?: string` prop | Renders `<HintMessage>` below the select; hidden when an error is present. |
+| Removed `React.forwardRef` | Same as Input — React 19 ref-as-prop pattern. |
+| Removed `SelectField.displayName` | Same as Input. |
+| Auto-wired `aria-invalid` + `aria-describedby` | When `error` or `hint` is set, SelectField sets these on the underlying `<select>` itself. |
+
+**No new `labelText` prop was added.** The existing `label?: ILabel = { htmlFor, text, direction?, required? }` shape already carries the label text. The "object vs flat string" awkwardness is a forward-looking AI-Native concern, not a v3 fix (see Recommendations).
+
+### `FormField` (`packages/ui-lib/src/Form/molecules/FormField.tsx`)
+
+Pure refactor: the styled components (`FieldWrapper`, `ErrorMessage`, `HintMessage`) that used to live inline are now imported from the new shared module. No behavior change, no contract change.
+
+### New: `fieldStyles.ts` (`packages/ui-lib/src/Form/atoms/fieldStyles.ts`)
+
+A small module that exports three styled-components (`FieldWrapper`, `ErrorMessage`, `HintMessage`). Not a React component — just shared CSS-in-JS definitions imported by both `FormField` and the refactored atoms. Single source of truth for error/hint styling.
+
+## What the atoms now do natively vs delegate
+
+| Concern | Atom (native mode) | RHF | FormField wrapper |
+|---|---|---|---|
+| Label rendering | Atom | — | Wrapper |
+| Error message rendering | Atom (when `error` set) | — | Wrapper |
+| Hint message rendering | Atom (when `hint` set) | — | Wrapper |
+| `aria-invalid` wiring | Atom | — | Wrapper |
+| `aria-describedby` wiring | Atom | — | Wrapper |
+| Form state / value subscription | — | RHF (`useController`) | RHF via wrapper |
+| Validation rule definition | — | RHF (`rules: {...}`) | RHF via wrapper |
+| Error message *text* | — | RHF (consumer writes `rules: { required: 'Name is required' }`) | RHF via wrapper |
+
+The atom owns the **presentation** of label/error/hint, but RHF still owns **when** an error exists and **what** it says. Atoms never decide validation — they just render what the consumer (via RHF) tells them.
+
+## What was awkward
+
+1. **SelectField's `label: ILabel` shape is verbose.** Compare:
+    - Input native: `<Input label='Name' required ... />`
+    - SelectField native: `<SelectField label={{ htmlFor: 'colour', text: 'Favourite colour', required: true }} ... />`
+
+    The `htmlFor` is redundant when the consumer has already spread `{...field}` (which contains `name`). This is preserved for backward compatibility; the AI-Native UI Kit should accept flat strings like Input does.
+
+2. **Auto-id derivation from `name`.** Native mode needs an `id` so `<label htmlFor>` and `aria-describedby` can wire to the input. If the consumer doesn't pass `id`, we fall back to `name`. This works because RHF's `field.name` is unique within a form, but it would collide if two forms were rendered with the same field name on the same page. Acceptable for now; the AI-Native version could use `useId()` to guarantee uniqueness.
+
+3. **Two error-rendering paths now exist** (FormField and the atom). They must produce equivalent DOM (same `role='alert'`, same `aria-invalid`/`aria-describedby` contract). Extracting `fieldStyles.ts` keeps the visual layer in sync, but the *structural* equivalence relies on careful copy-paste of the same JSX shape. This is fragile. The AI-Native version should consolidate to one path.
+
+4. **The `fieldState` prop's meaning shifts in native mode.** Today consumers can pass `fieldState='valid'` to opt into the green-border look. In native mode, an `error` prop forces `fieldState='invalid'`, overriding any explicit value. This is the right behavior (error wins) but the precedence is implicit; documenting it matters.
+
+5. **`useController` boilerplate per field.** Going wrapper-free means each field needs its own `useController` call. The `NativeRHFSpikePage` factored each field into a small component (`NameField`, `ColourField`, `EmailField`) to keep the JSX tidy — without that, the page would be a wall of hook calls. This is RHF-imposed, not UI-Kit-imposed, but it surfaces the design choice: native atoms make a "1 hook per field" pattern more visible than the wrapper did.
+
+## A11y considerations
+
+Both paths now produce equivalent ARIA structure on the rendered input/select:
+
+| Attribute | Wrapper (`FormField`) | Native (atom alone) |
+|---|---|---|
+| `<label for>` linkage | `<Label htmlFor>` in molecule | `<Label htmlFor>` in atom |
+| Error `role='alert'` | Yes (`ErrorMessage`) | Yes (`ErrorMessage`) |
+| Error `id` | `${name}-error` | `${id ?? name}-error` |
+| `aria-invalid` on field | Yes (via render-prop) | Yes (set by atom) |
+| `aria-describedby` on field | → error id when invalid | → error id when invalid; → hint id when valid+hint |
+| Required visual indicator | `<Label required>` dot | `<Label required>` dot |
+
+**One small improvement in native mode**: when only a `hint` is present (no error), the atom wires `aria-describedby` to the hint id. The wrapper path doesn't do this today; it's worth porting back to `FormField`. Added to the recommendation list below.
+
+## React 19 ref migration notes
+
+The old pattern:
+```tsx
+const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  return <input ref={ref} {...props} />;
+});
+Input.displayName = 'Input';
+```
+
+The new pattern:
+```tsx
+interface InputProps {
+  // ...
+  ref?: Ref<HTMLInputElement>;
+}
+
+function Input({ ref, ...props }: InputProps) {
+  return <input ref={ref} {...props} />;
+}
+```
+
+**What surprised:** absolutely nothing — `@types/react@19` cleanly types `ref` as a regular prop on function components. Spreading RHF's `field` object (which contains `ref`, `value`, `onChange`, `onBlur`, `name`) Just Worked. No consumer change required at all.
+
+**Test impact:** zero. The existing Playwright tests on `/rhf-spike` (which exercise the wrapped form built on these now-non-forwardRef atoms) continue to pass without modification.
+
+## Sanity-check sweep
+
+Searched `packages/ui-lib/src` and `packages/example/src` for deprecated React patterns after the refactor:
+
+| Pattern | Hits | Notes |
+|---|---|---|
+| `React.forwardRef` / `forwardRef` | **0** | The only two usages (Input, SelectField) were removed in this round. |
+| `defaultProps` on function components | 0 | — |
+| `propTypes` / `prop-types` imports | 0 | — |
+| `componentWillMount`/`Receive`/`Update` | 0 | — |
+| `UNSAFE_*` lifecycle methods | 0 | — |
+| `ReactDOM.render` / `findDOMNode` | 0 | — |
+| `react-dom/test-utils` (`act`) imports | 0 | — |
+| Legacy context (`childContextTypes`, `getChildContext`) | 0 | — |
+| String refs (`ref="foo"`) | 0 | — |
+| Class components (`class … extends Component`) | 0 | Already fully function-component. |
+| `React.createRef` | 1 (informational) | `StatusComponent.tsx` — not deprecated, just notable. |
+| `React.FC<...>` | 145 (informational) | Not deprecated in React 19 but mildly discouraged style (implicit `children`, no generics support). Out of scope for this round. |
+
+The codebase is in good shape with respect to React 19 deprecations. After this PoC there are no `forwardRef` usages anywhere.
+
+## Recommendations for the AI-Native UI Kit
+
+Based on what this refactor exposed:
+
+1. **Flat string contracts for label-related props.** Components should accept `label`, `htmlFor` (or auto-id), `required`, `direction` as top-level props — not a nested `ILabel` object. Input's API is the model; SelectField's `ILabel` is the legacy.
+
+2. **One error-rendering path, not two.** Having both `FormField` and the atom render `<ErrorMessage>` works but doubles the surface area. The AI-Native version should either:
+   - Make label/error/hint a required first-class concern of every field component (no wrapper exists), or
+   - Have a single `<FieldShell>` primitive that field components always compose internally, with no inline `<ErrorMessage>` duplication.
+
+3. **`fieldStyles` primitives should formalize into a "FieldShell" primitive set** (FieldWrapper, ErrorMessage, HintMessage, Label) that every native field component composes. Today they're just styled-components; in the AI-Native version they should be the *only* path for rendering field chrome.
+
+4. **Bring `aria-describedby` → hint-id behavior back to `FormField`.** The wrapper currently doesn't wire `aria-describedby` to the hint id when no error is present. The native path does. Easy port.
+
+5. **Drop `forwardRef` everywhere going forward.** It's deprecated in React 19. The sanity sweep confirms this codebase is now fully forwardRef-free; treat this as the new floor.
+
+6. **Use `useId()` for auto-id generation.** This round derives ids from `name`, which works but isn't collision-safe across multiple forms. The AI-Native version should `useId()` instead.
+
+7. **Group-level controls (Checkbox, RadioButton) need a separate design pass.** They're inherently group-shaped — error belongs on the `<fieldset>`, not the individual control. The native-mode contract for them will be different from Input/Select (probably a `<CheckboxGroup>` / `<RadioGroup>` composite component owning label/error/hint). Defer to a future round.
+
+8. **`React.FC<...>` is fine to leave alone for now**, but if a wholesale modernization is on the table, switching to plain function signatures (`function Foo(props: FooProps)`) unlocks generics and removes the implicit `children` confusion. Not urgent.
+
+## Files touched in this round
+
+```
+packages/ui-lib/src/Form/atoms/fieldStyles.ts        (new)
+packages/ui-lib/src/Form/atoms/Input.tsx             (native props + forwardRef removed)
+packages/ui-lib/src/Form/atoms/SelectField.tsx       (native props + ILabel.required + forwardRef removed)
+packages/ui-lib/src/Form/molecules/FormField.tsx     (import from fieldStyles)
+packages/example/src/pages/NativeRHFSpikePage.tsx    (new)
+packages/example/src/pages/Index.tsx                 (catalog entry)
+packages/example/src/App.tsx                         (route)
+packages/example/tests/rhf-spike-native.spec.ts      (new — 8 Playwright tests)
+findings-native-atoms.md                             (this file)
+```
+
+## How to run
+
+```bash
+# Type check + lint
+npm run check
+
+# Run the example app
+npm run start:example
+# → http://localhost:3000/#/rhf-spike         (wrapped — original)
+# → http://localhost:3000/#/rhf-spike-native  (native — this round)
+
+# Playwright (from packages/example)
+cd packages/example && npm run test:e2e
+```

--- a/packages/example/playwright.config.ts
+++ b/packages/example/playwright.config.ts
@@ -1,15 +1,19 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Uses a non-default port so it never reuses an unrelated dev server that happens to be on :3000.
+const TEST_PORT = 3101;
+
 export default defineConfig({
   testDir: './tests',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${TEST_PORT}`,
   },
   webServer: {
-    command: 'npm start',
-    url: 'http://localhost:3000',
+    command: `npm start -- --port ${TEST_PORT}`,
+    url: `http://localhost:${TEST_PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    env: { VITE_BASE_PATH: '/' },
   },
   projects: [
     {

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -13,6 +13,7 @@ import LinePage from './pages/LinePage';
 import LineRTCPage from './pages/LineRTCPage';
 import LineVideoPage from './pages/LineVideoPage';
 import LoginPage from './pages/Login';
+import NativeRHFSpikePage from './pages/NativeRHFSpikePage';
 import RHFSpikePage from './pages/RHFSpikePage';
 import SplitLayouts from './pages/SplitLayout';
 import SwitchWithAPI from './pages/SwitchTest';
@@ -43,6 +44,7 @@ const App: React.FC = () => {
         <Route path='/usepoll-test' element={<UsePollTestPage />} />
         <Route path='/webrtc-strictmode-test' element={<WebRTCStrictModeTestPage />} />
         <Route path='/rhf-spike' element={<RHFSpikePage />} />
+        <Route path='/rhf-spike-native' element={<NativeRHFSpikePage />} />
       </Routes>
     </Router>
   );

--- a/packages/example/src/pages/Index.tsx
+++ b/packages/example/src/pages/Index.tsx
@@ -199,6 +199,16 @@ const LinksPage: React.FC = () => {
             </Link>
           </Item>
           <Item>
+            <Link to={`/rhf-spike-native`}>
+              <Title>React Hook Form (Native)</Title>
+              <Description>
+                React Hook Form wired to UI Kit components supported natively (no FormField
+                wrapper). Spike PoC covering Input and SelectField with built-in label/error/hint.
+              </Description>
+              <FilenameTag>NativeRHFSpikePage.tsx</FilenameTag>
+            </Link>
+          </Item>
+          <Item>
             <Link to={`/login`}>
               <Title>Login</Title>
               <Description>A code sample of our commonly used login view.</Description>

--- a/packages/example/src/pages/NativeRHFSpikePage.tsx
+++ b/packages/example/src/pages/NativeRHFSpikePage.tsx
@@ -1,0 +1,98 @@
+import type React from 'react';
+import { useState } from 'react';
+import { FormProvider, useController, useForm } from 'react-hook-form';
+import { Button, Input, SelectField } from 'scorer-ui-kit';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type FormValues = {
+  name: string;
+  colour: string;
+  email: string;
+};
+
+const NameField: React.FC = () => {
+  const { field, fieldState } = useController<FormValues, 'name'>({
+    name: 'name',
+    rules: { required: 'Name is required' },
+  });
+  return <Input {...field} label='Name' required error={fieldState.error?.message} />;
+};
+
+const ColourField: React.FC = () => {
+  const { field, fieldState } = useController<FormValues, 'colour'>({
+    name: 'colour',
+    rules: { required: 'Favourite colour is required' },
+  });
+  return (
+    <SelectField
+      {...field}
+      label={{ htmlFor: 'colour', text: 'Favourite colour', required: true }}
+      error={fieldState.error?.message}
+      placeholder='Select a colour'
+    >
+      <option value='red'>Red</option>
+      <option value='green'>Green</option>
+      <option value='blue'>Blue</option>
+    </SelectField>
+  );
+};
+
+const EmailField: React.FC = () => {
+  const { field, fieldState } = useController<FormValues, 'email'>({
+    name: 'email',
+    rules: {
+      required: 'Email is required',
+      pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
+    },
+  });
+  return (
+    <Input
+      {...field}
+      type='email'
+      label='Email'
+      required
+      hint='We never share your email.'
+      error={fieldState.error?.message}
+    />
+  );
+};
+
+const NativeRHFSpikePage: React.FC = () => {
+  const [submittedData, setSubmittedData] = useState<FormValues | null>(null);
+  const methods = useForm<FormValues>({
+    mode: 'onTouched',
+    defaultValues: { name: '', colour: '', email: '' },
+  });
+  const { handleSubmit } = methods;
+
+  const onSubmit = (data: FormValues) => {
+    setSubmittedData(data);
+  };
+
+  return (
+    <div style={{ padding: '32px', maxWidth: '400px' }}>
+      <h1>React Hook Form (Native)</h1>
+      <p style={{ color: 'var(--grey-11)', fontSize: '14px' }}>
+        Input and SelectField rendering their own label/error/hint — no FormField wrapper.
+      </p>
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)} noValidate>
+          <NameField />
+          <ColourField />
+          <EmailField />
+          <div style={{ marginTop: '24px' }}>
+            <Button type='submit'>Submit</Button>
+          </div>
+        </form>
+      </FormProvider>
+      {submittedData !== null && (
+        <pre data-testid='submitted' style={{ marginTop: '16px', whiteSpace: 'pre-wrap' }}>
+          {JSON.stringify(submittedData, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default NativeRHFSpikePage;

--- a/packages/example/tests/rhf-spike-native.spec.ts
+++ b/packages/example/tests/rhf-spike-native.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+
+test('submitting empty native form shows required errors', async ({ page }) => {
+  await page.goto('/#/rhf-spike-native');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Name is required' })).toBeVisible();
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })
+  ).toBeVisible();
+  await expect(page.getByRole('alert').filter({ hasText: 'Email is required' })).toBeVisible();
+});
+
+test('native name field aria wiring is correct when invalid', async ({ page }) => {
+  await page.goto('/#/rhf-spike-native');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const nameError = page.getByRole('alert').filter({ hasText: 'Name is required' });
+  await expect(nameError).toBeVisible();
+
+  const nameInput = page.getByRole('textbox', { name: 'Name' });
+  const errorId = await nameError.getAttribute('id');
+  const describedBy = await nameInput.getAttribute('aria-describedby');
+  expect(describedBy).toBe(errorId);
+  await expect(nameInput).toHaveAttribute('aria-invalid', 'true');
+});
+
+test('native select field aria wiring is correct when invalid', async ({ page }) => {
+  await page.goto('/#/rhf-spike-native');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const colourError = page.getByRole('alert').filter({ hasText: 'Favourite colour is required' });
+  await expect(colourError).toBeVisible();
+
+  const select = page.getByRole('combobox');
+  const errorId = await colourError.getAttribute('id');
+  const describedBy = await select.getAttribute('aria-describedby');
+  expect(describedBy).toBe(errorId);
+  await expect(select).toHaveAttribute('aria-invalid', 'true');
+});
+
+test('native email field shows hint until an error replaces it', async ({ page }) => {
+  await page.goto('/#/rhf-spike-native');
+
+  await expect(page.getByText('We never share your email.')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByText('We never share your email.')).not.toBeVisible();
+  await expect(page.getByRole('alert').filter({ hasText: 'Email is required' })).toBeVisible();
+});
+
+test('native email field validates pattern', async ({ page }) => {
+  await page.goto('/#/rhf-spike-native');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('textbox', { name: 'Email' }).fill('not-an-email');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Enter a valid email address' })
+  ).toBeVisible();
+});
+
+test('native happy-path submit records correct payload', async ({ page }) => {
+  await page.goto('/#/rhf-spike-native');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('combobox').selectOption('green');
+  await page.getByRole('textbox', { name: 'Email' }).fill('alice@example.com');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const submitted = page.getByTestId('submitted');
+  await expect(submitted).toBeVisible();
+  const text = await submitted.textContent();
+  const payload = JSON.parse(text ?? '{}');
+  expect(payload.name).toBe('Alice');
+  expect(payload.colour).toBe('green');
+  expect(payload.email).toBe('alice@example.com');
+});
+
+test('native name field shows error on blur after touch without submit', async ({ page }) => {
+  await page.goto('/#/rhf-spike-native');
+
+  await page.getByRole('textbox', { name: 'Name' }).focus();
+  await page.getByRole('textbox', { name: 'Name' }).blur();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Name is required' })).toBeVisible();
+});
+
+test('native catalog entry links to the page', async ({ page }) => {
+  await page.goto('/#/');
+
+  const link = page.getByRole('link', { name: /React Hook Form \(Native\)/ });
+  await expect(link).toBeVisible();
+  await link.click();
+
+  await expect(page.getByRole('heading', { name: 'React Hook Form (Native)' })).toBeVisible();
+});

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -1,10 +1,11 @@
-import type { InputHTMLAttributes } from 'react';
-import React from 'react';
+import type { InputHTMLAttributes, Ref } from 'react';
 import styled, { css } from 'styled-components';
 import { removeAutoFillStyle } from '../../common';
 import Icon, { IconWrapper } from '../../Icons/Icon';
 import Spinner from '../../Indicators/Spinner';
 import type { TypeFieldState } from '..';
+import { ErrorMessage, FieldWrapper, HintMessage } from './fieldStyles';
+import Label from './Label';
 
 const ActionContainer = styled.div`
   position: absolute;
@@ -165,79 +166,118 @@ interface OwnProps {
   actionCallback?: () => void;
   actionIcon?: string;
   postfix?: string;
+  // Native mode props — when `label` is set, Input renders its own label/error/hint shell.
+  label?: string;
+  error?: string;
+  hint?: string;
+  required?: boolean;
+  ref?: Ref<HTMLInputElement>;
 }
 
 export type InputProps = OwnProps & InputHTMLAttributes<HTMLInputElement>;
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  (
-    {
-      type = 'text',
-      placeholder = '',
-      defaultValue,
-      fieldState = 'default',
-      showFeedback = false,
-      feedbackMessage,
-      actionCallback,
-      actionIcon,
-      postfix,
-      children,
-      formAction,
-      ...props
-    },
-    ref
-  ) => {
-    const isActionButton = actionCallback !== undefined;
-
-    const feedbackIcon = (fieldState: TypeFieldState) => {
-      switch (fieldState) {
-        case 'default':
-          break;
-        case 'disabled':
-          break;
-        case 'required':
-          return <Icon icon='Required' size={16} />;
-        case 'valid':
-          return <Icon icon='Success' size={16} />;
-        case 'invalid':
-          return <Icon icon='Invalid' size={16} />;
-        case 'processing':
-          return <Spinner size='medium' styling='primary' />;
-      }
-    };
-
-    return (
-      <Container $fieldState={fieldState || 'default'} $showFeedback={showFeedback}>
-        <InputContainer $hasAction={isActionButton}>
-          <StyledInput
-            ref={ref}
-            $fieldState={fieldState || 'default'}
-            disabled={fieldState === 'disabled' || fieldState === 'processing'}
-            type={type}
-            placeholder={placeholder}
-            defaultValue={defaultValue}
-            {...props}
-          />
-          {isActionButton ? (
-            <ActionContainer>
-              <InputActionButton onClick={actionCallback}>
-                <Icon icon={actionIcon || 'NoIcon'} color='primary' />
-              </InputActionButton>
-            </ActionContainer>
-          ) : null}
-        </InputContainer>
-
-        {fieldState && showFeedback ? (
-          <FeedbackContainer>
-            <FeedbackIcon>{feedbackIcon(fieldState)}</FeedbackIcon>
-            {feedbackMessage ? <FeedbackMessage>{feedbackMessage}</FeedbackMessage> : null}
-          </FeedbackContainer>
-        ) : null}
-      </Container>
-    );
+const feedbackIcon = (fieldState: TypeFieldState) => {
+  switch (fieldState) {
+    case 'default':
+      break;
+    case 'disabled':
+      break;
+    case 'required':
+      return <Icon icon='Required' size={16} />;
+    case 'valid':
+      return <Icon icon='Success' size={16} />;
+    case 'invalid':
+      return <Icon icon='Invalid' size={16} />;
+    case 'processing':
+      return <Spinner size='medium' styling='primary' />;
   }
-);
+};
 
-Input.displayName = 'Input';
+function Input({
+  type = 'text',
+  placeholder = '',
+  defaultValue,
+  fieldState = 'default',
+  showFeedback = false,
+  feedbackMessage,
+  actionCallback,
+  actionIcon,
+  postfix,
+  children,
+  formAction,
+  label,
+  error,
+  hint,
+  required,
+  ref,
+  ...props
+}: InputProps) {
+  const isActionButton = actionCallback !== undefined;
+  const isNative = label !== undefined;
+  const hasError = Boolean(error);
+  const effectiveFieldState: TypeFieldState = isNative && hasError ? 'invalid' : fieldState;
+
+  const derivedId = props.id ?? props.name;
+  const errorId = derivedId ? `${derivedId}-error` : undefined;
+  const hintId = derivedId && hint ? `${derivedId}-hint` : undefined;
+  const describedBy = hasError ? errorId : hintId;
+
+  const nativeAriaProps = isNative
+    ? {
+        id: derivedId,
+        'aria-invalid': hasError,
+        'aria-describedby': describedBy,
+      }
+    : {};
+
+  const inputElement = (
+    <Container $fieldState={effectiveFieldState} $showFeedback={showFeedback}>
+      <InputContainer $hasAction={isActionButton}>
+        <StyledInput
+          ref={ref}
+          $fieldState={effectiveFieldState}
+          disabled={fieldState === 'disabled' || fieldState === 'processing'}
+          type={type}
+          placeholder={placeholder}
+          defaultValue={defaultValue}
+          {...props}
+          {...nativeAriaProps}
+        />
+        {isActionButton ? (
+          <ActionContainer>
+            <InputActionButton onClick={actionCallback}>
+              <Icon icon={actionIcon || 'NoIcon'} color='primary' />
+            </InputActionButton>
+          </ActionContainer>
+        ) : null}
+      </InputContainer>
+
+      {fieldState && showFeedback ? (
+        <FeedbackContainer>
+          <FeedbackIcon>{feedbackIcon(effectiveFieldState)}</FeedbackIcon>
+          {feedbackMessage ? <FeedbackMessage>{feedbackMessage}</FeedbackMessage> : null}
+        </FeedbackContainer>
+      ) : null}
+    </Container>
+  );
+
+  if (!isNative) {
+    return inputElement;
+  }
+
+  return (
+    <FieldWrapper>
+      <Label htmlFor={derivedId ?? ''} labelText={label} required={required}>
+        {inputElement}
+      </Label>
+      {hint && !hasError ? <HintMessage id={hintId}>{hint}</HintMessage> : null}
+      {hasError ? (
+        <ErrorMessage id={errorId} role='alert'>
+          {error}
+        </ErrorMessage>
+      ) : null}
+    </FieldWrapper>
+  );
+}
 
 export default Input;

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -1,8 +1,9 @@
 import type React from 'react';
-import { forwardRef, type SelectHTMLAttributes, useCallback, useState } from 'react';
+import { type Ref, type SelectHTMLAttributes, useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';
 import Icon from '../../Icons/Icon';
 import type { TypeFieldState, TypeLabelDirection } from '..';
+import { ErrorMessage, FieldWrapper, HintMessage } from './fieldStyles';
 import Label from './Label';
 
 export const SelectWrapper = styled.div`
@@ -111,6 +112,7 @@ interface ILabel {
   text: string;
   isSameRow?: boolean;
   direction?: TypeLabelDirection;
+  required?: boolean;
 }
 
 interface OwnProps {
@@ -120,148 +122,163 @@ interface OwnProps {
   placeholder?: string;
   icon?: string;
   changeCallback?: (value: string) => void;
+  // Native mode props — when `error` or `hint` is set, SelectField renders its own error/hint shell.
+  error?: string;
+  hint?: string;
+  ref?: Ref<HTMLSelectElement>;
 }
 
 type ISelect = OwnProps & SelectHTMLAttributes<HTMLSelectElement>;
 
-const SelectField = forwardRef<HTMLSelectElement, ISelect>(
-  (
-    {
-      fieldState = 'default',
-      placeholder,
-      label,
-      icon,
-      isCompact,
-      defaultValue,
-      changeCallback = () => {},
-      onChange,
-      onKeyDown,
-      children,
-      ...props
-    },
-    ref
-  ) => {
-    if (label?.isSameRow) {
-      console.warn(
-        'Deprecation warning: `SelectField` is deprecating `label.isSameRow`, please update this to use `label.direction` set to `row`.'
-      );
-    }
-
-    const [activePlaceholder, setPlaceholderStatus] = useState<boolean>(!defaultValue);
-
-    const handleOnChange = useCallback(
-      (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const { value } = e.target;
-
-        setPlaceholderStatus((prev) => {
-          if (prev) {
-            return false;
-          }
-          return prev;
-        });
-        changeCallback(value);
-        onChange?.(e);
-      },
-      [changeCallback, onChange]
-    );
-
-    const handleOnKeyDown = useCallback(
-      (e: React.KeyboardEvent<HTMLSelectElement>) => {
-        onKeyDown?.(e);
-
-        if (e.defaultPrevented || e.key !== 'ArrowDown' || e.currentTarget.value !== '') {
-          return;
-        }
-
-        // In placeholder mode the empty option is reserved for the placeholder.
-        const nextOption = Array.from(e.currentTarget.options).find(
-          (option) => !option.disabled && !option.hidden && option.value !== ''
-        );
-
-        if (!nextOption) {
-          return;
-        }
-
-        e.preventDefault();
-        e.currentTarget.value = nextOption.value;
-        e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
-      },
-      [onKeyDown]
-    );
-
-    const iconColor = useCallback(() => {
-      if (props.disabled || fieldState === 'disabled') {
-        return 'input-disabled-lead-icon';
-      } else {
-        return 'input-lead-icon';
-      }
-    }, [fieldState, props.disabled]);
-
-    const renderSelect = useCallback(
-      (htmlFor?: string) => (
-        <SelectWrapper>
-          {icon && (
-            <SubjectIcon $isCompact={isCompact}>
-              <Icon icon={icon} color={iconColor()} size={isCompact ? 12 : 12} weight='regular' />
-            </SubjectIcon>
-          )}
-          <StyledSelect
-            ref={ref}
-            $withIcon={!!icon}
-            id={htmlFor}
-            $fieldState={fieldState}
-            $isCompact={isCompact}
-            {...props}
-            {...(props.value === undefined ? { defaultValue: defaultValue ?? '' } : {})}
-            onChange={handleOnChange}
-            onKeyDown={handleOnKeyDown}
-          >
-            {!defaultValue && (
-              <option value='' disabled hidden>
-                {placeholder}
-              </option>
-            )}
-            {children}
-          </StyledSelect>
-          <OpenIcon $isCompact={isCompact}>
-            <Icon icon='Down' color={iconColor()} weight='regular' size={isCompact ? 8 : 10} />
-          </OpenIcon>
-        </SelectWrapper>
-      ),
-      [
-        ref,
-        children,
-        defaultValue,
-        handleOnChange,
-        handleOnKeyDown,
-        placeholder,
-        // biome-ignore lint/correctness/useExhaustiveDependencies: props is the rest object from the destructuring of OwnProps & SelectHTMLAttributes — its identity changes every render. Stabilising requires an API change to forward props explicitly. See #644.
-        props,
-        fieldState,
-        icon,
-        iconColor,
-        isCompact,
-      ]
-    );
-
-    return (
-      <Container {...{ $isCompact: isCompact, $activePlaceholder: activePlaceholder }}>
-        {label ? (
-          <Label
-            htmlFor={label.htmlFor}
-            labelText={label.text}
-            direction={label.isSameRow ? 'row' : label.direction}
-          >
-            {renderSelect(label.htmlFor)}
-          </Label>
-        ) : (
-          renderSelect()
-        )}
-      </Container>
+function SelectField({
+  fieldState = 'default',
+  placeholder,
+  label,
+  icon,
+  isCompact,
+  defaultValue,
+  changeCallback = () => {},
+  onChange,
+  onKeyDown,
+  children,
+  error,
+  hint,
+  ref,
+  ...props
+}: ISelect) {
+  if (label?.isSameRow) {
+    console.warn(
+      'Deprecation warning: `SelectField` is deprecating `label.isSameRow`, please update this to use `label.direction` set to `row`.'
     );
   }
-);
 
-SelectField.displayName = 'SelectField';
+  const [activePlaceholder, setPlaceholderStatus] = useState<boolean>(!defaultValue);
+
+  const hasError = Boolean(error);
+  const isNative = hasError || Boolean(hint);
+  const effectiveFieldState: TypeFieldState = hasError ? 'invalid' : fieldState;
+  const fieldId = label?.htmlFor ?? props.id ?? props.name;
+  const errorId = fieldId ? `${fieldId}-error` : undefined;
+  const hintId = fieldId && hint ? `${fieldId}-hint` : undefined;
+  const describedBy = hasError ? errorId : hintId;
+
+  const handleOnChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const { value } = e.target;
+
+      setPlaceholderStatus((prev) => {
+        if (prev) {
+          return false;
+        }
+        return prev;
+      });
+      changeCallback(value);
+      onChange?.(e);
+    },
+    [changeCallback, onChange]
+  );
+
+  const handleOnKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLSelectElement>) => {
+      onKeyDown?.(e);
+
+      if (e.defaultPrevented || e.key !== 'ArrowDown' || e.currentTarget.value !== '') {
+        return;
+      }
+
+      // In placeholder mode the empty option is reserved for the placeholder.
+      const nextOption = Array.from(e.currentTarget.options).find(
+        (option) => !option.disabled && !option.hidden && option.value !== ''
+      );
+
+      if (!nextOption) {
+        return;
+      }
+
+      e.preventDefault();
+      e.currentTarget.value = nextOption.value;
+      e.currentTarget.dispatchEvent(new Event('change', { bubbles: true }));
+    },
+    [onKeyDown]
+  );
+
+  const iconColor = useCallback(() => {
+    if (props.disabled || fieldState === 'disabled') {
+      return 'input-disabled-lead-icon';
+    } else {
+      return 'input-lead-icon';
+    }
+  }, [fieldState, props.disabled]);
+
+  const renderSelect = (htmlFor?: string) => (
+    <SelectWrapper>
+      {icon && (
+        <SubjectIcon $isCompact={isCompact}>
+          <Icon icon={icon} color={iconColor()} size={isCompact ? 12 : 12} weight='regular' />
+        </SubjectIcon>
+      )}
+      <StyledSelect
+        ref={ref}
+        $withIcon={!!icon}
+        id={htmlFor}
+        $fieldState={effectiveFieldState}
+        $isCompact={isCompact}
+        {...props}
+        {...(props.value === undefined ? { defaultValue: defaultValue ?? '' } : {})}
+        {...(isNative
+          ? {
+              'aria-invalid': hasError,
+              'aria-describedby': describedBy,
+            }
+          : {})}
+        onChange={handleOnChange}
+        onKeyDown={handleOnKeyDown}
+      >
+        {!defaultValue && (
+          <option value='' disabled hidden>
+            {placeholder}
+          </option>
+        )}
+        {children}
+      </StyledSelect>
+      <OpenIcon $isCompact={isCompact}>
+        <Icon icon='Down' color={iconColor()} weight='regular' size={isCompact ? 8 : 10} />
+      </OpenIcon>
+    </SelectWrapper>
+  );
+
+  const container = (
+    <Container $isCompact={isCompact} $activePlaceholder={activePlaceholder}>
+      {label ? (
+        <Label
+          htmlFor={label.htmlFor}
+          labelText={label.text}
+          direction={label.isSameRow ? 'row' : label.direction}
+          required={label.required}
+        >
+          {renderSelect(label.htmlFor)}
+        </Label>
+      ) : (
+        renderSelect()
+      )}
+    </Container>
+  );
+
+  if (!isNative) {
+    return container;
+  }
+
+  return (
+    <FieldWrapper>
+      {container}
+      {hint && !hasError ? <HintMessage id={hintId}>{hint}</HintMessage> : null}
+      {hasError ? (
+        <ErrorMessage id={errorId} role='alert'>
+          {error}
+        </ErrorMessage>
+      ) : null}
+    </FieldWrapper>
+  );
+}
 
 export default SelectField;

--- a/packages/ui-lib/src/Form/atoms/fieldStyles.ts
+++ b/packages/ui-lib/src/Form/atoms/fieldStyles.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+export const FieldWrapper = styled.div`
+  margin-bottom: 24px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+export const ErrorMessage = styled.span`
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--input-invalid-border-color, #e53935);
+`;
+
+export const HintMessage = styled.span`
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--primary-7);
+`;

--- a/packages/ui-lib/src/Form/molecules/FormField.tsx
+++ b/packages/ui-lib/src/Form/molecules/FormField.tsx
@@ -3,29 +3,8 @@ import type { ControllerRenderProps, RegisterOptions } from 'react-hook-form';
 import { useController } from 'react-hook-form';
 import styled from 'styled-components';
 import type { TypeFieldState } from '..';
+import { ErrorMessage, FieldWrapper, HintMessage } from '../atoms/fieldStyles';
 import Label from '../atoms/Label';
-
-const ErrorMessage = styled.span`
-  display: block;
-  margin-top: 4px;
-  font-size: 12px;
-  color: var(--input-invalid-border-color, #e53935);
-`;
-
-const HintMessage = styled.span`
-  display: block;
-  margin-top: 4px;
-  font-size: 12px;
-  color: var(--primary-7);
-`;
-
-const FieldWrapper = styled.div`
-  margin-bottom: 24px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-`;
 
 // fieldset reset — inherits font stack and colors from Label
 const Fieldset = styled.fieldset`


### PR DESCRIPTION
## Summary

Research follow-up to #653 (round 1). This round answers: **can the existing UI Kit components render label/error/hint natively, without a `FormField` wrapper?** And: **can we drop `forwardRef` now that we're on React 19?**

- `Input` and `SelectField` now support a native (no-wrapper) mode via additive `label`/`error`/`hint`/`required` props. When those props aren't passed, behavior is unchanged — existing `FormField`-wrapped usage from #653 keeps working.
- `React.forwardRef` removed from both atoms (deprecated in React 19). A codebase sanity sweep confirms no other deprecated React patterns remain (`forwardRef`, `defaultProps`, `propTypes`, `UNSAFE_*`, legacy lifecycle, `findDOMNode`, string refs — all zero).
- New `/rhf-spike-native` demo page sits next to `/rhf-spike` so the team can A/B both approaches.

PR is targeted at **`feature/react-form-hooks-poc`** so the diff shows only this round's changes, layered on top of round 1.

## What changed

**Atoms (additive, opt-in to native mode):**
- `Input.tsx` — new `label`/`error`/`hint`/`required` props; auto-id from `name`; auto-wires `aria-invalid` + `aria-describedby` in native mode.
- `SelectField.tsx` — new `error`/`hint` props; `ILabel` extended with `required` to expose the existing `Label` atom capability.

**Shared primitives:**
- `fieldStyles.ts` (new) — exports `FieldWrapper` / `ErrorMessage` / `HintMessage` styled defs. Single source of truth for error/hint styling. Not a wrapper component, just shared CSS-in-JS imports.
- `FormField.tsx` — imports from `fieldStyles` instead of defining locally (pure refactor).

**React 19 ref migration:**
- `React.forwardRef` removed from `Input` and `SelectField`. `ref` is now a regular prop; `displayName` dropped.

**Demo + tests:**
- `NativeRHFSpikePage.tsx` (new) at `/rhf-spike-native`. Uses `useController` directly (no `FormField` import) to drive Input + SelectField.
- `rhf-spike-native.spec.ts` (new) — 8 Playwright tests: happy path, required validation, aria wiring, email pattern, hint→error swap, blur-on-touched, catalog navigation.
- `playwright.config.ts` — switched test port to `3101` so it doesn't reuse an unrelated dev server on `:3000`.

**Documentation:**
- `findings-native-atoms.md` (new, repo root) — per-component change log, awkward parts (notably SelectField's `ILabel` nested shape), a11y notes, React 19 ref migration observations, deprecated-pattern sanity sweep table, and recommendations for the AI-Native UI Kit direction.

## Sanity-check sweep results

After this round, `packages/ui-lib/src` and `packages/example/src` contain:

| Pattern | Count |
|---|---|
| `forwardRef` | **0** |
| `defaultProps` on function components | 0 |
| `propTypes` / `prop-types` imports | 0 |
| `componentWill*` / `UNSAFE_*` | 0 |
| `ReactDOM.render` / `findDOMNode` | 0 |
| `react-dom/test-utils` (`act`) | 0 |
| Legacy context / `childContextTypes` | 0 |
| String refs | 0 |
| Class components | 0 |
| `React.FC<...>` | 145 (informational — not deprecated in React 19, just a style consideration) |

## Open design question for round 3

Native mode shifts `useController` from the library to the consumer. That's good for library purity (atoms become form-library-agnostic) but adds per-field boilerplate when using RHF. Worth exploring in round 3:
- Keep both `FormField` and native mode shipping side-by-side, or
- Replace `FormField` with a thin `useRHFField(name, rules)` hook that returns ready-to-spread props.

Discussed in `findings-native-atoms.md` under recommendations.

## Test plan

- [x] `npm run check` (biome) passes
- [x] `cd packages/ui-lib && npm run test:types` passes
- [x] `cd packages/example && npm run build` passes
- [x] `cd packages/example && npm run test:e2e` — **22/22 Playwright tests pass** (14 existing wrapped-form + 8 new native)
- [ ] Visual review: open `/rhf-spike` and `/rhf-spike-native` side-by-side, confirm parity of label/error/hint rendering and aria attributes
- [ ] Code review focus: `fieldStyles.ts` extraction + the `isNative` branches in Input/SelectField

> **Heads up for reviewers:** `packages/example` imports the prebuilt `ui-lib/dist/index.modern.js`. If you pull this branch and only see source changes, run `cd packages/ui-lib && npm run build` (or `npm run start:ui-lib` for watch mode) before the example app picks up the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)