### PR TITLE
Bump @future-standard/icons 3.0.0 -> 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1312,7 +1312,9 @@
       "license": "MIT"
     },
     "node_modules/@future-standard/icons": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@future-standard/icons/-/icons-3.0.1.tgz",
+      "integrity": "sha512-x21VnVsS2KMM+xG59Gf1KnMUTZLHU2h7hmR0L8A5yhi0NqQ0sD3cAsCQDucG7dOhFjqmy1id1a7AN1ceNpqQsw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -9959,7 +9961,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@future-standard/icons": "3.0.0",
+        "@future-standard/icons": "3.0.1",
         "date-fns": "4.4.0",
         "immutability-helper": "3.1.1",
         "lodash.debounce": "4.0.8",

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -98,7 +98,7 @@
     "dist"
   ],
   "dependencies": {
-    "@future-standard/icons": "3.0.0",
+    "@future-standard/icons": "3.0.1",
     "date-fns": "4.4.0",
     "immutability-helper": "3.1.1",
     "lodash.debounce": "4.0.8",


### PR DESCRIPTION
### Description

Bumps the pinned runtime dependency `@future-standard/icons` from **3.0.0 → 3.0.1** in `packages/ui-lib` (the only manifest that declares it; example/storybook consume it via workspace hoisting).

- **What/why:** 3.0.1 is a patch-level upstream release of the icons package (published 2026-07-13, now `latest` on the public npm registry). This is a maintenance dependency bump, not a feature/bug fix in the kit itself.
- **Files changed:** `packages/ui-lib/package.json` (the exact pin) and `package-lock.json` (regenerated via `npm install`; the icons node gains `resolved`/`integrity` and moves to 3.0.1). No other packages touched. Per the dependency policy, the pin is exact (no `^`/`~`).

### Considerations on Implementation

- **Low risk / non-breaking.** Between 3.0.0 and 3.0.1 the `peerDependencies` (`react ^16–19`) and the `exports`/`main`/`module`/`types` map are **identical**.
- **Icon-set diff:** both versions expose exactly **87 icons with an identical name set** — nothing added, removed, or renamed. The kit consumes only the `IconSVGs` named export (`packages/ui-lib/src/Icons/Icon.tsx`) and resolves icons dynamically with a `string`-typed `icon` prop, so there is no risk of dead `icon="..."` references. The 3.0.1 change is internal (SVG content/metadata).
- React stays a single deduped `19.2.5` (root `overrides`); the lockfile diff is limited to the icons node + the ui-lib mirror.
- The scorer-ui-kit version is intentionally **not** bumped here — that is handled separately by `/release` after this merges.

### Reviewing/Testing steps

Local verification (all green):
- `npm run check` — Biome lint + format ✓
- `npm run test:types -w packages/ui-lib` — `tsc --noEmit` ✓
- `npm test -w packages/ui-lib` — vitest export smoke + biome lint + `vite build` ✓
- `npm run sweep` against `npm run start:all` — **86 pages (69 stories + 17 example routes), 0 errors, no timeouts, no render loops** ✓

CI will also run the required `lint` check and the PR-preview story sweep automatically. Icon rendering can be reviewed on the PR-preview Storybook (`Misc/Icons` grid, `StatusIcon`, `ButtonWithIcons`, `TabsWithIconBar`, `TabWithIcon`).
