### PR TITLE
npm OIDC trusted publishing (drop NPM_TOKEN for stable)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,16 @@ jobs:
       # npm >= 11.5.1 (bundled with Node 24) performs the OIDC token exchange
       # automatically. `prepublishOnly` runs the build; provenance is generated
       # automatically for this public repo + public package.
-      - run: npm publish -w packages/ui-lib
+      #
+      # The version guard keeps re-runs idempotent: native `npm publish` errors
+      # (EPUBLISHCONFLICT) when the version already exists, whereas the previous
+      # JS-DevTools/npm-publish action skipped silently. Re-running a tag that is
+      # already published is therefore a no-op success, not a red run.
+      - name: Publish to npm (skip if version already on registry)
+        run: |
+          VERSION=$(node -p "require('./packages/ui-lib/package.json').version")
+          if [ -n "$(npm view "scorer-ui-kit@${VERSION}" version 2>/dev/null)" ]; then
+            echo "scorer-ui-kit@${VERSION} is already published; skipping publish."
+            exit 0
+          fi
+          npm publish -w packages/ui-lib

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
+# OIDC trusted publishing: GitHub mints a short-lived id-token that npm verifies
+# against the trusted publisher configured for `scorer-ui-kit` (this repo +
+# workflow filename). No long-lived NPM_TOKEN secret is used.
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   publish:
@@ -13,10 +19,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - uses: JS-DevTools/npm-publish@v4
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: ./packages/ui-lib/package.json
-          ignore-scripts: false
-          # dry-run: true
+      # npm >= 11.5.1 (bundled with Node 24) performs the OIDC token exchange
+      # automatically. `prepublishOnly` runs the build; provenance is generated
+      # automatically for this public repo + public package.
+      - run: npm publish -w packages/ui-lib


### PR DESCRIPTION
## Description

- **What does this PR do?** Migrates the **stable** npm publish workflow (`.github/workflows/publish.yml`) from a long-lived `NPM_TOKEN` secret to **npm OIDC trusted publishing**. GitHub mints a short-lived `id-token` for the run, and npm verifies it against a trusted publisher configured on the `scorer-ui-kit` package (this repo + the workflow filename `publish.yml`). Nothing reusable is stored, so there is no token to expire, leak, or be exfiltrated.
- **Feature or bug fix?** Security / supply-chain hardening for the release pipeline. It also resolves the immediate breakage: the `v3.0.1` publish failed with `E404` on `PUT https://registry.npmjs.org/scorer-ui-kit` because the stored `NPM_TOKEN` had expired.
- **Source of documentation:** npm [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) (OIDC trusted publishing, OSSF standard).
- **Background context:** The repo already follows a strict supply-chain policy (exact-pinned dependencies; see `AGENTS.md`). Removing the long-lived publish token is the natural next step. npm allows **one** trusted publisher per package, so the **beta** workflow (`publish-beta.yml`) is intentionally left on a token in this PR and handled in a follow-up (see below).

### Changes

- Added `permissions: id-token: write` (+ `contents: read`) so GitHub can issue the OIDC token.
- Added `registry-url: 'https://registry.npmjs.org'` to `actions/setup-node`.
- Replaced the token-based `JS-DevTools/npm-publish@v4` step with native `npm publish -w packages/ui-lib`. npm ≥ 11.5.1 (bundled with Node 24) performs the OIDC exchange automatically, runs `prepublishOnly` (the build), and generates **provenance** attestations (repo and package are both public).
- Added a **skip-if-version-exists guard** before publishing (an `npm view` check). This preserves the idempotent behavior that `JS-DevTools/npm-publish` provided: native `npm publish` errors with `EPUBLISHCONFLICT` when the version already exists, so without the guard, re-running an already-published release tag would turn the workflow red. With it, that re-run is a no-op success.
- `publish.yml` no longer references `secrets.NPM_TOKEN`.

## Considerations on Implementation

- **Maintainer action required before this can publish.** The matching trusted publisher must exist on npm: `scorer-ui-kit` → Settings → Trusted Publisher → GitHub Actions, org `future-standard`, repo `scorer-ui-kit`, workflow filename `publish.yml`, allowed action `npm publish` (no environment). **Done.** If a publish runs before this exists, it fails with an auth error and can simply be re-triggered.
- **Re-run idempotency was deliberately preserved.** Per review feedback: native `npm publish` is not idempotent (it fails if the version is already on the registry), unlike the action it replaces. The `npm view "scorer-ui-kit@<version>" version` guard restores the skip-on-conflict behavior, so re-running a release tag (which is part of this repo's recovery flow) stays green. `npm view` is a read on a public package and needs no auth, so it does not interfere with OIDC or provenance.
- **Tag re-point needed for `v3.0.1`.** The existing `v3.0.1` tag points at a commit that still has the old token-based workflow. After this merges, the tag is moved onto the merged commit (still version `3.0.1`) so the publish runs through the new OIDC workflow. Safe because `3.0.1` was never published and no GitHub Release is attached.
- **`NPM_TOKEN` is intentionally kept for now.** `publish-beta.yml` still uses it. Fully dropping tokens (and enabling npm's "require 2FA and disallow tokens") requires consolidating stable + beta into one workflow file, since only one trusted publisher (one filename) is allowed per package. Tracked as a follow-up PR.
- **Behavior parity.** The previous step used `ignore-scripts: false`; native `npm publish` runs lifecycle scripts by default, so `prepublishOnly` (build) still runs. Same published artifact, plus provenance.

## Reviewing/Testing steps

### Pre-merge verification

| Check                                                        | Result |
|--------------------------------------------------------------|:------:|
| Workflow YAML structure reviewed (keys, steps, permissions)  | ✅ PASS |
| Re-run idempotency guard (skip when version already published)| ✅ PASS — logic reviewed; `npm view` read needs no auth |
| Lint (Biome)                                                 | ⏭️ N/A — Biome does not lint GitHub Actions YAML |
| Type-check / build (`tsc`, `vite build`)                     | ⏭️ N/A — no source or build inputs changed |
| Unit / integration tests                                     | ⏭️ N/A — no application code paths affected |
| GitHub workflow-file validation (parsed on push to the PR)   | ✅ PASS — no "invalid workflow file" annotation |
| Trusted publisher configured on npm                          | ✅ PASS — configured (`future-standard/scorer-ui-kit`, `publish.yml`, `npm publish`) |
| Actual OIDC publish                                          | ⚠️ VERIFIED AT RELEASE — exercised when the `v3.0.1` tag is pushed; cannot run locally (needs OIDC on a GitHub-hosted runner) |

### Detailed steps to reproduce

**Setup**
- Configure the trusted publisher on npm (fields above) once.
- Merge this PR to `main`.

**Reproduction**
- Re-point the release tag onto the merged commit so the new workflow runs:
  ```bash
  git fetch origin main
  git tag -f v3.0.1 origin/main
  git push -f origin v3.0.1
  ```

**Expected outcome**
- The `NPM Publish` workflow runs for tag `v3.0.1`, authenticates via OIDC (no `NPM_TOKEN`), and publishes `scorer-ui-kit@3.0.1` to npm with `latest`.
- `npm view scorer-ui-kit version` → `3.0.1`.
- The npm package page shows a **provenance** attestation linking the build to this repo and the `publish.yml` workflow.
- Re-running the same tag afterwards logs "already published; skipping publish." and the workflow stays green.

**Visual evidence** — N/A (CI/tooling change). Evidence is the green `NPM Publish` run for `v3.0.1` and the published `3.0.1` version with provenance on npm.