### PR TITLE
fix(DatePicker): exhaustive-deps + duplicate weekday keys (#644, #659)

### DIFF
--- a/packages/storybook/src/stories/Form/SelectField.stories.tsx
+++ b/packages/storybook/src/stories/Form/SelectField.stories.tsx
@@ -66,7 +66,7 @@ export const _SelectField = () => {
   const fixLabel = object('Fix Select Label', {
     htmlFor: 'fix_select',
     text: 'Page',
-    isSameRow: true,
+    direction: 'row' as const,
   });
 
   const freeOnChange = (value: string) => {

--- a/packages/ui-lib/src/Filters/atoms/DateTimeBlock.tsx
+++ b/packages/ui-lib/src/Filters/atoms/DateTimeBlock.tsx
@@ -111,6 +111,65 @@ interface IProps {
   isTimeRangeValid?: boolean;
 }
 
+/**
+ *
+ * Description of the rules can be found int https://docs.google.com/spreadsheets/d/1POe9uZxKXtLhQFF6DIV-RclUp7T7oXgSeSLlbYmE38g/edit?usp=sharing
+ */
+const validHourMin = (
+  textHour: string,
+  textMin: string,
+  hasDate: boolean,
+  allowAfterMidnight?: boolean
+): { newHour: number; newMin: number } => {
+  const intHour = Number(textHour.slice(-2));
+  const intMin = Number(textMin.slice(-2));
+
+  const newHour = intHour > 24 ? Number(textHour.slice(-1)) : intHour;
+  const newMin = intMin > 60 ? Number(textMin.slice(-1)) : intMin;
+
+  //Rule 8
+  if (newHour >= 24 && newMin !== -1 && allowAfterMidnight) {
+    return { newHour: 24, newMin: 0 };
+  }
+
+  // Rule 7
+  if (newHour === 0 && newMin === 0 && allowAfterMidnight && !hasDate) {
+    return { newHour: 0, newMin: 1 };
+  }
+
+  // Rule 6
+  if (newHour === 23 && newMin === 60 && !allowAfterMidnight) {
+    return { newHour: 23, newMin: 59 };
+  }
+
+  // Rule 5
+  if (newHour >= 24 && !allowAfterMidnight) {
+    return { newHour: 23, newMin };
+  }
+
+  // Rule 4
+  if (newMin === 60) {
+    return { newHour: newHour + 1, newMin: 0 };
+  }
+
+  // Rule 3
+  if (newHour > 0 && newMin === -1) {
+    return { newHour: newHour - 1, newMin: 59 };
+  }
+
+  // Rule 2
+  if (newHour === 0 && newMin === -1) {
+    return { newHour, newMin: 0 };
+  }
+
+  // Rule 1
+  if (newHour === -1) {
+    return { newHour: 0, newMin };
+  }
+
+  return { newHour, newMin };
+};
+
 const DateTimeBlock: React.FC<IProps> = ({
   allowAfterMidnight = false,
   title,
@@ -120,65 +179,6 @@ const DateTimeBlock: React.FC<IProps> = ({
   date = new Date(),
   setDateCallback = () => {},
 }) => {
-  /**
-   *
-   * Description of the rules can be found int https://docs.google.com/spreadsheets/d/1POe9uZxKXtLhQFF6DIV-RclUp7T7oXgSeSLlbYmE38g/edit?usp=sharing
-   */
-  const validHourMin = (
-    textHour: string,
-    textMin: string,
-    hasDate: boolean,
-    allowAfterMidnight?: boolean
-  ): { newHour: number; newMin: number } => {
-    const intHour = Number(textHour.slice(-2));
-    const intMin = Number(textMin.slice(-2));
-
-    const newHour = intHour > 24 ? Number(textHour.slice(-1)) : intHour;
-    const newMin = intMin > 60 ? Number(textMin.slice(-1)) : intMin;
-
-    //Rule 8
-    if (newHour >= 24 && newMin !== -1 && allowAfterMidnight) {
-      return { newHour: 24, newMin: 0 };
-    }
-
-    // Rule 7
-    if (newHour === 0 && newMin === 0 && allowAfterMidnight && !hasDate) {
-      return { newHour: 0, newMin: 1 };
-    }
-
-    // Rule 6
-    if (newHour === 23 && newMin === 60 && !allowAfterMidnight) {
-      return { newHour: 23, newMin: 59 };
-    }
-
-    // Rule 5
-    if (newHour >= 24 && !allowAfterMidnight) {
-      return { newHour: 23, newMin };
-    }
-
-    // Rule 4
-    if (newMin === 60) {
-      return { newHour: newHour + 1, newMin: 0 };
-    }
-
-    // Rule 3
-    if (newHour > 0 && newMin === -1) {
-      return { newHour: newHour - 1, newMin: 59 };
-    }
-
-    // Rule 2
-    if (newHour === 0 && newMin === -1) {
-      return { newHour, newMin: 0 };
-    }
-
-    // Rule 1
-    if (newHour === -1) {
-      return { newHour: 0, newMin };
-    }
-
-    return { newHour, newMin };
-  };
-
   const [displayHours, setDisplayHours] = useState<string>(format(date, 'mm'));
   const [displayMinutes, setDisplayMinutes] = useState<string>(format(date, 'HH'));
 
@@ -202,8 +202,7 @@ const DateTimeBlock: React.FC<IProps> = ({
         ])
       );
     },
-    // biome-ignore lint/correctness/useExhaustiveDependencies: validHourMin is declared inline, so its identity changes every render — fixing properly means wrapping it in useCallback. See #644.
-    [allowAfterMidnight, date, displayMinutes, hasDate, setDateCallback, validHourMin]
+    [allowAfterMidnight, date, displayMinutes, hasDate, setDateCallback]
   );
 
   const setDateMinutes = useCallback(
@@ -226,8 +225,7 @@ const DateTimeBlock: React.FC<IProps> = ({
         ])
       );
     },
-    // biome-ignore lint/correctness/useExhaustiveDependencies: validHourMin is declared inline, so its identity changes every render — fixing properly means wrapping it in useCallback. See #644.
-    [allowAfterMidnight, date, displayHours, hasDate, setDateCallback, validHourMin]
+    [allowAfterMidnight, date, displayHours, hasDate, setDateCallback]
   );
 
   useEffect(() => {

--- a/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
+++ b/packages/ui-lib/src/Filters/molecules/DatePicker.tsx
@@ -378,9 +378,30 @@ const CalCellB = styled(CalCell)<{ $thisMonth?: boolean; $isToday?: boolean; $st
 
 `;
 
-const enDayGuide: string[] = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+interface IDayGuide {
+  key: string;
+  label: string;
+}
 
-const jpDayGuide: string[] = ['日', '月', '火', '水', '木', '金', '土'];
+const enDayGuide: IDayGuide[] = [
+  { key: 'sun', label: 'S' },
+  { key: 'mon', label: 'M' },
+  { key: 'tue', label: 'T' },
+  { key: 'wed', label: 'W' },
+  { key: 'thu', label: 'T' },
+  { key: 'fri', label: 'F' },
+  { key: 'sat', label: 'S' },
+];
+
+const jpDayGuide: IDayGuide[] = [
+  { key: 'sun', label: '日' },
+  { key: 'mon', label: '月' },
+  { key: 'tue', label: '火' },
+  { key: 'wed', label: '水' },
+  { key: 'thu', label: '木' },
+  { key: 'fri', label: '金' },
+  { key: 'sat', label: '土' },
+];
 
 export interface IDatePicker {
   initialValue?: Date | IDateInterval;
@@ -600,8 +621,8 @@ const DatePicker: React.FC<IDatePicker> = ({
         </CalendarHeader>
 
         <CalHRow>
-          {dayGuide.map((day) => {
-            return <CalHCell key={day}>{day}</CalHCell>;
+          {dayGuide.map(({ key, label }) => {
+            return <CalHCell key={key}>{label}</CalHCell>;
           })}
         </CalHRow>
 

--- a/packages/ui-lib/src/Form/atoms/SelectField.tsx
+++ b/packages/ui-lib/src/Form/atoms/SelectField.tsx
@@ -166,47 +166,33 @@ const SelectField: React.FC<ISelect> = ({
     }
   }, [fieldState, props.disabled]);
 
-  const renderSelect = useCallback(
-    (htmlFor?: string) => (
-      <SelectWrapper>
-        {icon && (
-          <SubjectIcon $isCompact={isCompact}>
-            <Icon icon={icon} color={iconColor()} size={isCompact ? 12 : 12} weight='regular' />
-          </SubjectIcon>
+  const renderSelect = (htmlFor?: string) => (
+    <SelectWrapper>
+      {icon && (
+        <SubjectIcon $isCompact={isCompact}>
+          <Icon icon={icon} color={iconColor()} size={isCompact ? 12 : 12} weight='regular' />
+        </SubjectIcon>
+      )}
+      <StyledSelect
+        $withIcon={!!icon}
+        id={htmlFor}
+        $fieldState={fieldState}
+        $isCompact={isCompact}
+        {...props}
+        {...(props.value === undefined ? { defaultValue: defaultValue ?? '' } : {})}
+        onChange={handleOnChange}
+      >
+        {!defaultValue && (
+          <option value='' disabled hidden>
+            {placeholder}
+          </option>
         )}
-        <StyledSelect
-          $withIcon={!!icon}
-          id={htmlFor}
-          $fieldState={fieldState}
-          $isCompact={isCompact}
-          {...props}
-          {...(props.value === undefined ? { defaultValue: defaultValue ?? '' } : {})}
-          onChange={handleOnChange}
-        >
-          {!defaultValue && (
-            <option value='' disabled hidden>
-              {placeholder}
-            </option>
-          )}
-          {children}
-        </StyledSelect>
-        <OpenIcon $isCompact={isCompact}>
-          <Icon icon='Down' color={iconColor()} weight='regular' size={isCompact ? 8 : 10} />
-        </OpenIcon>
-      </SelectWrapper>
-    ),
-    [
-      children,
-      defaultValue,
-      handleOnChange,
-      placeholder,
-      // biome-ignore lint/correctness/useExhaustiveDependencies: props is the rest object from the destructuring of OwnProps & SelectHTMLAttributes — its identity changes every render. Stabilising requires an API change to forward props explicitly. See #644.
-      props,
-      fieldState,
-      icon,
-      iconColor,
-      isCompact,
-    ]
+        {children}
+      </StyledSelect>
+      <OpenIcon $isCompact={isCompact}>
+        <Icon icon='Down' color={iconColor()} weight='regular' size={isCompact ? 8 : 10} />
+      </OpenIcon>
+    </SelectWrapper>
   );
 
   return (


### PR DESCRIPTION
## Description

This PR bundles two small, self-contained **bug fixes** in the Filters/Form atoms that each clear React/Biome warnings surfaced during recent migration and sweep work, plus a related Storybook cleanup that drops a deprecated prop usage. There is no change to public component APIs and no change to rendered behavior — all three are correctness/cleanliness changes.

**What this PR does**

1. **Removes the three deferred `useExhaustiveDependencies` suppressions** from the Biome migration (PR #636) — `fixes #644`.
   - `DateTimeBlock.tsx`: `validHourMin` was declared inline in the component body, so its identity changed every render. Listing it in the `setDateHours` / `setDateMinutes` dependency arrays defeated `useCallback`. Because the function captures **no** closure variables, it is hoisted to module scope, giving it a stable identity, and removed from both deps arrays — the two callbacks now genuinely memoize.
   - `SelectField.tsx`: `renderSelect` was wrapped in `useCallback` whose `props` dependency is the rest object from destructuring, rebuilt on every render — so the cache never held. `renderSelect` is called once per render, so it is converted to a plain inline function (equivalent, no memo needed).
   - All three `biome-ignore` comments are removed.

2. **Fixes duplicate React keys in the DatePicker weekday header row** — `fixes #659`.
   - The weekday guide rendered `<CalHCell key={day}>` using the label as the key, but labels repeat within a week (EN: `S`/`S` for Sun+Sat, `T`/`T` for Tue+Thu), producing React duplicate-key warnings. Each guide entry is now modeled as `IDayGuide { key, label }` with stable unique day keys (`sun…sat`); cells are keyed on `key` and render `label`.

3. **Migrates the SelectField story off the deprecated `label.isSameRow`** to `label.direction: 'row'`. The story set `isSameRow: true`, which tripped `SelectField`'s own deprecation `console.warn` on every render; the replacement API gives the same layout with no component change. This is a story-only cleanup (no public API change) that clears the warning we observed during verification.

**Type:** Bug fix (warning cleanup). **Not** a feature, no breaking changes.

**Documentation / background:** Issues #644 and #659 in the repo. The `useExhaustiveDependencies` deferrals originate from the Biome migration (#636); the duplicate-key warning was surfaced by the Storybook story sweep (#648).

## Considerations on Implementation

- `validHourMin` was verified to reference only its own parameters and JS built-ins (no component state/props), which is what makes the hoist safe and behavior-preserving. The date-validation rule logic itself is unchanged — only its scope moved.
- For `SelectField`, dropping `useCallback` is preferred over memoizing the `props` rest object (messy/fragile) or rewriting to explicit prop forwarding (an API-discipline change out of scope here). Since `renderSelect` is invoked exactly once per render, the memo provided no benefit.
- The SelectField story previously set the deprecated `label.isSameRow: true`, which tripped `SelectField`'s own `label.isSameRow` deprecation `console.warn` on every render. The story is migrated to the replacement API (`label.direction: 'row'`) — same layout, no component API change — which clears that warning from the story and the sweep. The deprecated `isSameRow` prop and its warning are left intact in the component for real consumers; removing them is a breaking change out of scope here.

## Reviewing/Testing steps

### Pre-merge verification

| Check                                                   |  Result   |
|---------------------------------------------------------|:---------:|
| Lint (`biome lint` on the two changed atoms)            | ✅ PASS   |
| Type-check (`tsc --noEmit` in `packages/ui-lib`)        | ✅ PASS   |
| Unit tests (`vitest run` in `packages/ui-lib`, 2/2)     | ✅ PASS   |
| Story sweep — all 69 stories clean (DatePicker incl.)   | ✅ PASS   |
| Story sweep — example routes `/`, `/line`               | ⚠️ PRE-EXISTING |
| Manual smoke test of the affected flows (Storybook)     | ✅ PASS   |
| Console / log clean of new warnings (Chrome DevTools)   | ✅ PASS   |
| All 3 `biome-ignore` suppressions removed               | ✅ PASS   |
| Docker / deploy artifact builds                         | ⏭️ N/A    |

### Testing strategy — why no bespoke component tests

This change deliberately adds **no new test files**; each issue is already guarded by existing infrastructure:

- **#659 (duplicate React keys)** is covered by `scripts/sweep-stories.mjs`, the headless-Chromium (Playwright) sweep that loads every story and fails on any `console.error` / `pageerror`. React emits duplicate keys as a `console.error`, so the DatePicker story (`filters-molecules--date-picker`) is flagged pre-fix and clean post-fix — this is the same harness that surfaced the warning. No per-component test adds signal it doesn't already provide.
  - **Sweep result (this branch):** all **69/69 stories clean**, including the DatePicker story. The run exits non-zero only on two **example-app routes unrelated to this PR** — `/` (`createRoot()` called twice on the same container, in the example's `src/index.tsx` under React 19 StrictMode/HMR) and `/line` (`removeChild` `NotFoundError` in `LinksPage`/LineUI). Neither touches the three files changed here; both are pre-existing example-app issues tracked separately.
- **#644 (exhaustive-deps)** is a Biome **lint** rule with no runtime signal, so it is guarded by `biome lint ./src` — the three `biome-ignore` suppressions are removed and lint is green.

> Note: `packages/ui-lib`'s `vitest` suite currently contains only an export smoke test (`Button`, `defaultTheme`); it does **not** cover these components. Behavioral confidence for the refactor comes from the story sweep plus the manual Storybook + Chrome DevTools pass below. The one piece not asserted by either is `validHourMin`'s clamping rules — its logic is unchanged by this PR (only its scope moved), so it is out of scope here and noted as a future unit-test candidate.

### Detailed steps to reproduce

**Setup**
- `npm install` (repo root)
- `npm start -w packages/ui-lib` (watch/rebuild the library)
- `npm start -w packages/storybook` (Storybook on `:9009`)

**Reproduction & expected outcome**

1. **DateTimeBlock (#644)** — open *Filters / molecules → Date Picker*.
   - Type into the hour/minute inputs of either time block.
   - Expected: each keystroke fires `setDateCallback` with correctly computed (clamped/valid) times per the existing rules, the display updates, and the console shows **no** `useExhaustiveDependencies` or React warnings.
2. **SelectField (#644)** — open *Form / atoms → Select Field*.
   - All three variants (free width, fixed width, with icon) render; choose an option in the first select.
   - Expected: value updates, placeholder clears (`handleOnChange` fires), no console warnings. (The `label.isSameRow` deprecation warning this story used to emit is gone now that it is migrated to `label.direction: 'row'`.)
3. **DatePicker weekday keys (#659)** — same Date Picker story, EN locale.
   - Expected: the `S M T W T F S` header renders once with **no** React "two children with the same key" warning in the console.

**Static checks**
```bash
# from repo root
npx biome lint packages/ui-lib/src/Filters/atoms/DateTimeBlock.tsx \
                packages/ui-lib/src/Form/atoms/SelectField.tsx   # clean
( cd packages/ui-lib && npx tsc --noEmit )                        # clean
grep -rc "biome-ignore" packages/ui-lib/src/Filters/atoms/DateTimeBlock.tsx \
                        packages/ui-lib/src/Form/atoms/SelectField.tsx  # 0, 0

# Regression guard for #659 (needs Storybook running on :9009)
node scripts/sweep-stories.mjs   # DatePicker story reports no console.error
```

**Visual evidence:** Storybook Date Picker and Select Field stories render and operate unchanged; Chrome DevTools console is free of React duplicate-key and exhaustive-deps warnings after the change.

---

**Closes #644, Closes #659.**

