### PR TITLE
RHF PoC 3rd Iteration — integrated Input/SelectField

### DIFF
--- a/findings-integrated-rhf.md
+++ b/findings-integrated-rhf.md
@@ -1,0 +1,305 @@
+# Integrated RHF Atoms — Findings (PoC Round 3)
+
+## TL;DR — verdict on the framing question
+
+The PoC was set up to land on one of three outcomes:
+
+1. **UI Kit v3 can work well with RHF with none or minimal changes.**
+2. **UI Kit v3 would need significant breaking changes but could be pushed to work.**
+3. **New components are needed — this work informs the new UI Kit version.**
+
+**The answer is a split: (1) for v3, (3) for the AI-Native version.**
+
+- **For v3: outcome (1) holds.** All three rounds were achieved on top of v3 atoms without breaking changes — the diff vs `main` is almost entirely additive (new optional props, widened union types, opt-in rendering shells). Round 1's `FormField` molecule is a zero-touch addition. Round 2 added native `label`/`error`/`hint` props as optionals. Round 3 added internal `useController` behind a runtime dispatcher; the only footgun is `<Input name='x' />` placed inside a `<FormProvider>` without `value` silently subscribing to RHF — and there are no such call sites in this repo. **If we wanted to ship RHF support on v3 today, we could.**
+- **The cost of (1) is design debt, which points to (3).** Round 3 works only because of a dispatcher that picks between integrated and standalone modes at runtime, based on an implicit `value === undefined` signal. Two of every field component live in one file (StandaloneInput + IntegratedInput, etc.). `SelectField` has to support both an `ILabel` object label *and* a flat string. Two error-rendering paths (`FormField` + the atom shell) coexist. These compromises exist purely because v3's API is being preserved.
+- **The AI-Native UI Kit should take outcome (3).** Build integrated as the *only* mode, drop the dispatcher, drop `FormField`, drop `ILabel`, drop `children`-based options, use `useId()` everywhere, ship a single `<FieldShell>` primitive. The recommendations section below details this.
+
+**Outcome (2) — "significant breaking changes pushed onto v3" — is not the right framing.** The work proved the breaking changes aren't necessary on v3; the cleaner API is necessary for v4.
+
+See the [Breaking changes vs `main`](#breaking-changes-vs-main) and [Recommendations for the AI-Native UI Kit](#recommendations-for-the-ai-native-ui-kit) sections for the full reasoning.
+
+## Goal
+
+Round 1 (`feature/react-form-hooks-poc`) wired `react-hook-form` (RHF) to the UI Kit via a `FormField` molecule + render-prop. Round 2 (`feature/react-form-hooks-poc-2`) refactored `Input` and `SelectField` to render their own label/error/hint, but the consumer still called `useController` for each field.
+
+Round 3 (`feature/react-form-hooks-poc-3`) goes the rest of the way: the components own `useController` internally. The consumer writes **zero** per-field hook calls. Inside a `<FormProvider>`, `<Input name='firstName' label='First name' rules={{...}} />` is the entire field declaration.
+
+## DX comparison — all three rounds, same form
+
+A text field, a select, and an email field with a hint + pattern validation. The form is the same in all three demo pages; the *code* is the whole point.
+
+### Round 1 — `FormField` wrapper, render-prop (`RHFSpikePage.tsx`)
+
+```tsx
+<FormField name='name' label='Name' required rules={{ required: 'Name is required' }}>
+  {({ field, fieldState, id, errorId, 'aria-invalid': ariaInvalid }) => (
+    <Input
+      {...field}
+      id={id}
+      fieldState={fieldState}
+      aria-invalid={ariaInvalid}
+      aria-describedby={errorId}
+    />
+  )}
+</FormField>
+<FormField name='colour' label='Favourite colour' required rules={{ required: 'Favourite colour is required' }}>
+  {({ field, fieldState, id, errorId, 'aria-invalid': ariaInvalid }) => (
+    <SelectField
+      ref={field.ref}
+      id={id}
+      fieldState={fieldState}
+      aria-invalid={ariaInvalid}
+      aria-describedby={errorId}
+      value={field.value}
+      onChange={field.onChange}
+      onBlur={field.onBlur}
+      name={field.name}
+      placeholder='Select a colour'
+    >
+      <option value='red'>Red</option>
+      <option value='green'>Green</option>
+      <option value='blue'>Blue</option>
+    </SelectField>
+  )}
+</FormField>
+```
+
+### Round 2 — native atoms, consumer-owned `useController` (`NativeRHFSpikePage.tsx`)
+
+```tsx
+const NameField = () => {
+  const { field, fieldState } = useController<FormValues, 'name'>({
+    name: 'name',
+    rules: { required: 'Name is required' },
+  });
+  return <Input {...field} label='Name' required error={fieldState.error?.message} />;
+};
+
+const ColourField = () => {
+  const { field, fieldState } = useController<FormValues, 'colour'>({
+    name: 'colour',
+    rules: { required: 'Favourite colour is required' },
+  });
+  return (
+    <SelectField
+      {...field}
+      label={{ htmlFor: 'colour', text: 'Favourite colour', required: true }}
+      error={fieldState.error?.message}
+      placeholder='Select a colour'
+    >
+      <option value='red'>Red</option>
+      <option value='green'>Green</option>
+      <option value='blue'>Blue</option>
+    </SelectField>
+  );
+};
+```
+
+### Round 3 — integrated atoms, zero per-field hooks (`IntegratedNativeRHFSpikePage.tsx`)
+
+```tsx
+<Input name='name' label='Name' required rules={{ required: 'Name is required' }} />
+<SelectField
+  name='colour'
+  label='Favourite colour'
+  required
+  placeholder='Select a colour'
+  options={[
+    { value: 'red', label: 'Red' },
+    { value: 'green', label: 'Green' },
+    { value: 'blue', label: 'Blue' },
+  ]}
+  rules={{ required: 'Favourite colour is required' }}
+/>
+<Input
+  name='email'
+  type='email'
+  label='Email'
+  required
+  hint='We never share your email.'
+  rules={{
+    required: 'Email is required',
+    pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
+  }}
+/>
+```
+
+The whole `NameField`/`ColourField`/`EmailField` factoring from round 2 disappears. No `useController` import. No `{...field}` spreading. No `fieldState.error?.message` plumbing. The declaration is essentially what RHF advertises for native HTML.
+
+## What changed per atom
+
+### `Input` (`packages/ui-lib/src/Form/atoms/Input.tsx`)
+
+| Change | Reason |
+|---|---|
+| New `rules?: RegisterOptions` prop | RHF validation rules sit inline with the field. |
+| Existing body extracted into `StandaloneInput` | Unchanged behaviour — preserves round-1 and round-2 callers. |
+| New `IntegratedInput` component | Calls `useController({ name, rules, defaultValue })`, derives a stable `id` from `useId()`, forwards `field.ref/value/onChange/onBlur/name` and `fieldState.error?.message` down to `StandaloneInput`. |
+| New top-level `Input` dispatcher | Calls `useFormContext()`; routes to `IntegratedInput` when `formContext !== null && name !== undefined && value === undefined`, otherwise to `StandaloneInput`. |
+
+### `SelectField` (`packages/ui-lib/src/Form/atoms/SelectField.tsx`)
+
+| Change | Reason |
+|---|---|
+| `label?: ILabel | string` (was `ILabel` only) | Integrated mode accepts a flat string; standalone keeps the `ILabel` object shape for backward compat. |
+| New `required?: boolean`, `rules?: RegisterOptions`, `options?: Array<{ value: string; label: string }>` props | Integrated API. `options` renders `<option>` children when in integrated mode; standalone still accepts `children`. |
+| Existing body extracted into `StandaloneSelectField` | Unchanged behaviour. |
+| New `IntegratedSelectField` component | Calls `useController`, converts flat `label` to `ILabel { htmlFor: useId(), text, required }`, renders options as children, forwards everything to `StandaloneSelectField`. |
+| New top-level `SelectField` dispatcher | Same predicate as Input. |
+
+### `FormField`, `fieldStyles.ts`, `Label.tsx`
+
+Untouched. Round 2's groundwork (extracted `fieldStyles` module, `Label.required` dot) is exactly what made round 3 cheap.
+
+## Breaking changes vs `main`
+
+This branch rolls up rounds 1, 2, and 3 into `Input.tsx` and `SelectField.tsx`. Compared to `main`, the API surface is **almost entirely additive** — the legacy call shapes still render the same DOM. But there are a few behaviour-level deltas a downstream consumer should know about before this lands.
+
+### `Input` (`packages/ui-lib/src/Form/atoms/Input.tsx`)
+
+| Change | Caller impact | Severity |
+|---|---|---|
+| New optional props: `label`, `error`, `hint`, `required`, `ref`, `rules` | None — all optional, no defaults change | Additive |
+| `Input` typed as plain `(props: InputProps) => ...` instead of `React.FC<InputProps>` | None for prop usage. `React.FC` had implicit `children: ReactNode | undefined`; the new shape only accepts `children` because `InputHTMLAttributes` already declares it | Cosmetic |
+| `feedbackIcon` lifted from inside the component to module scope | None — pure refactor, identical output | Cosmetic |
+| Dispatcher: passing `name` to `<Input>` *inside* a `<FormProvider>` *without* `value` now subscribes to RHF | A caller doing `<Input name='foo' />` inside a `FormProvider` for **non-RHF reasons** (e.g. just naming the field for forms posting) will now try to register with RHF. The `name` must exist in the form's value type or RHF will get unhappy. | **Behavioural** |
+| New rendering shell wraps the input when `label` is set: `<FieldWrapper><Label>…</Label><HintMessage/><ErrorMessage/></FieldWrapper>` | None for existing callers (they don't pass `label`). New callers opting in get a different DOM tree than a bare `<input>` — CSS selectors that assumed `<input>` is the direct child of the consumer's container won't match | Additive |
+
+### `SelectField` (`packages/ui-lib/src/Form/atoms/SelectField.tsx`)
+
+| Change | Caller impact | Severity |
+|---|---|---|
+| `label?: ILabel` widened to `label?: ILabel | string` | None — `ILabel` callers still type-check | Additive |
+| `ILabel` gains optional `required?: boolean` | None — optional field | Additive |
+| New optional props: `error`, `hint`, `required`, `ref`, `rules`, `options` | None — all optional | Additive |
+| `SelectField` typed as plain `(props: ISelect) => ...` instead of `React.FC<ISelect>` | Same as Input — cosmetic | Cosmetic |
+| Dispatcher: passing `name` to `<SelectField>` *inside* a `<FormProvider>` *without* `value` now subscribes to RHF | Same as Input — non-RHF callers who happen to pass `name` inside a provider will get hijacked | **Behavioural** |
+| `onKeyDown` now intercepted: when the select is in placeholder state (empty value), pressing ArrowDown picks the first non-placeholder option and fires a `change` event | The user's `onKeyDown` is still called first, and the interception only kicks in if `e.defaultPrevented` is false and the value is empty. Callers who relied on ArrowDown opening the native dropdown picker will see a value selected instead | **Behavioural** |
+| `onChange` interception now also forwards to caller's `onChange` (previously only ran the placeholder-dismissal side effect) | Strictly additive — callers passing `onChange` now have it called. This is what they likely expected all along | Additive (bugfix-flavoured) |
+| New rendering shell wraps the select when `error` or `hint` is set: `<FieldWrapper>…<HintMessage/><ErrorMessage/></FieldWrapper>` | None for existing callers (they don't pass `error`/`hint`). Same DOM-structure caveat as Input | Additive |
+| `renderSelect` no longer wrapped in `useCallback` with a deps array | Slightly more re-renders of the inner JSX (the `useCallback` was unstable due to `props` rest-object identity — see [#644](https://github.com/future-standard/scorer-ui-kit/issues/644)). No functional regression | Cosmetic/perf |
+| `<Container {...{ $isCompact, $activePlaceholder }}>` → `<Container $isCompact={…} $activePlaceholder={…}>` | None — identical JSX semantics | Cosmetic |
+| `aria-invalid` / `aria-describedby` set on `<select>` when `error`/`hint` is present, after `{...props}` spread | A caller passing `aria-invalid` explicitly via `...props` would be overridden if they *also* set `error` or `hint`. In practice these are mutually exclusive concerns | Edge case |
+
+### `Input`/`SelectField` public exports
+
+`default export` identity is preserved. `InputProps` and the implicit `ISelect` prop shape are widened (only new optional members). `ILabel` is module-internal — its widening doesn't leak into the public API.
+
+### The one footgun worth a release note
+
+The **dispatcher hijack** is the only thing that can break an existing caller silently:
+
+```tsx
+// In `main`, this renders a plain <input> with name='whatever' as an HTML attribute.
+// On this branch, if there's a <FormProvider> anywhere above this, Input subscribes
+// to RHF for the field 'whatever' — and crashes/misbehaves if 'whatever' isn't in
+// the form's value type.
+<FormProvider {...someUnrelatedForm}>
+  <Input name='whatever' />
+</FormProvider>
+```
+
+In the scorer-ui-kit repo there are no such call sites — `FormProvider` only appears in the three RHF demo pages, and all of them pass `value` for non-RHF-managed inputs. Downstream consumers should audit for "bare `Input` or `SelectField` with `name` inside a `FormProvider`" before upgrading. The escape hatch is to pass `value={someValue}` (even `value=''`) to opt back into standalone behaviour.
+
+A cleaner future direction: replace the value-based predicate with an explicit `unmanaged` (or inverse `managed`) prop, so the integrated path is opt-in by name rather than opt-out by `value`-presence. Not done here because it would have churned rounds 1 and 2.
+
+## What was awkward
+
+1. **The "is this integrated mode?" predicate was non-obvious.** First attempt — `formContext !== null && name !== undefined` — broke rounds 1 and 2. Both pass `name` from `{...field}` spreads, so the dispatcher hijacked them, called a second `useController`, overrode the consumer's `value/onChange/ref`, and (for `SelectField`) discarded the consumer's `<option>` children. Adding `&& value === undefined` to the predicate fixed it: integrated mode is the path for consumers who *don't* manage value externally. The logic is correct but the rule needs documenting, because round-1/2-style callers look like they're asking for integrated mode at first glance.
+
+2. **The split-component pattern preserves rules-of-hooks but doubles the JSX path.** Standalone and integrated render through the same `StandaloneInput`/`StandaloneSelectField` tail, so styling and a11y stay in one place. But the integrated wrapper still has to know about every prop it might want to override, and the standalone body has to defensively destructure (and discard) integrated-only props like `rules` and `options` to keep them off the DOM element.
+
+3. **`SelectField`'s flat `label: string` vs object `label: ILabel` is now a union type.** Inside `StandaloneSelectField`, runtime branching with `typeof label === 'object'` separates the two. Works, but it's the kind of union that begs to become two separate components in the AI-Native version.
+
+4. **`name` is typed as `string`, not `keyof TFieldValues`.** Strongly-typed `name` requires generics propagation (`Input<TFieldValues>`) — high friction with `FormProvider` typing, ugly in JSX, and a poor fit for AI-generated code. Plain `string` is fine for the PoC; the cost is no autocomplete on `name` and no `rules` value-type checking. The AI-Native version could try `name extends Path<TFieldValues>` if a way to flow generics through cleanly emerges, but `string` is a defensible default.
+
+5. **`useController` always runs in `IntegratedInput`/`IntegratedSelectField` once the dispatcher picks them.** The dispatcher uses `useFormContext()`, which is unconditional and safe. Then it returns *one of two trees*. Each subtree's hooks are stable across renders for that subtree. But: if the same `<Input name='x' />` toggles between provider/no-provider across renders, the subtree swaps and the hook count for the subtree changes. In practice this can't happen — `FormProvider` is a structural choice, not a stateful one — but it's the kind of subtlety worth noting.
+
+6. **Per-field `defaultValue` flowing to RHF is typed `any`.** `useController`'s `defaultValue` is `FieldPathValue<TFieldValues, TName>`. With `TFieldValues = FieldValues = Record<string, any>` (no generics), the type collapses to `any`. The PoC casts via `as any` with a biome-ignore — acceptable for research code, ugly for production. Tied to decision (4).
+
+## Performance check
+
+Spot-checked with React DevTools Profiler on `/rhf-spike-integrated`. Typing into the **Name** field renders only the integrated `Input` subtree for `name`. The form root and the other fields do not re-render. RHF's per-field re-render isolation is preserved — each `IntegratedInput` / `IntegratedSelectField` is its own subscription boundary because the `useController` call lives inside the leaf component, not at the form root.
+
+This is the design's main payoff over a hypothetical "form-renders-all-fields" implementation: making each field its own component is what gives RHF its perf story, and the dispatcher pattern preserves that automatically.
+
+## ARIA parity across all three pages
+
+All three demo pages render the same DOM contract for the same form (verified by the same Playwright assertions, mechanically copy-pasted across `rhf-spike.spec.ts`, `rhf-spike-native.spec.ts`, and `rhf-spike-integrated.spec.ts`):
+
+| Attribute | Round 1 (wrapped) | Round 2 (native) | Round 3 (integrated) |
+|---|---|---|---|
+| `<label for>` linkage | Yes | Yes | Yes |
+| Error `role='alert'` | Yes | Yes | Yes |
+| `aria-invalid` on input/select | Yes | Yes | Yes |
+| `aria-describedby` → error id | Yes | Yes | Yes |
+| `aria-describedby` → hint id (no error) | No (FormField gap) | Yes | Yes |
+| Required dot indicator | Yes | Yes | Yes |
+
+The only differential — the hint-id wiring missing in `FormField` — was already flagged in round 2 and stays open. Both native paths get it for free.
+
+## `FormField`'s future
+
+Recommendation: **delete `FormField` (and `RHFSpikePage`) after the round-3 demo has served its team-comparison purpose.** Round 3 obsoletes it:
+
+- Anything `FormField` does (label, error, hint, aria, render-prop value plumbing), the integrated atoms now do — and they do it with a far smaller call site.
+- The render-prop pattern requires consumers to wire `id`, `aria-invalid`, `aria-describedby`, and `value`/`onChange`/`onBlur` manually on the child — error-prone and verbose.
+- Maintaining two error-rendering paths (`FormField` and the atoms' `fieldStyles` shell) means the visual contract drifts unless someone polices it.
+
+Don't delete on this branch — the three demo pages still need it for the side-by-side comparison the team will be reviewing. Schedule it as a follow-up PR once the comparison's value has been extracted.
+
+## Recommendations for the AI-Native UI Kit
+
+1. **Integrated is the right floor.** Round 3's DX is the one that AI code generators will emit naturally — it matches RHF's documented "native HTML" examples and reads as a declarative spec of the field. The AI-Native UI Kit should ship integrated as the *only* path, not as one of several.
+
+2. **No render-prop wrappers.** `FormField`-style render props are a holdover from pre-hooks idioms. Drop them — the call site cost is too high and the abstraction adds nothing the integrated atom doesn't already do.
+
+3. **No `value`-prop escape hatch on integrated components.** The dispatcher pattern used here exists to keep rounds 1 and 2 working. In an AI-Native rewrite, integrated mode is the path and there's no need for a parallel `value`-controlled mode on the same component. If a non-RHF use case appears, it's a separate component, not a runtime branch.
+
+4. **Flat label props.** `label: string`, `required: boolean`, `direction: 'row' | 'column'` — top-level. `ILabel` was a v2 mistake and should not survive the rewrite. Round 3's `SelectField` already shows the gap: the union type `ILabel | string` exists only to bridge to the legacy standalone API.
+
+5. **`options` prop, not `children`.** For `SelectField`, accept `options: Array<{ value, label, disabled? }>`. AI code generators emit data, not JSX. `children` makes sense for compositional widgets, but a `<select>` is closer to a data-driven control.
+
+6. **`useId()` everywhere, no `name`-derived IDs.** Round 2's auto-id was `id ?? name`, with the noted "collides if two forms use the same field name on the same page" risk. Round 3 swaps in `useId()` for the integrated path. The AI-Native version should make `useId()` the default for all field components.
+
+7. **Single error-rendering primitive.** Today two paths exist (`FormField` and the atoms' shell via `fieldStyles`). Consolidate to one `<FieldShell>` (or equivalent) primitive that all field components compose internally. No inline `<ErrorMessage>` JSX in molecules.
+
+8. **Generic `name` typing is the open question.** Plain `string` ships round 3 cleanly. For the AI-Native version, an experiment worth running: thread `TFieldValues` through `Input<TFieldValues>` and see whether the JSX-site cost (`<Input<FormValues> name='firstName' />`) is bearable. If not, accept `string` as the permanent floor and lean on schema-typed RHF (`zodResolver`-style) for the safety net.
+
+9. **Group controls still need their own pass.** `Checkbox` group and `RadioButton` group were deferred. They're inherently `<fieldset>`-shaped — error belongs on the group, not the individual control. The integrated pattern probably doesn't transplant directly; a composite `<RadioGroup name='...' options={...} />` is the likely shape. Round 4 territory.
+
+## Files touched in this round
+
+```
+packages/ui-lib/src/Form/atoms/Input.tsx                  (added IntegratedInput + dispatcher)
+packages/ui-lib/src/Form/atoms/SelectField.tsx            (added IntegratedSelectField + dispatcher)
+packages/example/src/pages/IntegratedNativeRHFSpikePage.tsx (new)
+packages/example/src/pages/Index.tsx                      (catalog entry)
+packages/example/src/App.tsx                              (route)
+packages/example/tests/rhf-spike-integrated.spec.ts       (new — 8 Playwright tests)
+findings-integrated-rhf.md                                (this file)
+```
+
+`FormField.tsx`, `fieldStyles.ts`, and `Label.tsx` were not modified.
+
+## How to run
+
+```bash
+# Type check + lint
+npm run check
+cd packages/ui-lib && npm run test:types
+
+# Build (the example imports from dist/, so ui-lib must build first)
+cd packages/ui-lib && npm run build
+cd packages/example && npm run build
+
+# Run the example app
+npm run start:example
+# → http://localhost:3000/#/rhf-spike              (round 1 — wrapped)
+# → http://localhost:3000/#/rhf-spike-native       (round 2 — native)
+# → http://localhost:3000/#/rhf-spike-integrated   (round 3 — integrated)
+
+# Playwright — all three pages must pass
+cd packages/example && npm run test:e2e
+# 30 tests passing as of this commit (14 + 8 + 8).
+```

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -7,6 +7,7 @@ import CustomUserDrawerPage from './pages/CustomUserDrawerPage';
 import FormPage from './pages/FormPage';
 import GlobalUIPage from './pages/GlobalUIPage';
 import LinksPage from './pages/Index';
+import IntegratedNativeRHFSpikePage from './pages/IntegratedNativeRHFSpikePage';
 import Layouts from './pages/Layouts';
 import LineHLSPage from './pages/LineHLSPage';
 import LinePage from './pages/LinePage';
@@ -45,6 +46,7 @@ const App: React.FC = () => {
         <Route path='/webrtc-strictmode-test' element={<WebRTCStrictModeTestPage />} />
         <Route path='/rhf-spike' element={<RHFSpikePage />} />
         <Route path='/rhf-spike-native' element={<NativeRHFSpikePage />} />
+        <Route path='/rhf-spike-integrated' element={<IntegratedNativeRHFSpikePage />} />
       </Routes>
     </Router>
   );

--- a/packages/example/src/pages/Index.tsx
+++ b/packages/example/src/pages/Index.tsx
@@ -209,6 +209,16 @@ const LinksPage: React.FC = () => {
             </Link>
           </Item>
           <Item>
+            <Link to={`/rhf-spike-integrated`}>
+              <Title>React Hook Form (Integrated)</Title>
+              <Description>
+                UI Kit components with RHF integration baked in — no per-field useController. Spike
+                PoC matching RHF's native-HTML DX promise.
+              </Description>
+              <FilenameTag>IntegratedNativeRHFSpikePage.tsx</FilenameTag>
+            </Link>
+          </Item>
+          <Item>
             <Link to={`/login`}>
               <Title>Login</Title>
               <Description>A code sample of our commonly used login view.</Description>

--- a/packages/example/src/pages/IntegratedNativeRHFSpikePage.tsx
+++ b/packages/example/src/pages/IntegratedNativeRHFSpikePage.tsx
@@ -1,0 +1,71 @@
+import type React from 'react';
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Button, Input, SelectField } from 'scorer-ui-kit';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type FormValues = {
+  name: string;
+  colour: string;
+  email: string;
+};
+
+const IntegratedNativeRHFSpikePage: React.FC = () => {
+  const [submittedData, setSubmittedData] = useState<FormValues | null>(null);
+  const methods = useForm<FormValues>({
+    mode: 'onTouched',
+    defaultValues: { name: '', colour: '', email: '' },
+  });
+
+  const onSubmit = (data: FormValues) => {
+    setSubmittedData(data);
+  };
+
+  return (
+    <div style={{ padding: '32px', maxWidth: '400px' }}>
+      <h1>React Hook Form (Integrated)</h1>
+      <p style={{ color: 'var(--grey-11)', fontSize: '14px' }}>
+        Input and SelectField subscribe to React Hook Form themselves — no per-field useController.
+      </p>
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)} noValidate>
+          <Input name='name' label='Name' required rules={{ required: 'Name is required' }} />
+          <SelectField
+            name='colour'
+            label='Favourite colour'
+            required
+            placeholder='Select a colour'
+            options={[
+              { value: 'red', label: 'Red' },
+              { value: 'green', label: 'Green' },
+              { value: 'blue', label: 'Blue' },
+            ]}
+            rules={{ required: 'Favourite colour is required' }}
+          />
+          <Input
+            name='email'
+            type='email'
+            label='Email'
+            required
+            hint='We never share your email.'
+            rules={{
+              required: 'Email is required',
+              pattern: { value: EMAIL_PATTERN, message: 'Enter a valid email address' },
+            }}
+          />
+          <div style={{ marginTop: '24px' }}>
+            <Button type='submit'>Submit</Button>
+          </div>
+        </form>
+      </FormProvider>
+      {submittedData !== null && (
+        <pre data-testid='submitted' style={{ marginTop: '16px', whiteSpace: 'pre-wrap' }}>
+          {JSON.stringify(submittedData, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default IntegratedNativeRHFSpikePage;

--- a/packages/example/tests/rhf-spike-integrated.spec.ts
+++ b/packages/example/tests/rhf-spike-integrated.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+
+test('submitting empty integrated form shows required errors', async ({ page }) => {
+  await page.goto('/#/rhf-spike-integrated');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Name is required' })).toBeVisible();
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Favourite colour is required' })
+  ).toBeVisible();
+  await expect(page.getByRole('alert').filter({ hasText: 'Email is required' })).toBeVisible();
+});
+
+test('integrated name field aria wiring is correct when invalid', async ({ page }) => {
+  await page.goto('/#/rhf-spike-integrated');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const nameError = page.getByRole('alert').filter({ hasText: 'Name is required' });
+  await expect(nameError).toBeVisible();
+
+  const nameInput = page.getByRole('textbox', { name: 'Name' });
+  const errorId = await nameError.getAttribute('id');
+  const describedBy = await nameInput.getAttribute('aria-describedby');
+  expect(describedBy).toBe(errorId);
+  await expect(nameInput).toHaveAttribute('aria-invalid', 'true');
+});
+
+test('integrated select field aria wiring is correct when invalid', async ({ page }) => {
+  await page.goto('/#/rhf-spike-integrated');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const colourError = page.getByRole('alert').filter({ hasText: 'Favourite colour is required' });
+  await expect(colourError).toBeVisible();
+
+  const select = page.getByRole('combobox');
+  const errorId = await colourError.getAttribute('id');
+  const describedBy = await select.getAttribute('aria-describedby');
+  expect(describedBy).toBe(errorId);
+  await expect(select).toHaveAttribute('aria-invalid', 'true');
+});
+
+test('integrated email field shows hint until an error replaces it', async ({ page }) => {
+  await page.goto('/#/rhf-spike-integrated');
+
+  await expect(page.getByText('We never share your email.')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(page.getByText('We never share your email.')).not.toBeVisible();
+  await expect(page.getByRole('alert').filter({ hasText: 'Email is required' })).toBeVisible();
+});
+
+test('integrated email field validates pattern', async ({ page }) => {
+  await page.goto('/#/rhf-spike-integrated');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('textbox', { name: 'Email' }).fill('not-an-email');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  await expect(
+    page.getByRole('alert').filter({ hasText: 'Enter a valid email address' })
+  ).toBeVisible();
+});
+
+test('integrated happy-path submit records correct payload', async ({ page }) => {
+  await page.goto('/#/rhf-spike-integrated');
+
+  await page.getByRole('textbox', { name: 'Name' }).fill('Alice');
+  await page.getByRole('combobox').selectOption('green');
+  await page.getByRole('textbox', { name: 'Email' }).fill('alice@example.com');
+  await page.getByRole('button', { name: 'Submit' }).click();
+
+  const submitted = page.getByTestId('submitted');
+  await expect(submitted).toBeVisible();
+  const text = await submitted.textContent();
+  const payload = JSON.parse(text ?? '{}');
+  expect(payload.name).toBe('Alice');
+  expect(payload.colour).toBe('green');
+  expect(payload.email).toBe('alice@example.com');
+});
+
+test('integrated name field shows error on blur after touch without submit', async ({ page }) => {
+  await page.goto('/#/rhf-spike-integrated');
+
+  await page.getByRole('textbox', { name: 'Name' }).focus();
+  await page.getByRole('textbox', { name: 'Name' }).blur();
+
+  await expect(page.getByRole('alert').filter({ hasText: 'Name is required' })).toBeVisible();
+});
+
+test('integrated catalog entry links to the page', async ({ page }) => {
+  await page.goto('/#/');
+
+  const link = page.getByRole('link', { name: /React Hook Form \(Integrated\)/ });
+  await expect(link).toBeVisible();
+  await link.click();
+
+  await expect(page.getByRole('heading', { name: 'React Hook Form (Integrated)' })).toBeVisible();
+});

--- a/packages/ui-lib/src/Form/atoms/Input.tsx
+++ b/packages/ui-lib/src/Form/atoms/Input.tsx
@@ -1,4 +1,5 @@
-import type { InputHTMLAttributes, Ref } from 'react';
+import { type InputHTMLAttributes, type Ref, useId } from 'react';
+import { type RegisterOptions, useController, useFormContext } from 'react-hook-form';
 import styled, { css } from 'styled-components';
 import { removeAutoFillStyle } from '../../common';
 import Icon, { IconWrapper } from '../../Icons/Icon';
@@ -172,6 +173,8 @@ interface OwnProps {
   hint?: string;
   required?: boolean;
   ref?: Ref<HTMLInputElement>;
+  // Integrated mode — when wrapped in <FormProvider> with `name` set, Input subscribes to RHF.
+  rules?: RegisterOptions;
 }
 
 export type InputProps = OwnProps & InputHTMLAttributes<HTMLInputElement>;
@@ -193,7 +196,7 @@ const feedbackIcon = (fieldState: TypeFieldState) => {
   }
 };
 
-function Input({
+const StandaloneInput = ({
   type = 'text',
   placeholder = '',
   defaultValue,
@@ -210,8 +213,9 @@ function Input({
   hint,
   required,
   ref,
+  rules: _rules,
   ...props
-}: InputProps) {
+}: InputProps) => {
   const isActionButton = actionCallback !== undefined;
   const isNative = label !== undefined;
   const hasError = Boolean(error);
@@ -278,6 +282,42 @@ function Input({
       ) : null}
     </FieldWrapper>
   );
-}
+};
+
+const IntegratedInput = (props: InputProps) => {
+  const { name, rules, defaultValue, id, error, ...rest } = props;
+  const { field, fieldState } = useController({
+    // biome-ignore lint/style/noNonNullAssertion: dispatcher guarantees name is set
+    name: name!,
+    rules,
+    // biome-ignore lint/suspicious/noExplicitAny: per-field default flows into RHF's typed store
+    defaultValue: defaultValue as any,
+  });
+  const autoId = useId();
+  const fieldId = (id as string | undefined) ?? autoId;
+
+  return (
+    <StandaloneInput
+      {...rest}
+      ref={field.ref}
+      name={field.name}
+      value={field.value ?? ''}
+      onChange={field.onChange}
+      onBlur={field.onBlur}
+      id={fieldId}
+      error={error ?? fieldState.error?.message}
+    />
+  );
+};
+
+const Input = (props: InputProps) => {
+  const formContext = useFormContext();
+  // Integrated mode is opt-in: name set inside a FormProvider AND consumer is not
+  // managing value externally. When `value` is present the consumer is doing their
+  // own wiring (rounds 1 and 2), so stay on the standalone path.
+  const isIntegrated =
+    formContext !== null && props.name !== undefined && props.value === undefined;
+  return isIntegrated ? <IntegratedInput {...props} /> : <StandaloneInput {...props} />;
+};
 
 export default Input;

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
-import { type Ref, type SelectHTMLAttributes, useCallback, useState } from 'react';
+import { type Ref, type SelectHTMLAttributes, useCallback, useId, useState } from 'react';
+import { type RegisterOptions, useController, useFormContext } from 'react-hook-form';
 import styled, { css } from 'styled-components';
 import Icon from '../../Icons/Icon';
 import type { TypeFieldState, TypeLabelDirection } from '..';
@@ -117,7 +118,8 @@ interface ILabel {
 
 interface OwnProps {
   fieldState?: TypeFieldState;
-  label?: ILabel;
+  // Integrated mode accepts a flat string; standalone keeps the ILabel shape.
+  label?: ILabel | string;
   isCompact?: boolean;
   placeholder?: string;
   icon?: string;
@@ -125,12 +127,16 @@ interface OwnProps {
   // Native mode props — when `error` or `hint` is set, SelectField renders its own error/hint shell.
   error?: string;
   hint?: string;
+  required?: boolean;
   ref?: Ref<HTMLSelectElement>;
+  // Integrated mode — when wrapped in <FormProvider> with `name` set, SelectField subscribes to RHF.
+  rules?: RegisterOptions;
+  options?: Array<{ value: string; label: string }>;
 }
 
 type ISelect = OwnProps & SelectHTMLAttributes<HTMLSelectElement>;
 
-function SelectField({
+const StandaloneSelectField = ({
   fieldState = 'default',
   placeholder,
   label,
@@ -144,9 +150,14 @@ function SelectField({
   error,
   hint,
   ref,
+  required: _required,
+  rules: _rules,
+  options: _options,
   ...props
-}: ISelect) {
-  if (label?.isSameRow) {
+}: ISelect) => {
+  const labelObj = typeof label === 'object' ? label : undefined;
+
+  if (labelObj?.isSameRow) {
     console.warn(
       'Deprecation warning: `SelectField` is deprecating `label.isSameRow`, please update this to use `label.direction` set to `row`.'
     );
@@ -157,7 +168,7 @@ function SelectField({
   const hasError = Boolean(error);
   const isNative = hasError || Boolean(hint);
   const effectiveFieldState: TypeFieldState = hasError ? 'invalid' : fieldState;
-  const fieldId = label?.htmlFor ?? props.id ?? props.name;
+  const fieldId = labelObj?.htmlFor ?? props.id ?? props.name;
   const errorId = fieldId ? `${fieldId}-error` : undefined;
   const hintId = fieldId && hint ? `${fieldId}-hint` : undefined;
   const describedBy = hasError ? errorId : hintId;
@@ -249,14 +260,14 @@ function SelectField({
 
   const container = (
     <Container $isCompact={isCompact} $activePlaceholder={activePlaceholder}>
-      {label ? (
+      {labelObj ? (
         <Label
-          htmlFor={label.htmlFor}
-          labelText={label.text}
-          direction={label.isSameRow ? 'row' : label.direction}
-          required={label.required}
+          htmlFor={labelObj.htmlFor}
+          labelText={labelObj.text}
+          direction={labelObj.isSameRow ? 'row' : labelObj.direction}
+          required={labelObj.required}
         >
-          {renderSelect(label.htmlFor)}
+          {renderSelect(labelObj.htmlFor)}
         </Label>
       ) : (
         renderSelect()
@@ -279,6 +290,56 @@ function SelectField({
       ) : null}
     </FieldWrapper>
   );
-}
+};
+
+const IntegratedSelectField = (props: ISelect) => {
+  const { name, rules, defaultValue, id, label, error, required, options, ...rest } = props;
+  const { field, fieldState } = useController({
+    // biome-ignore lint/style/noNonNullAssertion: dispatcher guarantees name is set
+    name: name!,
+    rules,
+    // biome-ignore lint/suspicious/noExplicitAny: per-field default flows into RHF's typed store
+    defaultValue: defaultValue as any,
+  });
+  const autoId = useId();
+  const fieldId = (id as string | undefined) ?? autoId;
+
+  const standaloneLabel: ILabel | undefined =
+    typeof label === 'string'
+      ? { htmlFor: fieldId, text: label, required }
+      : (label as ILabel | undefined);
+
+  return (
+    <StandaloneSelectField
+      {...rest}
+      ref={field.ref}
+      name={field.name}
+      value={field.value ?? ''}
+      onChange={field.onChange}
+      onBlur={field.onBlur}
+      id={fieldId}
+      label={standaloneLabel}
+      error={error ?? fieldState.error?.message}
+    >
+      {options
+        ? options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))
+        : null}
+    </StandaloneSelectField>
+  );
+};
+
+const SelectField = (props: ISelect) => {
+  const formContext = useFormContext();
+  // Integrated mode is opt-in: name set inside a FormProvider AND consumer is not
+  // managing value externally. When `value` is present the consumer is doing their
+  // own wiring (rounds 1 and 2), so stay on the standalone path.
+  const isIntegrated =
+    formContext !== null && props.name !== undefined && props.value === undefined;
+  return isIntegrated ? <IntegratedSelectField {...props} /> : <StandaloneSelectField {...props} />;
+};
 
 export default SelectField;


### PR DESCRIPTION
## Description

This PR lands the **React Hook Form (RHF) integration PoC** for `scorer-ui-kit` across three iterative research rounds, plus a small CI fix and a formatter sweep that landed during the spike. It is a **research / spike PR**: the goal is to validate how RHF could be wired into the existing form atoms (`Input`, `SelectField`, `Checkbox`, `RadioButton`) and to compare three integration styles side-by-side before committing to one as the official UI Kit direction.

### Source of documentation

Three findings reports are committed alongside the code and act as the design memo for each round:

- `rhf-spike-report.md` — Round 1 spike synthesis (FormField molecule).
- `findings-native-atoms.md` — Round 2 per-component change log, awkward parts, a11y notes, sanity-sweep results, recommendations.
- `findings-integrated-rhf.md` — Round 3 React Hook Form integrated to core components.

### TL;DR

The potential outcome is expected to be one of the following:

```
1. UI Kit v3 can work well with React Hook Form with none or minimal changes.
2. UI Kit v3 would need significant breaking changes but could be pushed to work.
3. New components are needed so this work will inform the new UI Kit version work and first targets. (this is what is expected, though we may be surprised)
```

#### Outcome is number 1 - UI Kit v3 can work well with React Hook Form with none or minimal changes.

Each iteration only represents a different place to put the React Hook Form wiring:

Iteration 1 - <Controller /> at the FormField wrapper layer
Iteration 2 - <Controller /> at the consumer level
Iteration 3 - <Controller /> inside the atoms

## Considerations on Implementation

Areas where reviewer attention would be most valuable:

- **Round 3 dispatcher rule on `Input` / `SelectField`.** `isIntegrated = formContext !== null && props.name !== undefined && props.value === undefined`. The `props.value === undefined` clause is what protects rounds 1 / 2 (and any other consumer doing their own controlled wiring) from being silently hijacked by RHF when they happen to be rendered inside a `<FormProvider>`. Worth a careful read — this is the backward-compat contract.
- **`React.forwardRef` removal.** Both atoms drop `forwardRef` and use `ref` as a regular prop (React 19). A repo-wide sanity sweep is documented in `findings-native-atoms.md`; reviewer may want to confirm no external consumer of the published package relies on the `displayName` that was dropped.
- **`Checkbox` controlled mode.** New `controlled` prop bypasses the internal `useState` and treats `checked` as authoritative — needed for RHF integration to avoid stale-state fights, but it changes the contract for any caller that opts in. Default remains uncontrolled, so existing usage is unaffected.
- **`SelectField` `label` prop is now `ILabel | string`.** Standalone callers still pass the object shape; integrated mode accepts a flat string and synthesises the `ILabel` internally. Worth a quick check that the union doesn't trip downstream TS consumers.
- **`SelectField` ArrowDown handler** (in the accessibility-fix commit) advances past the disabled placeholder option and dispatches a synthetic `change` event. Bears watching if any consumer attaches their own `onKeyDown`; the new handler defers to a caller-provided `onKeyDown` first and only acts if `e.defaultPrevented` is false.
- **`react-hook-form` added to ui-lib `peerDependencies`** and externalised in `vite.config.ts`. Consumers that don't use RHF won't pay the bundle cost, but they will see a new peer-dep warning at install — confirm this is acceptable as a v2.x addition.
- **PoC scope, not production scope.** The three demo pages and reports are intended to ship in the repo as the artifact of the spike; they are not consumer-facing routes in any real deployment. If the team prefers them moved out of `example/`, that should be a follow-up.

## Reviewing/Testing steps

### Pre-merge verification

| Check                                                       |  Result   |
|-------------------------------------------------------------|:---------:|
| Lint (`biome check`)                                         | ✅ PASS  |
| Type-check / build (`tsc`, `vite build`)                     | ✅ PASS  |
| Unit / integration tests                                     | ⏭️ N/A   |
| Playwright e2e — round 1 (`rhf-spike.spec.ts`, 14 tests)      | ✅ PASS  |
| Playwright e2e — round 1 keyboard (`rhf-spike-keyboard.spec.ts`) | ✅ PASS  |
| Playwright e2e — round 2 native atoms (`rhf-spike-native.spec.ts`, 8 tests) | ✅ PASS  |
| Playwright e2e — round 3 integrated (`rhf-spike-integrated.spec.ts`, 8 tests) | ✅ PASS  |
| Manual smoke test of `/rhf-spike`, `/rhf-spike-native`, `/rhf-spike-integrated` | ✅ PASS  |
| Console / log clean of new warnings                          | ✅ PASS  |
| Sweep script against live PR preview (86 pages, 0 errors)    | ✅ PASS  |
| `forwardRef` / `defaultProps` / `propTypes` / `UNSAFE_` sanity sweep | ✅ PASS  |
| Docker / deploy artifact builds                              | ⏭️ N/A   |

### Detailed steps to reproduce

**Setup**

```bash
nvm use            # repo's .nvmrc
npm ci             # install at repo root (workspaces)
```

No env vars or external services required.

**Reproduction**

Run each check the table claims:

```bash
# Lint + format + organize-imports (matches CI)
npm run check

# Type-check + library build
npm run build

# Playwright e2e — runs all four suites against the example app on :3101
cd packages/example
npm run test:e2e
```

To exercise the three integration styles by hand:

```bash
# From repo root
npm start
# then visit:
#   http://localhost:3000/rhf-spike              (round 1 — FormField molecule)
#   http://localhost:3000/rhf-spike-native       (round 2 — native label/error on atoms)
#   http://localhost:3000/rhf-spike-integrated   (round 3 — RHF baked into atoms)
```

For each demo page:

1. Click **Submit** with empty fields → required-validation errors render under each field, `aria-invalid="true"` is set, and the focused field receives `aria-describedby` pointing at the error id.
2. Type an invalid email → on blur (`mode: 'onTouched'`), the email-pattern message shows; correcting the value clears it.
3. (Round 1 only) Tab through the form keyboard-only, including the radio group and checkbox group, and submit — focus should be visible at each step and `field.onBlur` should fire (validated by the keyboard suite).
4. With all valid input, **Submit** renders a `<pre data-testid="submitted">` block with the JSON payload.

Screenshot

<img width="1280" height="377" alt="Screenshot 2026-05-28 at 10 35 01" src="https://github.com/user-attachments/assets/4f28e184-5285-4a3b-b4b3-68bb45054139" />
