### PR TITLE
TopBar: left-area content, controlled drawers & side drawers

### DIFF
--- a/COMPONENT_INVENTORY.md
+++ b/COMPONENT_INVENTORY.md
@@ -842,8 +842,13 @@ This document provides a comprehensive inventory of all React components in the 
     - `notificationsHistory?`: `INotificationsHistory` - Notifications data
       - **INotificationsHistory:** `{ read: INotificationItem[], unread: INotificationItem[], noNotificationsText?: string, readNotificationsText?: string, unreadNotificationsText?: string }`
       - **INotificationItem:** `{ imgUrl?: string, title: string, message: string, time: string }`
-    - `customDrawer?`: `ICustomDrawer` - Custom drawer configuration
+    - `customDrawer?`: `ICustomDrawer` - Custom drawer configuration (icon-triggered)
       - **ICustomDrawer:** `{ customComponent: ReactElement, icon: string, status?: IStatusDot, counter?: number, width?: string, maxCounter?: number }`
+    - `sideDrawers?`: `ISideDrawer[]` - Extra drawers with no top-bar toggle, opened via `activeDrawer` by id (desktop `TopBar` only; not supported by `GlobalUI` on mobile)
+      - **ISideDrawer:** `{ id: string, content: ReactElement, width?: string }`
+    - `leftAreaElement?`: `ReactElement` - Custom content for the left area; rendered only when `hasSearch` is false, replacing the search bar
+    - `activeDrawer?`: `IActiveDrawer` (`'user' | 'notifications' | 'custom' | (string & {}) | null`) - Controlled open drawer. Built-in keys are `'user'`/`'notifications'`/`'custom'`; the `(string & {})` member accepts any custom side-drawer id while keeping those keys as editor autocomplete. When provided (including `null`) the consumer owns drawer state, otherwise TopBar uses internal state
+    - `onActiveDrawerChange?`: `(activeDrawer: IActiveDrawer) => void` - Callback whenever a drawer opens or closes (icon clicks included)
     - `hasSwitchTheme?`: `boolean` - Show theme switcher
     - `isLightMode?`: `boolean` - Current theme mode
     - `switchThemeText?`: `string` - Switch theme text
@@ -2225,7 +2230,12 @@ This document provides a comprehensive inventory of all React components in the 
   - `currentUserText`: `string` - Text for current user menu
   - `accountOptionText`: `string` - Text for account option
   - `userDrawerBespoke`: `ReactElement` - Custom drawer content element
-  - `customDrawer`: `ICustomDrawer` - Custom drawer configuration
+  - `customDrawer`: `ICustomDrawer` - Custom drawer configuration (icon-triggered)
+  - `sideDrawers?`: `ISideDrawer[]` - Extra drawers with no top-bar toggle, opened via `activeDrawer` by id (desktop only; not supported on mobile)
+    - **ISideDrawer:** `{ id: string, content: ReactElement, width?: string }`
+  - `leftAreaElement?`: `ReactElement` - Custom content for the left area; rendered only when `hasSearch` is false, replacing the search bar
+  - `activeDrawer?`: `IActiveDrawer` (`'user' | 'notifications' | 'custom' | (string & {}) | null`) - Controlled open drawer. Built-in keys are `'user'`/`'notifications'`/`'custom'`; the `(string & {})` member accepts any custom side-drawer id while keeping those keys as editor autocomplete. When provided (including `null`) the consumer owns drawer state, otherwise TopBar uses internal state
+  - `onActiveDrawerChange?`: `(activeDrawer: IActiveDrawer) => void` - Callback whenever a drawer opens or closes (icon clicks included)
   - `hasSwitchTheme`: `boolean` - Shows theme toggle option
   - `isLightMode`: `boolean` - Current theme mode state
   - `switchThemeText`: `string` - Text for theme switch button
@@ -2249,6 +2259,9 @@ This document provides a comprehensive inventory of all React components in the 
   - **Language Toggle**: Optional language switcher with custom text
   - **Theme Toggle**: Optional light/dark mode switcher
   - **User Drawer**: Customizable drawer with metadata, footer, and bespoke content
+  - **Left-Area Content**: Optional `leftAreaElement` replaces the search bar when `hasSearch` is false
+  - **Controlled Drawers**: Optional `activeDrawer`/`onActiveDrawerChange` open any drawer from outside the top bar (falls back to internal state when omitted)
+  - **Side Drawers**: `sideDrawers` add extra drawers with no toggle button, opened via `activeDrawer`, reusing the built-in open/close transition (desktop only; reserved/duplicate ids are ignored with a warning)
   - **Badge Support**: Optional badge with link or click handler
   - **Portal Rendering**: Dropdowns render to document.body
   - **Responsive Layout**: Flexbox layout with gap spacing

--- a/packages/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/packages/storybook/src/stories/Global/TopBar.stories.tsx
@@ -4,6 +4,7 @@ import {
   type ICustomDrawer,
   type INotificationItem,
   type INotificationsHistory,
+  SplitButton,
   TopBar,
   useThemeToggle,
 } from 'scorer-ui-kit';
@@ -15,6 +16,12 @@ const Container = styled.div`
   top: 0;
   left: 0;
   right: 0;
+`;
+
+const LeftContent = styled.div`
+  display: flex;
+  align-items: center;
+  height: 100%;
 `;
 
 const TopBarStory = {
@@ -99,11 +106,11 @@ const allNotifications: INotificationsHistory = {
 
 export const _TopBar = () => {
   const { onThemeToggle, isLightMode } = useThemeToggle();
-  const [attributeLanguage, setAttributeLanguage] = useState('ja');
+  const [attributeLanguage, setAttributeLanguage] = useState('en');
 
   const loggedInUser = text('Logged In User', 'full.name@example.com');
 
-  const hasSearch = boolean('Has Search', true);
+  const hasSearch = boolean('Has Search', false);
   const hasLogout = boolean('Has Logout', true);
   const hasNotifications = boolean('Has Notifications', true);
   const hasCurrentUser = boolean('Has Current User', true);
@@ -112,8 +119,8 @@ export const _TopBar = () => {
   const hasLanguage = boolean('Has Language', true);
   const hasSwitchTheme = boolean('Has Switch Theme', true);
   const switchThemeText = text('Switch Theme Text', 'SWITCH THEME');
-  const selectedThemeText = text('Selected Theme Text', 'Light/Dark Mode');
   const languageToggle = action('onLanguageToggle');
+  const selectedThemeText = text('Selected Theme Text', 'Light/Dark Mode');
 
   const currentUserText = text('Current User Text', 'Current User');
   const logoutText = text('Logout Text', 'Logout');
@@ -185,6 +192,40 @@ export const _TopBar = () => {
     });
   }, [languageToggle]);
 
+  const saveLayoutAction = action('Save layout pressed');
+  const takeSnapshotAction = action('Take a Snapshot pressed');
+  const resetAction = action('Reset pressed');
+
+  // Consumers can pass their own element to the left area. It only renders when
+  // `hasSearch` is false, replacing the built-in search bar.
+  const leftAreaButtonList = [
+    {
+      id: 'save-layout',
+      text: attributeLanguage === 'ja' ? 'レイアウトを保存' : 'Save layout',
+      icon: 'LayoutGrid',
+      hasOnSelectLoading: true,
+      onClickCallback: saveLayoutAction,
+    },
+    {
+      id: 'take-snapshot',
+      text: attributeLanguage === 'ja' ? 'スナップショットを撮影' : 'Take a Snapshot',
+      icon: 'Camera',
+      onClickCallback: takeSnapshotAction,
+    },
+    {
+      id: 'reset',
+      text: attributeLanguage === 'ja' ? 'リセット' : 'Reset',
+      icon: 'RetryJob',
+      onClickCallback: resetAction,
+    },
+  ];
+
+  const leftAreaElement = (
+    <LeftContent>
+      <SplitButton mainButtonId='save-layout' buttonList={leftAreaButtonList} />
+    </LeftContent>
+  );
+
   return (
     <Container>
       <TopBar
@@ -219,6 +260,7 @@ export const _TopBar = () => {
           userDrawerFooter,
           copySuccessMessage,
           includeCopyTitle,
+          leftAreaElement,
         }}
         userDrawerMeta={userDrawerMetaConfig}
         customDrawer={drawerProps}

--- a/packages/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/packages/storybook/src/stories/Global/TopBar.stories.tsx
@@ -1,5 +1,5 @@
 import { boolean, object, select, text } from '@storybook/addon-knobs';
-import { type ReactElement, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   Button,
   type IActiveDrawer,
@@ -25,7 +25,16 @@ const Container = styled.div`
 const LeftContent = styled.div`
   display: flex;
   align-items: center;
+  gap: 16px;
   height: 100%;
+`;
+
+const BrandTitle = styled.span`
+  font-family: var(--font-ui);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--grey-12);
+  white-space: nowrap;
 `;
 
 // Page content sits below the fixed top bar; the top padding clears the 56px bar.
@@ -86,82 +95,76 @@ const SectionHeading = styled.h3`
   margin: 8px 0 0;
 `;
 
+// All user-facing cafeteria + chrome text, toggled by the language switch. The
+// generic notifications and device-meta demo data below stay as-is (English).
+const COPY = {
+  en: {
+    brand: 'Smart Cafeteria',
+    newOrder: 'New Order',
+    printReceipt: 'Print Receipt',
+    clearOrders: 'Clear Orders',
+    ordersTitle: 'Orders',
+    inTheMaking: 'In the making',
+    readyForPickup: 'Ready for pick up',
+    ready: 'Ready',
+    coffee: 'Coffee',
+    cake: 'Cake',
+    tea: 'Tea',
+    todaysMenu: "Today's Menu",
+    aboutTitle: 'About the Cafeteria',
+    aboutImageAlt: 'Cafeteria photo',
+    currentUser: 'Current User',
+    logout: 'Logout',
+    accountOptions: 'Account Options',
+    accounts: 'Accounts',
+    billing: 'Billing',
+    payments: 'Payments',
+    switchTheme: 'SWITCH THEME',
+    themeMode: 'Light/Dark Mode',
+    copied: 'Copied',
+    searchPlaceholder: 'Search area names, etc.',
+    badgeText: 'Guest',
+    badgeLinkText: 'Login',
+    minutes: (n: number) => `${n} min`,
+    yen: (n: number) => `${n} yen`,
+  },
+  ja: {
+    brand: 'スマートカフェテリア',
+    newOrder: '新規注文',
+    printReceipt: 'レシートを印刷',
+    clearOrders: '注文をクリア',
+    ordersTitle: '注文',
+    inTheMaking: '準備中',
+    readyForPickup: '受け取り可能',
+    ready: '準備完了',
+    coffee: 'コーヒー',
+    cake: 'ケーキ',
+    tea: '紅茶',
+    todaysMenu: '本日のメニュー',
+    aboutTitle: 'カフェテリアについて',
+    aboutImageAlt: 'カフェテリアの写真',
+    currentUser: '現在のユーザー',
+    logout: 'ログアウト',
+    accountOptions: 'アカウント設定',
+    accounts: 'アカウント',
+    billing: '請求',
+    payments: '支払い',
+    switchTheme: 'テーマ切り替え',
+    themeMode: 'ライト/ダークモード',
+    copied: 'コピーしました',
+    searchPlaceholder: 'エリア名などを検索',
+    badgeText: 'ゲスト',
+    badgeLinkText: 'ログイン',
+    minutes: (n: number) => `${n}分`,
+    yen: (n: number) => `${n}円`,
+  },
+};
+
 const TopBarStory = {
   title: 'Global',
   component: TopBar,
   decorators: [],
 };
-
-const AboutCafeteria: ReactElement = (
-  <CustomDrawerContent>
-    <CustomDrawerImage src={placeholderImage} alt='About the Cafeteria snapshot' />
-    <CustomDrawerTitle>About the Cafeteria</CustomDrawerTitle>
-  </CustomDrawerContent>
-);
-
-const TodaysMenu: ReactElement = (
-  <CustomDrawerContent>
-    <CustomDrawerTitle>Today's Menu</CustomDrawerTitle>
-    <MenuList>
-      <MenuItem>
-        <span>Tea</span>
-        <span>130 yen</span>
-      </MenuItem>
-      <MenuItem>
-        <span>Coffee</span>
-        <span>300 yen</span>
-      </MenuItem>
-      <MenuItem>
-        <span>Cake</span>
-        <span>350 yen</span>
-      </MenuItem>
-    </MenuList>
-  </CustomDrawerContent>
-);
-
-// Icon-triggered drawer (opens from the top bar). The counter badge shows how
-// many orders are currently waiting.
-const OrdersDrawerContent: ReactElement = (
-  <CustomDrawerContent>
-    <CustomDrawerTitle>Orders</CustomDrawerTitle>
-    <SectionHeading>In the making</SectionHeading>
-    <MenuList>
-      <MenuItem>
-        <span>#014 · Coffee</span>
-        <span>2 min</span>
-      </MenuItem>
-      <MenuItem>
-        <span>#015 · Cake</span>
-        <span>5 min</span>
-      </MenuItem>
-    </MenuList>
-    <SectionHeading>Ready for pick up</SectionHeading>
-    <MenuList>
-      <MenuItem>
-        <span>#012 · Tea</span>
-        <span>Ready</span>
-      </MenuItem>
-      <MenuItem>
-        <span>#013 · Coffee</span>
-        <span>Ready</span>
-      </MenuItem>
-    </MenuList>
-  </CustomDrawerContent>
-);
-
-const ordersDrawer: ICustomDrawer = {
-  customComponent: OrdersDrawerContent,
-  icon: 'Time',
-  status: 'caution',
-  counter: 2,
-  width: '300px',
-};
-
-// Side drawers have no top-bar button; they open from the page content below.
-const sideDrawers: ISideDrawer[] = [
-  { id: 'menu', width: '260px', content: TodaysMenu },
-  { id: 'about', width: '320px', content: AboutCafeteria },
-];
 
 const unreadNotifications: INotificationItem[] = [
   {
@@ -234,44 +237,26 @@ export const _TopBar = () => {
   // while the Orders icon in the top bar still works via onActiveDrawerChange.
   const [activeDrawer, setActiveDrawer] = useState<IActiveDrawer>(null);
 
-  const loggedInUser = text('Logged In User', 'full.name@example.com');
+  // All visible cafeteria/chrome text comes from here and flips with the toggle.
+  const t = attributeLanguage === 'ja' ? COPY.ja : COPY.en;
 
+  // Structural config stays knob-driven; user-facing text is language-driven.
+  const loggedInUser = text('Logged In User', 'full.name@example.com');
   const hasSearch = boolean('Has Search', false);
   const hasLogout = boolean('Has Logout', true);
   const hasNotifications = boolean('Has Notifications', true);
   const hasCurrentUser = boolean('Has Current User', true);
   const logoutLink = text('Logout Url', '#');
-  const searchPlaceholder = text('Search Placeholder', 'Search area names, etc.');
   const hasLanguage = boolean('Has Language', true);
   const hasSwitchTheme = boolean('Has Switch Theme', true);
-  const switchThemeText = text('Switch Theme Text', 'SWITCH THEME');
   const languageToggle = action('onLanguageToggle');
-  const selectedThemeText = text('Selected Theme Text', 'Light/Dark Mode');
-
-  const currentUserText = text('Current User Text', 'Current User');
-  const logoutText = text('Logout Text', 'Logout');
   const hasUserDrawerMeta = boolean('Has User Drawer Meta', true);
-  const copySuccessMessage = text('Tooltip Text', 'Copied');
   const includeCopyTitle = boolean('Include Title Copy', true);
   const hasUserDrawerFooter = boolean('Has User Drawer Footer', false);
   const userDrawerFooter = object('User Drawer Footer', {
     icon: 'Information',
     title: 'V12.3.4',
   });
-  const userSubmenu = object('Submenu', [
-    {
-      text: 'Accounts',
-      href: '#',
-    },
-    {
-      text: 'Billing',
-      href: '#',
-    },
-    {
-      text: 'Payments',
-      href: '#',
-    },
-  ]);
   const notificationsHistory = object('Notifications History', allNotifications);
 
   const userDrawerMetaConfig = object('User Drawer Meta', [
@@ -297,18 +282,20 @@ export const _TopBar = () => {
     },
   ]);
 
-  const badgeText = text('Badge Text', 'Guest');
   const badgeColor = select(
     'Badge Color',
     ['primary', 'grey', 'info', 'success', 'caution', 'warning'],
     'info'
   );
   const badgeLinkTo = text('Badge To', '/login');
-  const badgeLinkText = text('Badge Link Text', 'Login');
   const useBadgeOnClick = boolean('Use Badge onClick', false);
   const badgeClickAction = action('Badge onClick was triggered');
 
-  // userDrawerBespoke: See examples for implementation of this prop.
+  const userSubmenu = [
+    { text: t.accounts, href: '#' },
+    { text: t.billing, href: '#' },
+    { text: t.payments, href: '#' },
+  ];
 
   const onLanguageToggle = useCallback(() => {
     setAttributeLanguage((prev: string) => {
@@ -318,49 +305,123 @@ export const _TopBar = () => {
     });
   }, [languageToggle]);
 
-  const saveLayoutAction = action('Save layout pressed');
-  const takeSnapshotAction = action('Take a Snapshot pressed');
-  const resetAction = action('Reset pressed');
+  const newOrderAction = action('New Order pressed');
+  const printReceiptAction = action('Print Receipt pressed');
+  const clearOrdersAction = action('Clear Orders pressed');
 
-  // Consumers can pass their own element to the left area. It only renders when
-  // `hasSearch` is false, replacing the built-in search bar.
+  // Consumer content for the left area. It only renders when `hasSearch` is
+  // false, replacing the built-in search bar.
   const leftAreaButtonList = [
     {
-      id: 'save-layout',
-      text: attributeLanguage === 'ja' ? 'レイアウトを保存' : 'Save layout',
-      icon: 'LayoutGrid',
+      id: 'new-order',
+      text: t.newOrder,
+      icon: 'Add',
       hasOnSelectLoading: true,
-      onClickCallback: saveLayoutAction,
+      onClickCallback: newOrderAction,
     },
     {
-      id: 'take-snapshot',
-      text: attributeLanguage === 'ja' ? 'スナップショットを撮影' : 'Take a Snapshot',
-      icon: 'Camera',
-      onClickCallback: takeSnapshotAction,
+      id: 'print-receipt',
+      text: t.printReceipt,
+      icon: 'Download',
+      onClickCallback: printReceiptAction,
     },
     {
-      id: 'reset',
-      text: attributeLanguage === 'ja' ? 'リセット' : 'Reset',
+      id: 'clear-orders',
+      text: t.clearOrders,
       icon: 'RetryJob',
-      onClickCallback: resetAction,
+      onClickCallback: clearOrdersAction,
     },
   ];
 
   const leftAreaElement = (
     <LeftContent>
-      <SplitButton mainButtonId='save-layout' buttonList={leftAreaButtonList} />
+      <BrandTitle>{t.brand}</BrandTitle>
+      <SplitButton mainButtonId='new-order' buttonList={leftAreaButtonList} />
     </LeftContent>
   );
+
+  // Icon-triggered drawer (opens from the top bar). The counter badge shows how
+  // many orders are currently waiting.
+  const ordersDrawer: ICustomDrawer = {
+    customComponent: (
+      <CustomDrawerContent>
+        <CustomDrawerTitle>{t.ordersTitle}</CustomDrawerTitle>
+        <SectionHeading>{t.inTheMaking}</SectionHeading>
+        <MenuList>
+          <MenuItem>
+            <span>#014 · {t.coffee}</span>
+            <span>{t.minutes(2)}</span>
+          </MenuItem>
+          <MenuItem>
+            <span>#015 · {t.cake}</span>
+            <span>{t.minutes(5)}</span>
+          </MenuItem>
+        </MenuList>
+        <SectionHeading>{t.readyForPickup}</SectionHeading>
+        <MenuList>
+          <MenuItem>
+            <span>#012 · {t.tea}</span>
+            <span>{t.ready}</span>
+          </MenuItem>
+          <MenuItem>
+            <span>#013 · {t.coffee}</span>
+            <span>{t.ready}</span>
+          </MenuItem>
+        </MenuList>
+      </CustomDrawerContent>
+    ),
+    icon: 'Time',
+    status: 'caution',
+    counter: 2,
+    width: '300px',
+  };
+
+  // Side drawers have no top-bar button; they open from the page content below.
+  const sideDrawers: ISideDrawer[] = [
+    {
+      id: 'menu',
+      width: '260px',
+      content: (
+        <CustomDrawerContent>
+          <CustomDrawerTitle>{t.todaysMenu}</CustomDrawerTitle>
+          <MenuList>
+            <MenuItem>
+              <span>{t.tea}</span>
+              <span>{t.yen(130)}</span>
+            </MenuItem>
+            <MenuItem>
+              <span>{t.coffee}</span>
+              <span>{t.yen(300)}</span>
+            </MenuItem>
+            <MenuItem>
+              <span>{t.cake}</span>
+              <span>{t.yen(350)}</span>
+            </MenuItem>
+          </MenuList>
+        </CustomDrawerContent>
+      ),
+    },
+    {
+      id: 'about',
+      width: '320px',
+      content: (
+        <CustomDrawerContent>
+          <CustomDrawerImage src={placeholderImage} alt={t.aboutImageAlt} />
+          <CustomDrawerTitle>{t.aboutTitle}</CustomDrawerTitle>
+        </CustomDrawerContent>
+      ),
+    },
+  ];
 
   return (
     <>
       <Container>
         <TopBar
           badge={{
-            text: badgeText,
+            text: t.badgeText,
             color: badgeColor,
             linkTo: badgeLinkTo,
-            linkText: badgeLinkText,
+            linkText: t.badgeLinkText,
             onClick: useBadgeOnClick ? badgeClickAction : undefined,
           }}
           {...{
@@ -370,7 +431,6 @@ export const _TopBar = () => {
             hasLogout,
             hasNotifications,
             logoutLink,
-            searchPlaceholder,
             hasLanguage,
             hasUserDrawerMeta,
             hasUserDrawerFooter,
@@ -378,17 +438,19 @@ export const _TopBar = () => {
             notificationsHistory,
             hasSwitchTheme,
             isLightMode,
-            switchThemeText,
-            selectedThemeText,
             onThemeToggle,
             onLanguageToggle,
-            currentUserText,
-            logoutText,
             userDrawerFooter,
-            copySuccessMessage,
             includeCopyTitle,
             leftAreaElement,
           }}
+          searchPlaceholder={t.searchPlaceholder}
+          switchThemeText={t.switchTheme}
+          selectedThemeText={t.themeMode}
+          currentUserText={t.currentUser}
+          logoutText={t.logout}
+          accountOptionText={t.accountOptions}
+          copySuccessMessage={t.copied}
           userDrawerMeta={userDrawerMetaConfig}
           customDrawer={ordersDrawer}
           sideDrawers={sideDrawers}
@@ -400,10 +462,10 @@ export const _TopBar = () => {
       </Container>
       <PageContent>
         <Button design='secondary' onClick={() => setActiveDrawer('menu')}>
-          Today's Menu
+          {t.todaysMenu}
         </Button>
         <Button design='secondary' onClick={() => setActiveDrawer('about')}>
-          About the cafeteria
+          {t.aboutTitle}
         </Button>
       </PageContent>
     </>

--- a/packages/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/packages/storybook/src/stories/Global/TopBar.stories.tsx
@@ -1,6 +1,8 @@
 import { boolean, object, select, text } from '@storybook/addon-knobs';
 import { type ReactElement, useCallback, useState } from 'react';
 import {
+  Button,
+  type IActiveDrawer,
   type ICustomDrawer,
   type INotificationItem,
   type INotificationsHistory,
@@ -10,6 +12,7 @@ import {
 } from 'scorer-ui-kit';
 import { action } from 'storybook/actions';
 import styled from 'styled-components';
+import placeholderImage from '../assets/placeholder.jpg';
 
 const Container = styled.div`
   position: fixed;
@@ -24,13 +27,45 @@ const LeftContent = styled.div`
   height: 100%;
 `;
 
+// Page content sits below the fixed top bar; the top padding clears the 56px bar.
+const PageContent = styled.div`
+  padding: 80px 24px 24px;
+`;
+
+const CustomDrawerContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+`;
+
+const CustomDrawerImage = styled.img`
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 4px;
+`;
+
+const CustomDrawerTitle = styled.h2`
+  font-family: var(--font-ui);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--grey-11);
+  margin: 0;
+`;
+
 const TopBarStory = {
   title: 'Global',
   component: TopBar,
   decorators: [],
 };
 
-const MyCustomDrawer: ReactElement = <h1>Hello Drawer</h1>;
+const MyCustomDrawer: ReactElement = (
+  <CustomDrawerContent>
+    <CustomDrawerImage src={placeholderImage} alt='About the Cafeteria snapshot' />
+    <CustomDrawerTitle>About the Cafeteria</CustomDrawerTitle>
+  </CustomDrawerContent>
+);
 
 const drawerProps: ICustomDrawer = {
   customComponent: MyCustomDrawer,
@@ -107,6 +142,9 @@ const allNotifications: INotificationsHistory = {
 export const _TopBar = () => {
   const { onThemeToggle, isLightMode } = useThemeToggle();
   const [attributeLanguage, setAttributeLanguage] = useState('en');
+  // Controlled drawer state: lets an element in the page content (the button
+  // below) open a TopBar drawer, while icon clicks still work via onActiveDrawerChange.
+  const [activeDrawer, setActiveDrawer] = useState<IActiveDrawer>(null);
 
   const loggedInUser = text('Logged In User', 'full.name@example.com');
 
@@ -227,47 +265,56 @@ export const _TopBar = () => {
   );
 
   return (
-    <Container>
-      <TopBar
-        badge={{
-          text: badgeText,
-          color: badgeColor,
-          linkTo: badgeLinkTo,
-          linkText: badgeLinkText,
-          onClick: useBadgeOnClick ? badgeClickAction : undefined,
-        }}
-        {...{
-          loggedInUser,
-          userSubmenu,
-          hasSearch,
-          hasLogout,
-          hasNotifications,
-          logoutLink,
-          searchPlaceholder,
-          hasLanguage,
-          hasUserDrawerMeta,
-          hasUserDrawerFooter,
-          hasCurrentUser,
-          notificationsHistory,
-          hasSwitchTheme,
-          isLightMode,
-          switchThemeText,
-          selectedThemeText,
-          onThemeToggle,
-          onLanguageToggle,
-          currentUserText,
-          logoutText,
-          userDrawerFooter,
-          copySuccessMessage,
-          includeCopyTitle,
-          leftAreaElement,
-        }}
-        userDrawerMeta={userDrawerMetaConfig}
-        customDrawer={drawerProps}
-        selectedLangAttribute={attributeLanguage}
-        selectedLanguageText={attributeLanguage === 'ja' ? '日本語' : 'ENGLISH'}
-      />
-    </Container>
+    <>
+      <Container>
+        <TopBar
+          badge={{
+            text: badgeText,
+            color: badgeColor,
+            linkTo: badgeLinkTo,
+            linkText: badgeLinkText,
+            onClick: useBadgeOnClick ? badgeClickAction : undefined,
+          }}
+          {...{
+            loggedInUser,
+            userSubmenu,
+            hasSearch,
+            hasLogout,
+            hasNotifications,
+            logoutLink,
+            searchPlaceholder,
+            hasLanguage,
+            hasUserDrawerMeta,
+            hasUserDrawerFooter,
+            hasCurrentUser,
+            notificationsHistory,
+            hasSwitchTheme,
+            isLightMode,
+            switchThemeText,
+            selectedThemeText,
+            onThemeToggle,
+            onLanguageToggle,
+            currentUserText,
+            logoutText,
+            userDrawerFooter,
+            copySuccessMessage,
+            includeCopyTitle,
+            leftAreaElement,
+          }}
+          userDrawerMeta={userDrawerMetaConfig}
+          customDrawer={drawerProps}
+          activeDrawer={activeDrawer}
+          onActiveDrawerChange={setActiveDrawer}
+          selectedLangAttribute={attributeLanguage}
+          selectedLanguageText={attributeLanguage === 'ja' ? '日本語' : 'ENGLISH'}
+        />
+      </Container>
+      <PageContent>
+        <Button design='secondary' onClick={() => setActiveDrawer('custom')}>
+          About the cafeteria
+        </Button>
+      </PageContent>
+    </>
   );
 };
 

--- a/packages/storybook/src/stories/Global/TopBar.stories.tsx
+++ b/packages/storybook/src/stories/Global/TopBar.stories.tsx
@@ -6,6 +6,7 @@ import {
   type ICustomDrawer,
   type INotificationItem,
   type INotificationsHistory,
+  type ISideDrawer,
   SplitButton,
   TopBar,
   useThemeToggle,
@@ -30,6 +31,10 @@ const LeftContent = styled.div`
 // Page content sits below the fixed top bar; the top padding clears the 56px bar.
 const PageContent = styled.div`
   padding: 80px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
 `;
 
 const CustomDrawerContent = styled.div`
@@ -54,26 +59,109 @@ const CustomDrawerTitle = styled.h2`
   margin: 0;
 `;
 
+const MenuList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const MenuItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  color: var(--grey-11);
+`;
+
+const SectionHeading = styled.h3`
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.35px;
+  color: var(--grey-9);
+  margin: 8px 0 0;
+`;
+
 const TopBarStory = {
   title: 'Global',
   component: TopBar,
   decorators: [],
 };
 
-const MyCustomDrawer: ReactElement = (
+const AboutCafeteria: ReactElement = (
   <CustomDrawerContent>
     <CustomDrawerImage src={placeholderImage} alt='About the Cafeteria snapshot' />
     <CustomDrawerTitle>About the Cafeteria</CustomDrawerTitle>
   </CustomDrawerContent>
 );
 
-const drawerProps: ICustomDrawer = {
-  customComponent: MyCustomDrawer,
-  icon: 'Add',
-  status: 'danger',
-  // counter: 5,
-  width: '300px;',
+const TodaysMenu: ReactElement = (
+  <CustomDrawerContent>
+    <CustomDrawerTitle>Today's Menu</CustomDrawerTitle>
+    <MenuList>
+      <MenuItem>
+        <span>Tea</span>
+        <span>130 yen</span>
+      </MenuItem>
+      <MenuItem>
+        <span>Coffee</span>
+        <span>300 yen</span>
+      </MenuItem>
+      <MenuItem>
+        <span>Cake</span>
+        <span>350 yen</span>
+      </MenuItem>
+    </MenuList>
+  </CustomDrawerContent>
+);
+
+// Icon-triggered drawer (opens from the top bar). The counter badge shows how
+// many orders are currently waiting.
+const OrdersDrawerContent: ReactElement = (
+  <CustomDrawerContent>
+    <CustomDrawerTitle>Orders</CustomDrawerTitle>
+    <SectionHeading>In the making</SectionHeading>
+    <MenuList>
+      <MenuItem>
+        <span>#014 · Coffee</span>
+        <span>2 min</span>
+      </MenuItem>
+      <MenuItem>
+        <span>#015 · Cake</span>
+        <span>5 min</span>
+      </MenuItem>
+    </MenuList>
+    <SectionHeading>Ready for pick up</SectionHeading>
+    <MenuList>
+      <MenuItem>
+        <span>#012 · Tea</span>
+        <span>Ready</span>
+      </MenuItem>
+      <MenuItem>
+        <span>#013 · Coffee</span>
+        <span>Ready</span>
+      </MenuItem>
+    </MenuList>
+  </CustomDrawerContent>
+);
+
+const ordersDrawer: ICustomDrawer = {
+  customComponent: OrdersDrawerContent,
+  icon: 'Time',
+  status: 'caution',
+  counter: 2,
+  width: '300px',
 };
+
+// Side drawers have no top-bar button; they open from the page content below.
+const sideDrawers: ISideDrawer[] = [
+  { id: 'menu', width: '260px', content: TodaysMenu },
+  { id: 'about', width: '320px', content: AboutCafeteria },
+];
 
 const unreadNotifications: INotificationItem[] = [
   {
@@ -142,8 +230,8 @@ const allNotifications: INotificationsHistory = {
 export const _TopBar = () => {
   const { onThemeToggle, isLightMode } = useThemeToggle();
   const [attributeLanguage, setAttributeLanguage] = useState('en');
-  // Controlled drawer state: lets an element in the page content (the button
-  // below) open a TopBar drawer, while icon clicks still work via onActiveDrawerChange.
+  // Controlled drawer state: the page-content buttons open the side drawers by id,
+  // while the Orders icon in the top bar still works via onActiveDrawerChange.
   const [activeDrawer, setActiveDrawer] = useState<IActiveDrawer>(null);
 
   const loggedInUser = text('Logged In User', 'full.name@example.com');
@@ -302,7 +390,8 @@ export const _TopBar = () => {
             leftAreaElement,
           }}
           userDrawerMeta={userDrawerMetaConfig}
-          customDrawer={drawerProps}
+          customDrawer={ordersDrawer}
+          sideDrawers={sideDrawers}
           activeDrawer={activeDrawer}
           onActiveDrawerChange={setActiveDrawer}
           selectedLangAttribute={attributeLanguage}
@@ -310,7 +399,10 @@ export const _TopBar = () => {
         />
       </Container>
       <PageContent>
-        <Button design='secondary' onClick={() => setActiveDrawer('custom')}>
+        <Button design='secondary' onClick={() => setActiveDrawer('menu')}>
+          Today's Menu
+        </Button>
+        <Button design='secondary' onClick={() => setActiveDrawer('about')}>
           About the cafeteria
         </Button>
       </PageContent>

--- a/packages/ui-lib/src/Global/index.ts
+++ b/packages/ui-lib/src/Global/index.ts
@@ -85,6 +85,13 @@ export interface IUserSubmenuItem {
   href: string;
 }
 
+/**
+ * Identifies which TopBar drawer is currently open, or `null` when all are
+ * closed. Pass `activeDrawer`/`onActiveDrawerChange` to control it from outside the
+ * component (e.g. to open a drawer from a button in the page content).
+ */
+export type IActiveDrawer = 'user' | 'notifications' | 'custom' | null;
+
 export interface ITopBar {
   hasNotifications?: boolean;
   userSubmenu?: IUserSubmenuItem[];
@@ -105,6 +112,14 @@ export interface ITopBar {
   notificationsHistory?: INotificationsHistory;
   customDrawer?: ICustomDrawer;
   leftAreaElement?: ReactElement;
+  /**
+   * Which drawer is open, for controlled usage. When provided (including
+   * `null`), TopBar becomes controlled and the consumer owns the state.
+   * When omitted, TopBar manages the open drawer with its own internal state.
+   */
+  activeDrawer?: IActiveDrawer;
+  /** Called whenever a drawer is opened or closed (icon clicks included). */
+  onActiveDrawerChange?: (activeDrawer: IActiveDrawer) => void;
   hasSwitchTheme?: boolean;
   isLightMode?: boolean;
   switchThemeText?: string;

--- a/packages/ui-lib/src/Global/index.ts
+++ b/packages/ui-lib/src/Global/index.ts
@@ -104,6 +104,7 @@ export interface ITopBar {
   userDrawerBespoke?: ReactElement;
   notificationsHistory?: INotificationsHistory;
   customDrawer?: ICustomDrawer;
+  leftAreaElement?: ReactElement;
   hasSwitchTheme?: boolean;
   isLightMode?: boolean;
   switchThemeText?: string;

--- a/packages/ui-lib/src/Global/index.ts
+++ b/packages/ui-lib/src/Global/index.ts
@@ -89,8 +89,33 @@ export interface IUserSubmenuItem {
  * Identifies which TopBar drawer is currently open, or `null` when all are
  * closed. Pass `activeDrawer`/`onActiveDrawerChange` to control it from outside the
  * component (e.g. to open a drawer from a button in the page content).
+ *
+ * Built-in keys are `'user'`, `'notifications'` and `'custom'`; a side drawer is
+ * addressed by its own `id`, so the type also accepts any string.
  */
-export type IActiveDrawer = 'user' | 'notifications' | 'custom' | null;
+export type IActiveDrawer = 'user' | 'notifications' | 'custom' | (string & {}) | null;
+
+/**
+ * A drawer that has no top-bar toggle button. It is opened from anywhere in the
+ * app through the controlled `activeDrawer` prop (matched by `id`), and reuses
+ * the same open/close transition as the built-in drawers. Each can set its own
+ * `width`.
+ *
+ * Not supported on mobile: `GlobalUI` renders `MobileNavbar` below the large
+ * breakpoint, which does not implement side drawers. Use `customDrawer` for a
+ * drawer that works across breakpoints.
+ */
+export interface ISideDrawer {
+  /**
+   * Unique id used to open this drawer via `activeDrawer`. Must not be one of the
+   * reserved built-in keys (`'user'`, `'notifications'`, `'custom'`) or duplicate
+   * another side drawer's id: a reserved or duplicate id will not open from its
+   * trigger and logs a warning.
+   */
+  id: string;
+  content: ReactElement;
+  width?: string;
+}
 
 export interface ITopBar {
   hasNotifications?: boolean;
@@ -111,6 +136,12 @@ export interface ITopBar {
   userDrawerBespoke?: ReactElement;
   notificationsHistory?: INotificationsHistory;
   customDrawer?: ICustomDrawer;
+  /**
+   * Extra drawers with no top-bar toggle, opened from anywhere via the
+   * controlled `activeDrawer` prop (matched by `id`). Requires controlled usage.
+   * Desktop `TopBar` only — not supported by `GlobalUI` on mobile.
+   */
+  sideDrawers?: ISideDrawer[];
   leftAreaElement?: ReactElement;
   /**
    * Which drawer is open, for controlled usage. When provided (including

--- a/packages/ui-lib/src/Global/molecules/TopBar.tsx
+++ b/packages/ui-lib/src/Global/molecules/TopBar.tsx
@@ -6,7 +6,7 @@ import { removeAutoFillStyle } from '../../common';
 import Icon from '../../Icons/Icon';
 import StatusIcon from '../../Icons/StatusIcon';
 import TopBarBadge from '../atoms/TopBarBadge';
-import type { ITopBar } from '../index';
+import type { IActiveDrawer, ITopBar } from '../index';
 import UserMenu from '../molecules/UserMenu';
 import NotificationsHistory from './NotificationsHistory';
 
@@ -195,8 +195,6 @@ const NotificationsContainer = styled.div`
     margin-right: -17px;
 `;
 
-type IDrawerKeys = 'user' | 'notifications' | 'custom' | null;
-
 const TopBar: React.FC<ITopBar> = ({
   hasNotifications = false,
   hasLanguage = false,
@@ -232,18 +230,26 @@ const TopBar: React.FC<ITopBar> = ({
   hasUserDrawerFooter,
   badge,
   leftAreaElement,
+  activeDrawer,
+  onActiveDrawerChange,
 }) => {
-  const [openDrawer, setOpenDrawer] = useState<IDrawerKeys>(null);
+  const [internalDrawer, setInternalDrawer] = useState<IActiveDrawer>(null);
 
-  const toggleDrawers = (drawerKey: IDrawerKeys) => {
-    setOpenDrawer((prevDrawer) => {
-      // if prevDrawer is open, just update to null to close
-      if (prevDrawer === drawerKey) {
-        return null;
-      }
+  // Controlled when `activeDrawer` is provided (including `null`); otherwise
+  // TopBar falls back to its own internal state, so existing consumers that
+  // don't pass the prop keep working unchanged.
+  const isControlled = activeDrawer !== undefined;
+  const openDrawer = isControlled ? activeDrawer : internalDrawer;
 
-      return drawerKey;
-    });
+  const toggleDrawers = (drawerKey: IActiveDrawer) => {
+    // if the drawer is already open, close it (null); otherwise open it
+    const nextDrawer = openDrawer === drawerKey ? null : drawerKey;
+
+    if (!isControlled) {
+      setInternalDrawer(nextDrawer);
+    }
+
+    onActiveDrawerChange?.(nextDrawer);
   };
 
   return (

--- a/packages/ui-lib/src/Global/molecules/TopBar.tsx
+++ b/packages/ui-lib/src/Global/molecules/TopBar.tsx
@@ -256,10 +256,10 @@ const TopBar: React.FC<ITopBar> = ({
           <SearchInput placeholder={searchPlaceholder} />
         </SearchBar>
       ) : leftAreaElement ? (
-        <LeftArea>
-          {leftAreaElement}
-        </LeftArea>
-      ) : <div />}
+        <LeftArea>{leftAreaElement}</LeftArea>
+      ) : (
+        <div />
+      )}
       <RightArea>
         {badge && <TopBarBadge {...badge} />}
         <ButtonArea>

--- a/packages/ui-lib/src/Global/molecules/TopBar.tsx
+++ b/packages/ui-lib/src/Global/molecules/TopBar.tsx
@@ -1,14 +1,18 @@
 import type React from 'react';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ReactDom from 'react-dom';
 import styled, { css, keyframes } from 'styled-components';
 import { removeAutoFillStyle } from '../../common';
 import Icon from '../../Icons/Icon';
 import StatusIcon from '../../Icons/StatusIcon';
 import TopBarBadge from '../atoms/TopBarBadge';
-import type { IActiveDrawer, ITopBar } from '../index';
+import type { IActiveDrawer, ISideDrawer, ITopBar } from '../index';
 import UserMenu from '../molecules/UserMenu';
 import NotificationsHistory from './NotificationsHistory';
+
+// Keys used by the built-in drawers. A side drawer must not reuse them, or both
+// it and the built-in drawer would match the same `openDrawer` value at once.
+const RESERVED_DRAWER_IDS = ['user', 'notifications', 'custom'];
 
 const Container = styled.div`
   z-index: 9;
@@ -230,6 +234,7 @@ const TopBar: React.FC<ITopBar> = ({
   hasUserDrawerFooter,
   badge,
   leftAreaElement,
+  sideDrawers,
   activeDrawer,
   onActiveDrawerChange,
 }) => {
@@ -251,6 +256,41 @@ const TopBar: React.FC<ITopBar> = ({
 
     onActiveDrawerChange?.(nextDrawer);
   };
+
+  // Split side drawers once: `sideDrawersToRender` is used below, and any rejected
+  // ids are reported by the mount-time warning. Reserved ids clash with a built-in
+  // drawer, and duplicate ids would open twice and collide on the React key — both
+  // are excluded so a single, uniquely-keyed drawer opens per activeDrawer value.
+  const { sideDrawersToRender, sideDrawerWarnings } = useMemo(() => {
+    const toRender: ISideDrawer[] = [];
+    const warnings: string[] = [];
+    const acceptedIds = new Set<string>();
+    for (const drawer of sideDrawers ?? []) {
+      if (RESERVED_DRAWER_IDS.includes(drawer.id)) {
+        warnings.push(
+          `the side drawer with id "${drawer.id}" uses a reserved id (${RESERVED_DRAWER_IDS.join(', ')}), so it will not open when its trigger is clicked. Please use a different id.`
+        );
+        continue;
+      }
+      if (acceptedIds.has(drawer.id)) {
+        warnings.push(
+          `a side drawer with id "${drawer.id}" already exists; the duplicate will not open when its trigger is clicked. Please use a unique id.`
+        );
+        continue;
+      }
+      acceptedIds.add(drawer.id);
+      toRender.push(drawer);
+    }
+    return { sideDrawersToRender: toRender, sideDrawerWarnings: warnings };
+  }, [sideDrawers]);
+
+  // Warn once on mount (not per render) so the console does not get noisy.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: warn once on mount, not on every render
+  useEffect(() => {
+    for (const warning of sideDrawerWarnings) {
+      console.warn(`TopBar: ${warning}`);
+    }
+  }, []);
 
   return (
     <Container>
@@ -345,6 +385,18 @@ const TopBar: React.FC<ITopBar> = ({
               {customDrawer.customComponent}
             </Drawer>
           )}
+
+          {/* Side drawers: no toggle button, opened via the controlled activeDrawer.
+              Reserved and duplicate ids are excluded (see the mount-time warning above). */}
+          {sideDrawersToRender.map((drawer) => (
+            <Drawer
+              key={drawer.id}
+              $isOpen={openDrawer === drawer.id}
+              $baseWidth={drawer.width ? drawer.width : '200px'}
+            >
+              {drawer.content}
+            </Drawer>
+          ))}
         </DrawerPortalWrapper>,
         document.body
       )}

--- a/packages/ui-lib/src/Global/molecules/TopBar.tsx
+++ b/packages/ui-lib/src/Global/molecules/TopBar.tsx
@@ -32,6 +32,11 @@ const RightArea = styled.div`
   height: 100%;
 `;
 
+const LeftArea = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
 const SearchBar = styled.div`
   flex: 0 1 500px;
   display: flex;
@@ -226,6 +231,7 @@ const TopBar: React.FC<ITopBar> = ({
   includeCopyTitle,
   hasUserDrawerFooter,
   badge,
+  leftAreaElement,
 }) => {
   const [openDrawer, setOpenDrawer] = useState<IDrawerKeys>(null);
 
@@ -249,9 +255,11 @@ const TopBar: React.FC<ITopBar> = ({
           </IconWrapper>
           <SearchInput placeholder={searchPlaceholder} />
         </SearchBar>
-      ) : (
-        <div />
-      )}
+      ) : leftAreaElement ? (
+        <LeftArea>
+          {leftAreaElement}
+        </LeftArea>
+      ) : <div />}
       <RightArea>
         {badge && <TopBarBadge {...badge} />}
         <ButtonArea>

--- a/packages/ui-lib/src/Global/organisms/MobileNavbar.tsx
+++ b/packages/ui-lib/src/Global/organisms/MobileNavbar.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import { MobileTab, TabContent, Tabs } from '../../Tabs/index';
 import { TabList, TabListWrapper } from '../../Tabs/TabList';
@@ -62,11 +63,25 @@ const MobileNavbar: React.FC<IMobileNavbar> = ({
   loggedInUser,
   notificationsHistory,
   customDrawer,
+  sideDrawers,
   supportText,
   onLogout,
   onLanguageToggle,
   ...props
 }) => {
+  // Side drawers are opened only through the controlled `activeDrawer` prop, which
+  // the mobile navbar does not implement — so they are not supported on mobile.
+  // Warn once on mount (not per render) instead of failing silently. `customDrawer`
+  // remains fully supported.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: warn once on mount, not on every render
+  useEffect(() => {
+    if (sideDrawers?.length) {
+      console.warn(
+        'MobileNavbar: `sideDrawers` are not supported on mobile and will not open. Use `customDrawer` for a drawer that works across breakpoints.'
+      );
+    }
+  }, []);
+
   return (
     <Container>
       <Tabs>

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -209,6 +209,7 @@ import {
   type INotificationItem,
   type INotificationsHistory,
   type ICustomDrawer,
+  type ISideDrawer,
 } from './Global';
 import type {
   IMenuTop,
@@ -450,6 +451,7 @@ export type {
   ITopBar,
   ITopBarBadge,
   IActiveDrawer,
+  ISideDrawer,
   // Form types
   TypeFieldState,
   TypeButtonDesigns,

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -220,6 +220,7 @@ import type {
   IUserSubmenuItem,
   ITopBar,
   ITopBarBadge,
+  IActiveDrawer,
 } from './Global';
 
 // Tabs
@@ -448,6 +449,7 @@ export type {
   IUserSubmenuItem,
   ITopBar,
   ITopBarBadge,
+  IActiveDrawer,
   // Form types
   TypeFieldState,
   TypeButtonDesigns,


### PR DESCRIPTION
## Description

This PR extends the desktop **`TopBar`** left area and drawer system with three related, opt-in capabilities, and updates the Storybook story to showcase them.

- **What does this PR do?**
  1. **`leftAreaElement`** — lets a consumer render custom content in the top bar's left area. It shows when `hasSearch` is `false`, replacing the built-in search bar (the story uses a "Smart Cafeteria" brand label plus a `SplitButton` of counter actions).
  2. **Controlled drawer state** — new optional `activeDrawer` + `onActiveDrawerChange` props, plus a new exported type `IActiveDrawer`. When provided, the consumer owns which drawer is open, so any drawer can be opened/closed from outside the top bar (e.g. a button in the page content). When omitted, `TopBar` keeps its previous internal state.
  3. **`sideDrawers` (`ISideDrawer[]`)** — extra drawers with **no top-bar toggle button**, opened only through `activeDrawer` (matched by `id`), each with its own `width`. They reuse the existing `Drawer` element, so switching between them animates with the same open/close transition as the built-in drawers.

## Considerations on Implementation

Points I'd like the reviewer to focus on:

- **Controlled vs uncontrolled detection.** `TopBar` is controlled when `activeDrawer !== undefined`. `null` is a valid controlled value ("all closed"), so `undefined` (prop omitted) is the only signal for uncontrolled. Please confirm this contract is acceptable.
- **`IActiveDrawer` is intentionally open-ended.** It widened from a closed union to `'user' | 'notifications' | 'custom' | (string & {}) | null` so a side drawer can be addressed by its own `id`. Trade-off: it now accepts any string, and a custom id must not collide with the reserved built-in keys.
- **Reserved / duplicate side-drawer ids.** Ids that are reserved (`'user'`/`'notifications'`/`'custom'`) or duplicated are rejected in a single `useMemo` pass, so only one uniquely-keyed drawer opens per `activeDrawer` value (prevents double-open and duplicate React keys). Rejected ids emit a `console.warn` **once on mount** (not per render) to avoid console noise — a bad id added after mount is still safely excluded from render but won't emit a warning. This mount-only behavior is deliberate.
- **Mobile is intentionally scoped out for `sideDrawers`.** Below the large breakpoint, `GlobalUI` renders `MobileNavbar`, which uses its own tab mechanism and does not read `activeDrawer`. Side drawers have no tab trigger, so they are **not supported on mobile**: `MobileNavbar` logs a one-time warning and ignores them. `customDrawer` remains fully supported on mobile (rendered as a tab). Please confirm desktop-only is acceptable, or flag if mobile parity is required.
- **Drawer content is always mounted (pre-existing behavior, unchanged).** Closed drawers use `visibility: hidden`, which is visual only — React keeps their content mounted, so effects/data-fetching in a consumer's drawer content run on load, not on open. This PR does not change that; noted as a possible future optimization (lazy mount), not something introduced here.

## Reviewing/Testing steps

### Pre-merge verification

| Check                                                   |  Result   |
|---------------------------------------------------------|:---------:|
| Lint (`npm run check` — Biome lint + format)            | ✅ PASS   |
| Type-check (`npm run test:types -w packages/ui-lib`)    | ✅ PASS   |
| Build (`vite build` via `npm test -w packages/ui-lib`)  | ✅ PASS   |
| Unit test (vitest export smoke via `npm test`)          | ✅ PASS   |
| Manual smoke — story sweep (`npm run sweep`)            | ✅ PASS   |
| Console clean of new warnings (normal usage)            | ✅ PASS   |
| CI (lint / type-check / build on GitHub Actions)        | ✅ PASS   |
| Docker / deploy artifact builds                         | ⏭️ N/A    |

Notes:
- **Story sweep:** 86 pages swept; the only failures are two **pre-existing** example-app routes (`/` and `/line`, dev-only errors unrelated to this PR). All Storybook stories, including Top Bar, passed.
- **Console warnings:** the new `console.warn` calls only fire on misuse (reserved/duplicate side-drawer id, or `sideDrawers` passed on mobile). The story uses valid ids on desktop, so normal usage is clean.

### Detailed steps to reproduce

**Setup**
```bash
npm install
npm run start:all   # ui-lib build + types, example app (:3000), storybook (:9009)
```

**Reproduction** — open Storybook → **Global → Top Bar** (`?path=/story/global--top-bar`), then:

1. **Left-area content:** turn the **Has Search** knob off. → A "Smart Cafeteria" label and a `SplitButton` (New Order / Print Receipt / Clear Orders) appear in the left area.
2. **Language toggle (all text):** open the user drawer (top-right person icon) and toggle language. → All cafeteria + chrome text switches between English and Japanese (brand label, split button, the three drawers, page buttons, and user-drawer labels). The Notifications list and device-meta rows intentionally stay English.
3. **Icon-triggered drawer:** click the clock icon with the "2" counter badge in the top bar. → The **Orders** drawer opens with two lists (In the making / Ready for pick up).
4. **Side drawers (controlled):** click **Today's Menu** or **About the Cafeteria** in the page content. → The matching side drawer opens; switching between them shows the same open/close transition as the built-in drawers.
5. **Guard (optional):** temporarily set a side drawer `id` to `'user'` or duplicate an id. → It does not open, and a single `console.warn` explains why.

**Automated checks**
```bash
npm run check                         # Biome lint + format
npm run test:types -w packages/ui-lib # tsc --noEmit
npm test -w packages/ui-lib           # vitest smoke + lint + build
npm run sweep                         # story sweep (needs npm run start:all running)
```

**Expected outcome**
- Lint, type-check, unit, and build commands exit `0`.
- Only one drawer is open at a time; side drawers slide/fade in and out identically to the user/notifications drawers.
- No new `console.error`; no `console.warn` during the story's normal (valid) usage.

### Screenshoot

#### Menu Button opens sideDrawer
<img width="1223" height="556" alt="Screenshot 2026-07-24 at 11 48 44" src="https://github.com/user-attachments/assets/d2955cb5-986b-4b90-b699-f6f3efec6fd9" />

### Clock status button with Orders (customDrawer)
<img width="1218" height="565" alt="Screenshot 2026-07-24 at 11 49 01" src="https://github.com/user-attachments/assets/65726ab6-d58b-45a5-913e-b22acf82f496" />

### About the cafeteria button opens sideDrawer
<img width="1226" height="681" alt="Screenshot 2026-07-24 at 11 48 34" src="https://github.com/user-attachments/assets/069a4c0f-e49f-4a9f-9451-edd91e2bf845" />

