### PR TITLE
fix(deps): 2026 Q2 security update (part 2) — qs, ws, lodash, yaml, brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3748,7 +3748,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4822,7 +4824,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6056,7 +6060,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8948,7 +8954,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6982,7 +6982,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Description

**What does this PR do?**
Clears outstanding `npm audit` advisories by bumping five dev-only transitive
dependencies in `package-lock.json` to their fixed versions. This is the
second part of the 2026 Q2 dependency-security work (follows PR #666 on `main`).

- `qs` 6.15.0 → 6.15.2 — moderate: `qs.stringify` DoS (TypeError on null/undefined entries in comma-format arrays)
- `ws` 8.19.0 → 8.21.0 — **high**: uninitialized memory disclosure + memory-exhaustion DoS from tiny fragments
- `lodash` 4.17.23 → 4.18.1 — **high**: code injection via `_.template`, prototype pollution via `_.unset`/`_.omit`
- `yaml` 1.10.2 → 1.10.3 — moderate: stack overflow on deeply nested collections (via `cosmiconfig`)
- `brace-expansion` 5.0.5 → 5.0.6 — moderate: large-numeric-range DoS that defeats the documented `max` protection (via `glob`)

Result: **`npm audit` 7 → 2** (the 2 remaining are low/dev-only — see Considerations).

**Is this a feature or bug fix?**
Security maintenance (dependency fix). No application code changes; lockfile only.

**Source of documentation:**
Each bump corresponds to a published GitHub Security Advisory (GHSA) for the
package; versions and integrity hashes were verified against the npm registry.

**Background context:**
The equivalent Dependabot PRs (e.g. #654 for `qs`) were not used because, on
this repo's dependency tree, Dependabot's regenerated lockfile **re-idealises
the tree and downgrades the root `react` 19.2.5 → 18.3.1**. That produces a
dual-React `Cannot read properties of null (reading 'useState')` runtime crash
which fails the story sweep. This PR instead edits only the affected lockfile
nodes, so React is untouched.

## Considerations on Implementation

- **Lockfile-only, surgical edits.** Each change touches a single hoisted
  install node (version + the previously-missing `resolved`/`integrity`
  fields). No `package.json` change; no `peerDependencies` change. The bumps
  were applied by hand rather than via `npm update` / `npm audit fix`,
  because those commands re-resolve the whole tree and reintroduce the
  React 18 downgrade described above.
- **No React drift.** After the change, `react` is still a single
  `19.2.5` at the root — explicitly verified.
- **Authenticity.** Every added `integrity` hash matches the hash served by
  `registry.npmjs.org` for that exact version.
- **All targets are `dev`-only transitive deps** (build/storybook tooling),
  so there is no change to the published `scorer-ui-kit` runtime or its
  consumer contract.
- **Two low advisories intentionally deferred** (not worth the risk for a
  low, dev-only issue):
  - `@babel/core` — the only version above the affected `<=7.29.0` is
    **8.0.0 (semver-major)**; a Babel 8 bump risks breaking the build.
  - `esbuild` — the fix requires updating multiple nodes plus their
    `@esbuild/*` platform-binary packages; low severity (Windows-only
    dev-server file read).

**No breaking changes.** All fixed versions satisfy their dependents'
declared ranges (`lodash ^4.17.21`, `ws ^8.x`, `yaml ^1.10.0`,
`brace-expansion ^5.x`, `qs ^6.11.1`).

## Reviewing/Testing steps

### Pre-merge verification

| Check                                                   |  Result   |
|---------------------------------------------------------|:---------:|
| Lint (`npm run check` — Biome, 320 files)               | ✅ PASS  |
| Type-check (`tsc --noEmit`, ui-lib)                      | ✅ PASS  |
| Build (`vite build` — ui-lib / example / storybook)     | ✅ PASS  |
| Unit tests (`vitest run`, ui-lib — export smoke, 2 tests)| ✅ PASS  |
| Integration / e2e — story sweep (Playwright, 86 pages)  | ✅ PASS  |
| Console / log clean (sweep `console.error` = 0)         | ✅ PASS  |
| Deploy artifact builds (example + storybook)            | ✅ PASS  |
| `npm audit` (7 → 2; 0 critical/high/moderate)           | ✅ PASS  |
| React single-copy check (no dual-React drift)           | ✅ PASS  |
| Integrity hashes match npm registry                     | ✅ PASS  |

### Detailed steps to reproduce

**Setup**
```bash
git checkout feature/dependencies-update-2026Q2-part-2
npm install            # reconciles node_modules to the edited lockfile
```

**Reproduction**
```bash
# Audit — expect 2 low (@babel/core, esbuild), 0 high/moderate/critical
npm audit

# No dual-React — expect a single root react@19.2.5
npm ls react

# Lint / types / unit / builds
npm run check
npm run test:types -w packages/ui-lib
npm run test:unit -w packages/ui-lib    # vitest — export smoke test
npm run build -w packages/ui-lib
npm run build -w packages/example
npm run build-storybook -w packages/storybook

# Story sweep (needs the dev servers running)
npm run start:storybook &   # http://localhost:9009
npm run start:example &     # http://localhost:3000/scorer-ui-kit
EXAMPLE_URL="http://localhost:3000/scorer-ui-kit" STORYBOOK_URL="http://localhost:9009" \
  npm run sweep
```

**Expected outcome**
- `npm audit` → `2 low severity vulnerabilities` (`@babel/core`, `esbuild`), nothing higher.
- `npm ls react` → a single `react@19.2.5` (no `react@18.x`).
- Lint / type-check / all three builds exit `0`.
- Story sweep → `Total: 86 | With errors: 0 | Timed out: 0 | Loop suspect: 0`,
  and the `/` page renders with no `useState` error (the failure mode of
  Dependabot PR #654).

**Visual evidence** — N/A (tooling/lockfile change, no UI change). Evidence is
the sweep summary line and `npm audit` output above.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
