### PR TITLE
Release v3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "ISC",
       "workspaces": [
         "packages/storybook",
@@ -9956,7 +9956,7 @@
     },
     "packages/ui-lib": {
       "name": "scorer-ui-kit",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@future-standard/icons": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "This project is a ui library with an example project of use cases and storybook to showcase the components",
   "main": "index.js",
   "scripts": {

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorer-ui-kit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "SCORER UI Components",
   "author": "Josh Lipps",
   "license": "MIT",


### PR DESCRIPTION
**Fixes**

- **DatePicker:** Fixed duplicate React keys in the weekday header row. Repeated weekday labels (for example `S` for Sunday and Saturday) no longer trigger React "two children with the same key" warnings; each weekday cell now uses a stable, unique key. [PR #668](https://github.com/future-standard/scorer-ui-kit/pull/668)

**Dependencies**

- **react-router / react-router-dom:** Raised the `peerDependencies` floor from `^7.0.0` to `^7.18.0` so the patched, security-fixed versions are required. This is a `package.json`-only change for consumers — no code change is needed. Apps on `react-router` below `7.18.0` will see a peer-range warning and should update to `7.18.0` or later. [PR #666](https://github.com/future-standard/scorer-ui-kit/pull/666)
- Applied the 2026 Q2 security maintenance across the build and tooling dependencies, clearing all critical and high `npm audit` advisories. These are dev/build-time dependencies only and are not part of the published package. [PR #666](https://github.com/future-standard/scorer-ui-kit/pull/666), [PR #669](https://github.com/future-standard/scorer-ui-kit/pull/669)
