### PR TITLE
ChipButton, ChipDropdown, ChipBar, ChipZoneBreak

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,11 @@ jobs:
     - name: TypeScript check
       run: npm run test:types -w packages/ui-lib
 
+    # ~2s. Targeted regression tests only — behavioural verification is the story sweep
+    # (pr-deploy.yml); these cover the few things the sweep structurally cannot see.
+    - name: Unit tests
+      run: npm run test:unit -w packages/ui-lib
+
     - name: Build
       run: npm run build -w packages/ui-lib
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,8 @@ The exhaustive, source-of-truth export list lives in [`packages/ui-lib/src/index
 - MediaBox
 - ActionsBar
 
-#### Chip Components (2 components)
+#### Chip Components (3 components)
+- ChipBar
 - ChipButton
 - ChipDropdown
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,8 +275,9 @@ The exhaustive, source-of-truth export list lives in [`packages/ui-lib/src/index
 - MediaBox
 - ActionsBar
 
-#### Chip Components (1 component)
+#### Chip Components (2 components)
 - ChipButton
+- ChipDropdown
 
 #### LineUI Components (3 components)
 - LineUI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,10 +275,11 @@ The exhaustive, source-of-truth export list lives in [`packages/ui-lib/src/index
 - MediaBox
 - ActionsBar
 
-#### Chip Components (3 components)
+#### Chip Components (4 components)
 - ChipBar
 - ChipButton
 - ChipDropdown
+- ChipZoneBreak
 
 #### LineUI Components (3 components)
 - LineUI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,6 +275,9 @@ The exhaustive, source-of-truth export list lives in [`packages/ui-lib/src/index
 - MediaBox
 - ActionsBar
 
+#### Chip Components (1 component)
+- ChipButton
+
 #### LineUI Components (3 components)
 - LineUI
 - LineUIVideo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ npm run sweep
   - `any` is discouraged (`noExplicitAny` warns); TypeScript strict mode is enabled — do not use `any`.
 - Prefer **arrow-function components** (`const Foo = () => { ... }`) for new and refactored top-level components.
 - Prefer explicit interfaces for public component props.
+- Comments follow [COMMENT_STYLE_GUIDE.md](COMMENT_STYLE_GUIDE.md). In short: default to none, and write one only when you can name the wrong change it prevents. Design deviations and status notes go in the PR description, not in the code. Keep every comment **out of** `styled` / `css` / `keyframes` template literals — a single backtick inside one ends the literal, and Biome then reformats the result into code that no longer parses.
 
 ## Dependency policy (maintainers)
 

--- a/COMMENT_STYLE_GUIDE.md
+++ b/COMMENT_STYLE_GUIDE.md
@@ -1,0 +1,238 @@
+# Comment Style Guide
+
+This document defines when to write a comment in this repository, when to leave it out, and where a
+note belongs when it does not belong in the code. It applies to contributors and to AI agents.
+
+The short version: **the code carries the logic, a comment carries only what the code cannot.**
+Default to writing none.
+
+## Core Principles
+
+1. **Comments are for constraints, not for narration.** If the code already says it, the comment is
+   noise.
+2. **A comment must earn its place.** Name the wrong change it prevents, or delete it.
+3. **A comment is a standing instruction.** It has to stay true for as long as the code exists.
+4. **A stale comment is worse than no comment**, because readers trust it.
+5. **The reader is a person, not a parser.** Write plain sentences. Only the public API needs a
+   machine-readable format (see [JSDoc on the public API](#jsdoc-on-the-public-api)).
+
+## The Test
+
+Before writing a comment, **name the wrong change it prevents.**
+
+If you cannot name one, delete it. "A reader might not follow this" does not qualify — a reader can
+read the code. Try a clearer name or a small extraction first, and write a comment only when naming
+cannot carry the point.
+
+Applied:
+
+- "Without `min-width: 0` a flex item will not shrink past its content" → prevents someone removing a
+  line that looks unnecessary. **Keep.**
+- "Watch for locking prop" above a `useEffect` on `locking` → prevents nothing. **Delete.**
+
+## Where a Note Belongs
+
+Decide by how long the note stays true.
+
+| | Stays true for | Read by | Use it for |
+|---|---|---|---|
+| **Source comment** | the life of the code | whoever edits that code next | constraints that must be obeyed |
+| **PR description** | one moment | the reviewer, once | design provenance, deviations, status |
+
+A source file has no way to expire a statement. So anything that describes a moment — what the design
+said, what is not finished, which PR is coming — goes in the PR description, under
+**Considerations on Implementation** in [`pull_request_template.md`](pull_request_template.md). That
+section already exists for exactly this purpose.
+
+## Comments That Earn Their Place
+
+### 1. A constraint that is invisible in the code
+
+An order that looks arbitrary but is not, or an option that must stay out of a list.
+
+✅ **Do:**
+```ts
+/* `attributeFilter` must never include `tabindex`: sync() writes it, so observing it would
+   re-enter this callback forever. */
+```
+
+### 2. Why the obvious alternative does not work
+
+Write this when someone would otherwise simplify the code and break it.
+
+✅ **Do:**
+```ts
+/* `&&` doubles the class so this beats the atom's own rule without depending on stylesheet
+   order. */
+```
+
+### 3. A fact that came from measuring, not from reasoning
+
+A browser or library behaviour, or a number found by testing. Nobody can re-derive these by reading.
+
+✅ **Do:**
+```ts
+/* Without this, flex items default to flex-shrink: 1 and a narrow container silently shrinks the
+   56px cells — measured at 36px in a 200px container. */
+```
+
+## Comments to Leave Out
+
+### 1. What the code already says
+
+❌ **Don't:**
+```ts
+/** Watch for locking prop. */
+useEffect(() => { ... }, [locking]);
+
+// fire the callback once
+if (hasFired.current) { return; }
+```
+
+### 2. Design provenance and deviations from design
+
+Which Figma or Zeplin node this came from, and where the build differs from it, goes in the PR
+description.
+
+❌ **Don't:**
+```ts
+/* Deviation from Figma "Spaces/Card Shadow": that shadow has no theme token, and its literal rgba
+   pair read badly — the glow is invisible on light and a halo on dark. We reuse
+   FilterDropdownContainer's shadow instead, which is theme-aware. */
+```
+
+✅ **Do** — keep one line in the code only when the deviation invites a "fix" that would bring the
+problem back, and put the reasoning in the PR:
+```ts
+/* Uses FilterDropdownContainer's shadow, not Figma's "Spaces/Card Shadow" — do not switch back,
+   see PR discussion. */
+```
+
+The bar for that single line: **a future editor could plausibly change it back, and would break
+something by doing so.** If nobody would touch it, no line is needed.
+
+### 3. Status, history and plans
+
+❌ **Don't:** "not on this branch yet", "already shipped", "PR #675 adds this", "will change when we
+migrate". Nothing forces these to expire. They belong in the PR description or an issue.
+
+### 4. Section banners inside logic
+
+❌ **Don't:** `// ---- helpers ----`, `// ===== STATE =====` in a component or hook. If a file with
+logic needs signposting, it needs splitting.
+
+✅ **Exception — export barrels.** A file that is only a long list of exports has no logic to read, and
+group labels there help. `src/index.tsx` already does this, so follow it:
+```ts
+// Components - Chips
+import { ChipBar, ChipButton } from './Chips';
+```
+
+## Keeping Comments True
+
+- **Keep the note beside the code it describes**, so whoever edits the code sees the note in the same
+  diff.
+- **Do not describe another file or component from here.** The person who changes that code will never
+  read this comment. Describing ChipBar's behaviour inside ChipZoneBreak guarantees drift.
+- **Update or delete the comment in the same commit as the code.** A comment is part of the change,
+  not documentation of it.
+- **Avoid "for now", "temporarily", "will change when".** Nothing makes them expire.
+- **Do not point at a document that is not in the repository.** "see SPEC §4" or "per the design doc"
+  cannot be followed by the next reader and cannot be kept in step. Either the document is committed
+  here and you link to it, or you state the constraint itself in one sentence.
+- **Do not quote a value from the code.** A comment saying "280px here" dies the moment the value
+  changes, and nothing warns you. Say why the value is what it is, and let the code hold the number.
+
+### The one forced exception
+
+A backtick inside a `styled` / `css` / `keyframes` template literal ends the literal, and the
+formatter then reflows the result into code that no longer parses. Notes about CSS rules therefore sit
+in a block comment **above** the declaration, not inside it.
+
+That separates a note from the rule it describes, so **name the rule each note is about**, and keep
+these notes to real constraints:
+
+✅ **Do:**
+```ts
+/* `flex-shrink: 0`: ChipBar protects its own children, but a zone break sits outside any bar, so it
+   has to protect itself or a narrow top bar squashes the band. */
+const Break = styled.div`
+  flex-shrink: 0;
+  ...
+`;
+```
+
+## Comments in Tests
+
+A test file is the one place where a note about a past defect belongs in the code, because the test
+exists to hold that defect down. The test name says what is asserted; a comment adds why it matters.
+
+✅ **Do** — name the defect, or the reason an assertion is written a certain way:
+```ts
+// without the MutationObserver the newly enabled button keeps its native tabIndex of 0 alongside
+// the existing one, giving the bar two tab stops
+expect(tabStops(container)).toBe(1);
+
+// offsetWidth is not asserted: jsdom does no layout and always returns 0
+expect(getComputedStyle(band).boxSizing).toBe('border-box');
+```
+
+❌ **Don't** restate the test name, and do not count things the file will outgrow ("regression tests
+for two defects" stops being true at the third test).
+
+## JSDoc on the Public API
+
+`/** */` is preserved in the published `.d.ts` — on props, exported types and components alike — so it
+appears on hover in an editor, both in this repo and in any app that installs `scorer-ui-kit`. It is
+the only comment style a tool reads today, so it is the one worth standardising.
+
+✅ **Do** — one line per prop, on anything exported:
+```ts
+interface OwnProps {
+  /** collapse the cell to zero width — the removal animation */
+  leaving?: boolean;
+}
+```
+
+❌ **Don't** — a trailing comment on the same line is dropped by the build, so consumers never see it:
+```ts
+interface OwnProps {
+  leaving?: boolean; // collapse the cell to zero width — the removal animation
+}
+```
+
+Two things to skip:
+
+- **`@param` and `@returns` tags.** TypeScript already carries the names and types, and nothing here
+  reads the tags.
+- **Writing for a docs generator.** Storybook runs without `addon-docs`
+  (`packages/storybook/.storybook/main.mjs`), so no site extracts these comments. The editor tooltip is
+  the audience.
+
+> Checking what actually ships: the declaration output is cached, and a plain rebuild can leave
+> `dist/**/*.d.ts` untouched. Run `rm -rf packages/ui-lib/dist` first, then `npm run build -w
+> packages/ui-lib`.
+
+## Applying This Guide
+
+- **New and edited code follows it.** Existing comments are not swept: rewriting comments across
+  untouched files produces a large diff with no behaviour change and no reviewer.
+- **When you edit a component anyway**, delete the comments in it that fail The Test, and convert its
+  public props from trailing `//` to `/** */`.
+
+## Checklist
+
+Before opening a PR, for each comment you added:
+
+- [ ] I can name the wrong change it prevents.
+- [ ] It says something the code does not already say.
+- [ ] It describes the code it sits next to, not another file.
+- [ ] It contains no design provenance, status, PR number, or plan.
+- [ ] It will still be true in a year, or it is gone.
+- [ ] It is outside every `styled` / `css` / `keyframes` literal.
+- [ ] Public props use `/** */`, not a trailing `//`.
+
+---
+
+**Last Updated:** 2026-07-29
+**Maintained By:** Development Team

--- a/COMMENT_STYLE_GUIDE.md
+++ b/COMMENT_STYLE_GUIDE.md
@@ -44,6 +44,11 @@ said, what is not finished, which PR is coming — goes in the PR description, u
 **Considerations on Implementation** in [`pull_request_template.md`](pull_request_template.md). That
 section already exists for exactly this purpose.
 
+**Both homes must be self-contained.** Working notes that live only on one machine — a local spec, a
+scratch harness, a checklist, an agent's working folder — cannot be cited from either place. A
+reviewer cannot open them, and a reader in a year will not have them. If a fact in those notes is
+worth keeping, copy the fact itself into the code or the PR, and cite nothing.
+
 ## Comments That Earn Their Place
 
 ### 1. A constraint that is invisible in the code
@@ -139,7 +144,8 @@ import { ChipBar, ChipButton } from './Chips';
 - **Avoid "for now", "temporarily", "will change when".** Nothing makes them expire.
 - **Do not point at a document that is not in the repository.** "see SPEC §4" or "per the design doc"
   cannot be followed by the next reader and cannot be kept in step. Either the document is committed
-  here and you link to it, or you state the constraint itself in one sentence.
+  here and you link to it, or you state the constraint itself in one sentence. A reference can be
+  accurate and still be useless: if the document is not committed, the pointer is dead on arrival.
 - **Do not quote a value from the code.** A comment saying "280px here" dies the moment the value
   changes, and nothing warns you. Say why the value is what it is, and let the code hold the number.
 

--- a/COMPONENT_INVENTORY.md
+++ b/COMPONENT_INVENTORY.md
@@ -378,6 +378,29 @@ This document provides a comprehensive inventory of all React components in the 
 
 ---
 
+### ChipZoneBreak
+- **Status:** ✅ Has Storybook
+- **Component Path:** `ui-lib/src/Chips/atoms/ChipZoneBreak.tsx`
+- **Story Path:** `storybook/src/stories/Chips/atoms/ChipZoneBreak.stories.tsx`
+- **Exported From:** `Chips`
+- **Props:** (`HTMLAttributes<HTMLDivElement>` — no props of its own)
+  - All standard HTML div attributes (`className`, `style`, `role`, `aria-hidden`, etc.)
+- **Notable Features:**
+  - 12×56 band separating two zones of the top bar (Figma: Spaces / Top Bar / Zone Break)
+  - `--grey-3` fill with a 1px `--grey-4` hairline on each edge; no states, not interactive
+  - Owns both edge hairlines, so the cells either side drop their adjoining border - this is why
+    ChipBar suppresses its first cell's left divider unconditionally
+  - `box-sizing: border-box` keeps both hairlines inside the 12px; without it the band renders
+    14px and the top bar drifts 2px per zone break
+  - `flex-shrink: 0` - it sits outside any ChipBar, so it protects its own width
+  - `aria-hidden='true'` by default (decorative). To have it announced, pass **both**
+    `role='separator'` and `aria-hidden={false}` - `role` alone is inert, because the default
+    `aria-hidden='true'` survives and keeps the element out of the accessibility tree
+  - Place it **between** ChipBars, never inside one: a zone break is not a cell of either zone
+  - Uses theme CSS variables for automatic light/dark support
+
+---
+
 ### ConfirmationModal
 - **Status:** ✅ Has Storybook
 - **Component Path:** `ui-lib/src/Modals/ConfirmationModal.tsx`

--- a/COMPONENT_INVENTORY.md
+++ b/COMPONENT_INVENTORY.md
@@ -1,7 +1,7 @@
 # Scorer UI Kit - Component Inventory
 
 **Generated:** 2026-02-04
-**Last Updated:** 2026-07-27
+**Last Updated:** 2026-07-28
 **Source:** ui-lib/src & storybook/src/stories
 
 This document provides a comprehensive inventory of all React components in the Scorer UI Kit to be used by human and AI, organized alphabetically with their corresponding Storybook documentation status, file paths, props, and notable features.
@@ -303,6 +303,27 @@ This document provides a comprehensive inventory of all React components in the 
 
 ---
 
+### ChipBar
+- **Status:** ✅ Has Storybook
+- **Component Path:** `ui-lib/src/Chips/organisms/ChipBar.tsx`
+- **Story Path:** `storybook/src/stories/Chips/organisms/ChipBar.stories.tsx`
+- **Exported From:** `Chips`
+- **Props:** (extends `HTMLAttributes<HTMLDivElement>`)
+  - `children`: `ReactNode` - The cells: any mix of ChipButton / ChipDropdown, in any order (required)
+  - Plus all standard HTML div attributes (`className`, `style`, `aria-label`, etc.)
+- **Notable Features:**
+  - 56px top-bar chip row (Figma: Spaces / Top Bar / Space Selection)
+  - Pure layout glue - holds no selection state; the consumer sets `selected` per chip
+  - Composes ChipButton and ChipDropdown children in any order and any count
+  - Suppresses the first cell's 1px left divider automatically
+  - `role='toolbar'` with arrow-key roving focus (Left/Right/Home/End), one tab stop - kept in
+    sync by a MutationObserver, so a child that enables its own button cannot add a second tab stop
+  - Does not hijack arrow keys while a ChipDropdown menu is open
+  - Cells never shrink (`flex-shrink: 0`): in a narrow container the row overflows rather than
+    squashing the 56px cells. Overflow itself is undefined in v1 - wrap ChipBar if you need scrolling
+
+---
+
 ### ChipButton
 - **Status:** ✅ Has Storybook
 - **Component Path:** `ui-lib/src/Chips/atoms/ChipButton.tsx`
@@ -314,6 +335,8 @@ This document provides a comprehensive inventory of all React components in the 
   - `label?`: `string` - Text/numeral rendered when variant='text' (falls back to children)
   - `selected?`: `boolean` - Persistent selected state: primary wash background + bottom bar (default: false)
   - `noDivider?`: `boolean` - Suppress the 1px left divider shown by default on all chips (default: false)
+  - `leaving?`: `boolean` - Play the removal animation: collapse the cell to zero width (default: false)
+  - `onLeaveEnd?`: `() => void` - Fired when the collapse finishes, or immediately when the user prefers reduced motion. Unmount the cell here
   - Plus all standard HTML button attributes (`onClick`, `disabled`, `aria-label`, etc.)
 - **Notable Features:**
   - 56×56 top-bar "Space" chip (Figma: Spaces / Top Bar / Chip)
@@ -321,6 +344,9 @@ This document provides a comprehensive inventory of all React components in the 
   - CSS-driven hover bar; prop-driven persistent selected state (bar + wash)
   - 4px bottom bar overhanging 1px each side to cover cell hairlines
   - 1px left divider on both variants, suppressible via noDivider (leftmost cell / zone breaks)
+  - Built-in removal animation (`leaving` + `onLeaveEnd`): the cell collapses to zero width over
+    `--speed-fast`, and in a flex row every later cell slides left on its own. Honours
+    `prefers-reduced-motion`, in which case `onLeaveEnd` fires at once so the caller never stalls
   - Uses theme CSS variables for automatic light/dark support
 
 ---
@@ -339,7 +365,11 @@ This document provides a comprehensive inventory of all React components in the 
   - `onOpenChange?`: `(open: boolean) => void` - Notified when the menu opens/closes
 - **Notable Features:**
   - Top-bar ellipsis "Space actions" cell (Figma: Spaces / Top Bar / Space Menu Cell)
-  - Composes the ChipButton atom as the trigger (open state = chip 'selected' bar)
+  - Composes the ChipButton atom as the trigger (idle = no bar, hover = `--primary-6` bar,
+    open = `--primary-9` bar)
+  - The open trigger takes the bar only - the atom's `--primary-a3` selected wash is suppressed,
+    so an open menu next to an active chip does not read as one merged block (Figma: the ellipsis
+    cell is "a different kind of button from the chips")
   - Click-outside and Escape close the menu (uses useClickOutside)
   - Action menu with per-row icon + label; selecting a row fires onClick and closes
   - Menu shadow reuses FilterDropdownContainer's `--filter-button-shadow-color` token

--- a/COMPONENT_INVENTORY.md
+++ b/COMPONENT_INVENTORY.md
@@ -333,7 +333,7 @@ This document provides a comprehensive inventory of all React components in the 
   - `variant?`: `IChipVariant` (`'icon' | 'text'`) - Content mode; 'icon' renders an Icon, 'text' renders a number/letter label (default: 'text')
   - `icon?`: `string` - Icon name rendered when variant='icon'
   - `label?`: `string` - Text/numeral rendered when variant='text' (falls back to children)
-  - `selected?`: `boolean` - Persistent selected state: primary wash background + bottom bar (default: false)
+  - `selected?`: `boolean` - Persistent selected state: primary wash background + bottom bar (default: false). Surfaces as `aria-pressed`, making the chip a toggle button - unless the cell is given `aria-haspopup`, in which case it is a menu button and `aria-pressed` is omitted so `aria-expanded` is its only state
   - `noDivider?`: `boolean` - Suppress the 1px left divider shown by default on all chips (default: false)
   - `leaving?`: `boolean` - Play the removal animation: collapse the cell to zero width (default: false)
   - `onLeaveEnd?`: `() => void` - Fired when the collapse finishes, or immediately when the user prefers reduced motion. Unmount the cell here
@@ -375,6 +375,9 @@ This document provides a comprehensive inventory of all React components in the 
     so an open menu next to an active chip does not read as one merged block (Figma: the ellipsis
     cell is "a different kind of button from the chips")
   - Click-outside and Escape close the menu (uses useClickOutside)
+  - The trigger is a **menu button**: `aria-haspopup='menu'` plus `aria-expanded`, and no
+    `aria-pressed`. It borrows ChipButton's `selected` only to get the open bar, so the atom drops
+    the toggle-button semantics whenever a cell owns a popup
   - Action menu with per-row icon + label; selecting a row fires onClick and closes
   - **Labelled mode** (`label` set) is the Arrangement cell, the active-layout picker (Figma:
     Spaces / Top Bar / Arrangement Cell). The trigger becomes glyph (18px) + text + a 12px `Down`

--- a/COMPONENT_INVENTORY.md
+++ b/COMPONENT_INVENTORY.md
@@ -356,10 +356,14 @@ This document provides a comprehensive inventory of all React components in the 
 - **Component Path:** `ui-lib/src/Chips/molecules/ChipDropdown.tsx`
 - **Story Path:** `storybook/src/stories/Chips/molecules/ChipDropdown.stories.tsx`
 - **Exported From:** `Chips`
+- **Story Path (labelled / Arrangement cell):** `storybook/src/stories/Chips/molecules/ChipDropdownArrangement.stories.tsx`, and in context in `storybook/src/stories/Chips/organisms/SpacesTopBar.stories.tsx`
 - **Props:** (extends `HTMLAttributes<HTMLDivElement>`)
   - `items`: `IChipDropdownItem[]` - Menu rows: `{ id, label, icon?, disabled?, onClick? }` (required)
-  - `icon?`: `string` - Trigger icon name (default: 'FilterEllipsis')
-  - `triggerLabel?`: `string` - Accessible label for the trigger button (default: 'Space actions')
+  - `icon?`: `string` - Icon-only mode: the trigger icon, 16px. Labelled mode: the leading glyph, 18px (default: 'FilterEllipsis')
+  - `label?`: `string` - Visible trigger text, e.g. '6-up'. Setting it switches the trigger to labelled mode: glyph + label + caret, sized to its content. Empty counts as absent
+  - `selectedId?`: `string` - `items[].id` of the current row: `--grey-4` background + a check, and the rows become `menuitemradio`/`aria-checked`
+  - `checkIcon?`: `string` - Icon name for the current-row indicator (default: 'Success')
+  - `triggerLabel?`: `string` - Accessible label for the trigger button (default: 'Space actions' in icon-only mode only - see below)
   - `noDivider?`: `boolean` - Hide the trigger chip's 1px left divider (default: false)
   - `disabled?`: `boolean` - Disable the trigger (default: false)
   - `onOpenChange?`: `(open: boolean) => void` - Notified when the menu opens/closes
@@ -372,8 +376,33 @@ This document provides a comprehensive inventory of all React components in the 
     cell is "a different kind of button from the chips")
   - Click-outside and Escape close the menu (uses useClickOutside)
   - Action menu with per-row icon + label; selecting a row fires onClick and closes
+  - **Labelled mode** (`label` set) is the Arrangement cell, the active-layout picker (Figma:
+    Spaces / Top Bar / Arrangement Cell). The trigger becomes glyph (18px) + text + a 12px `Down`
+    caret, 56px tall but sized to its content instead of the 56px square, with 14px/16px padding and
+    no left divider - it always sits right of a ChipZoneBreak, which owns both hairlines
+  - The caret does **not** flip when the menu opens (Figma uses one caret asset in all three
+    states). Note `SplitButton` swaps `Down`→`Close`; the two kit components differ on purpose
+  - `triggerLabel` is only defaulted in icon-only mode. In labelled mode the visible text is the
+    accessible name, so defaulting it would be a WCAG 2.5.3 (Label in Name) failure - an explicitly
+    passed `triggerLabel` is still honoured
+  - **Trap:** in labelled mode `triggerLabel` becomes an `aria-label`, which *replaces* the visible
+    text as the accessible name rather than adding to it. `triggerLabel='Arrangement'` on a trigger
+    reading "6-up" hides "6-up" from assistive tech and from voice control, failing WCAG 2.5.3.
+    Either omit it - the visible text is already the name - or lead with the visible value, e.g.
+    `` triggerLabel={`${value} arrangement`} ``
+  - **Current-row semantics:** with `selectedId` set, rows switch from `role='menuitem'` to
+    `role='menuitemradio'` + `aria-checked`, so "current" reaches a screen reader and the check
+    glyph is decorative (`aria-hidden`). Without `selectedId` the menu is byte-identical to before
+  - A hovered current row deepens to `--grey-5` rather than taking the `--grey-3` hover: `--grey-4`
+    is a step darker than the hover in both themes, so letting hover win would make the current row
+    look *less* selected when pointed at
   - Menu shadow reuses FilterDropdownContainer's `--filter-button-shadow-color` token
     (deviation from Figma's untokenised "Spaces/Card Shadow")
+  - **Deviations from Figma:** the menu keeps `min-width: 216px` (shared with the ellipsis menu)
+    against Figma's 192px for the Arrangement menu; and `checkIcon` defaults to `Success`, a tick
+    inside a circle, because `@future-standard/icons` has no bare check mark - swapping the default
+    later is a one-line, non-breaking change. The four layout glyphs (6-up / 4-up / 2-up /
+    1 big + 2) are **not** in the icon package: pass whatever names the consuming project provides
   - Uses theme CSS variables for automatic light/dark support
 
 ---
@@ -1861,6 +1890,16 @@ This document provides a comprehensive inventory of all React components in the 
   - Supports all standard button HTML attributes via ISplitButtonItem
   - Automatic text width calculation for dropdown options
   - Used for primary action with alternatives
+  - The leading icon column is **always** reserved, even on a row with no icon: `SplitButton`
+    substitutes the `NoIcon` placeholder, which draws nothing but still measures
+    `--button-icon-size`. That is deliberate - it is what keeps the text of icon-less dropdown rows
+    aligned with the rows that do have icons. The cost is ~30px (`--button-icon-size` plus
+    2 × `--button-icon-h-padding`) on a button with no icon anywhere, so such a button cannot be
+    made as narrow as a design that hides its icon slot entirely
+  - **Known issue:** `...rest` is spread after the component's own `className`, so
+    `styled(SplitButton)` replaces the `split-button-<design>` class instead of merging with it and
+    the design's theme variables are lost. Wrap it in a styled container rather than calling
+    `styled()` on it. `Button` was fixed for this in PR #632; SplitButton has not been
 
 ---
 

--- a/COMPONENT_INVENTORY.md
+++ b/COMPONENT_INVENTORY.md
@@ -1,7 +1,7 @@
 # Scorer UI Kit - Component Inventory
 
 **Generated:** 2026-02-04
-**Last Updated:** 2026-02-06
+**Last Updated:** 2026-07-24
 **Source:** ui-lib/src & storybook/src/stories
 
 This document provides a comprehensive inventory of all React components in the Scorer UI Kit to be used by human and AI, organized alphabetically with their corresponding Storybook documentation status, file paths, props, and notable features.
@@ -300,6 +300,28 @@ This document provides a comprehensive inventory of all React components in the 
   - Controlled/uncontrolled modes
   - Accessibility compliant
   - Visual state management (on/off/indeterminate)
+
+---
+
+### ChipButton
+- **Status:** ✅ Has Storybook
+- **Component Path:** `ui-lib/src/Chips/atoms/ChipButton.tsx`
+- **Story Path:** `storybook/src/stories/Chips/atoms/ChipButton.stories.tsx`
+- **Exported From:** `Chips`
+- **Props:** (extends `ButtonHTMLAttributes<HTMLButtonElement>`)
+  - `variant?`: `IChipVariant` (`'icon' | 'text'`) - Content mode; 'icon' renders an Icon, 'text' renders a number/letter label (default: 'text')
+  - `icon?`: `string` - Icon name rendered when variant='icon'
+  - `label?`: `string` - Text/numeral rendered when variant='text' (falls back to children)
+  - `selected?`: `boolean` - Persistent selected state: primary wash background + bottom bar (default: false)
+  - `noDivider?`: `boolean` - Suppress the 1px left divider shown by default on 'text' chips (default: false)
+  - Plus all standard HTML button attributes (`onClick`, `disabled`, `aria-label`, etc.)
+- **Notable Features:**
+  - 56×56 top-bar "Space" chip (Figma: Spaces / Top Bar / Chip)
+  - Two content variants: icon (workspace grid glyph) and text/number
+  - CSS-driven hover bar; prop-driven persistent selected state (bar + wash)
+  - 4px bottom bar overhanging 1px each side to cover cell hairlines
+  - 1px left divider on text chips, suppressible via noDivider (for zone breaks)
+  - Uses theme CSS variables for automatic light/dark support
 
 ---
 

--- a/COMPONENT_INVENTORY.md
+++ b/COMPONENT_INVENTORY.md
@@ -1,7 +1,7 @@
 # Scorer UI Kit - Component Inventory
 
 **Generated:** 2026-02-04
-**Last Updated:** 2026-07-24
+**Last Updated:** 2026-07-27
 **Source:** ui-lib/src & storybook/src/stories
 
 This document provides a comprehensive inventory of all React components in the Scorer UI Kit to be used by human and AI, organized alphabetically with their corresponding Storybook documentation status, file paths, props, and notable features.
@@ -313,14 +313,37 @@ This document provides a comprehensive inventory of all React components in the 
   - `icon?`: `string` - Icon name rendered when variant='icon'
   - `label?`: `string` - Text/numeral rendered when variant='text' (falls back to children)
   - `selected?`: `boolean` - Persistent selected state: primary wash background + bottom bar (default: false)
-  - `noDivider?`: `boolean` - Suppress the 1px left divider shown by default on 'text' chips (default: false)
+  - `noDivider?`: `boolean` - Suppress the 1px left divider shown by default on all chips (default: false)
   - Plus all standard HTML button attributes (`onClick`, `disabled`, `aria-label`, etc.)
 - **Notable Features:**
   - 56×56 top-bar "Space" chip (Figma: Spaces / Top Bar / Chip)
   - Two content variants: icon (workspace grid glyph) and text/number
   - CSS-driven hover bar; prop-driven persistent selected state (bar + wash)
   - 4px bottom bar overhanging 1px each side to cover cell hairlines
-  - 1px left divider on text chips, suppressible via noDivider (for zone breaks)
+  - 1px left divider on both variants, suppressible via noDivider (leftmost cell / zone breaks)
+  - Uses theme CSS variables for automatic light/dark support
+
+---
+
+### ChipDropdown
+- **Status:** ✅ Has Storybook
+- **Component Path:** `ui-lib/src/Chips/molecules/ChipDropdown.tsx`
+- **Story Path:** `storybook/src/stories/Chips/molecules/ChipDropdown.stories.tsx`
+- **Exported From:** `Chips`
+- **Props:** (extends `HTMLAttributes<HTMLDivElement>`)
+  - `items`: `IChipDropdownItem[]` - Menu rows: `{ id, label, icon?, disabled?, onClick? }` (required)
+  - `icon?`: `string` - Trigger icon name (default: 'FilterEllipsis')
+  - `triggerLabel?`: `string` - Accessible label for the trigger button (default: 'Space actions')
+  - `noDivider?`: `boolean` - Hide the trigger chip's 1px left divider (default: false)
+  - `disabled?`: `boolean` - Disable the trigger (default: false)
+  - `onOpenChange?`: `(open: boolean) => void` - Notified when the menu opens/closes
+- **Notable Features:**
+  - Top-bar ellipsis "Space actions" cell (Figma: Spaces / Top Bar / Space Menu Cell)
+  - Composes the ChipButton atom as the trigger (open state = chip 'selected' bar)
+  - Click-outside and Escape close the menu (uses useClickOutside)
+  - Action menu with per-row icon + label; selecting a row fires onClick and closes
+  - Menu shadow reuses FilterDropdownContainer's `--filter-button-shadow-color` token
+    (deviation from Figma's untokenised "Spaces/Card Shadow")
   - Uses theme CSS variables for automatic light/dark support
 
 ---

--- a/COMPONENT_INVENTORY.md
+++ b/COMPONENT_INVENTORY.md
@@ -321,6 +321,11 @@ This document provides a comprehensive inventory of all React components in the 
   - Does not hijack arrow keys while a ChipDropdown menu is open
   - Cells never shrink (`flex-shrink: 0`): in a narrow container the row overflows rather than
     squashing the 56px cells. Overflow itself is undefined in v1 - wrap ChipBar if you need scrolling
+  - **Trap:** children must not be wrapped in a `Fragment`. `Children.toArray` flattens arrays but
+    not fragments, so the fragment itself arrives as the first child - `noDivider` then lands on the
+    (prop-less) fragment instead of the chip inside it, silently leaving the leading cell's hairline
+    in place. React only logs the invalid-prop warning on a re-render, never on mount, so the bug is
+    easy to miss on first render
 
 ---
 
@@ -381,8 +386,10 @@ This document provides a comprehensive inventory of all React components in the 
   - Action menu with per-row icon + label; selecting a row fires onClick and closes
   - **Labelled mode** (`label` set) is the Arrangement cell, the active-layout picker (Figma:
     Spaces / Top Bar / Arrangement Cell). The trigger becomes glyph (18px) + text + a 12px `Down`
-    caret, 56px tall but sized to its content instead of the 56px square, with 14px/16px padding and
-    no left divider - it always sits right of a ChipZoneBreak, which owns both hairlines
+    caret, 56px tall but sized to its content instead of the 56px square, with 14px/16px padding. In
+    the Arrangement layout it sits right of a ChipZoneBreak, which owns both hairlines - but `noDivider`
+    is not set automatically in labelled mode, it stays a plain pass-through defaulting to `false`.
+    Pass `noDivider` yourself, or the trigger keeps its own 1px divider next to the Zone Break's
   - The caret does **not** flip when the menu opens (Figma uses one caret asset in all three
     states). Note `SplitButton` swaps `Down`→`Close`; the two kit components differ on purpose
   - `triggerLabel` is only defaulted in icon-only mode. In labelled mode the visible text is the

--- a/packages/storybook/src/stories/Chips/atoms/ChipButton.stories.tsx
+++ b/packages/storybook/src/stories/Chips/atoms/ChipButton.stories.tsx
@@ -1,0 +1,34 @@
+import { boolean, select, text } from '@storybook/addon-knobs';
+import { ChipButton, type IChipVariant } from 'scorer-ui-kit';
+import { action } from 'storybook/actions';
+import { generateIconList } from '../../helpers';
+
+const ChipButtonStory = {
+  title: 'Chips/atoms',
+  component: ChipButton,
+  decorators: [],
+};
+
+export const _ChipButton = () => {
+  const iconList = generateIconList();
+  const variant = select('Variant', { Icon: 'icon', Text: 'text' }, 'text');
+  const icon = select('Icon', iconList, 'LayoutGrid');
+  const label = text('Label', '1');
+  const selected = boolean('Selected', false);
+  const noDivider = boolean('No divider', false);
+  const onClick = action('chip-click');
+
+  return (
+    <ChipButton
+      variant={variant as IChipVariant}
+      icon={icon}
+      label={label}
+      selected={selected}
+      noDivider={noDivider}
+      onClick={onClick}
+      aria-label={variant === 'icon' ? 'Workspace' : `Space ${label}`}
+    />
+  );
+};
+
+export default ChipButtonStory;

--- a/packages/storybook/src/stories/Chips/atoms/ChipZoneBreak.stories.tsx
+++ b/packages/storybook/src/stories/Chips/atoms/ChipZoneBreak.stories.tsx
@@ -1,0 +1,65 @@
+import { boolean } from '@storybook/addon-knobs';
+import { ChipBar, ChipButton, ChipDropdown, ChipZoneBreak } from 'scorer-ui-kit';
+import { action } from 'storybook/actions';
+import styled from 'styled-components';
+
+const ChipZoneBreakStory = {
+  title: 'Chips/atoms',
+  component: ChipZoneBreak,
+  decorators: [],
+};
+
+// stands in for the consumer's top bar: the band only reads as a separation against the zones
+// on either side of it
+const TopBar = styled.div`
+  display: flex;
+  align-items: center;
+  height: 56px;
+  background: var(--grey-2);
+  border-bottom: 1px solid var(--dividing-line);
+`;
+
+// the alternative the band replaces — a plain hairline between the two zones
+const Hairline = styled.div`
+  flex-shrink: 0;
+  width: 1px;
+  height: 56px;
+  background-color: var(--grey-4);
+`;
+
+export const _ChipZoneBreak = () => {
+  const useZoneBreak = boolean('Use zone break (off = plain 1px divider)', true);
+  const trailingBreak = boolean('Trailing zone break', true);
+  const onClick = action('cell-click');
+
+  const Separator = useZoneBreak ? ChipZoneBreak : Hairline;
+
+  return (
+    <TopBar>
+      <ChipBar aria-label='Spaces'>
+        <ChipButton variant='icon' icon='LayoutGrid' aria-label='Workspace' onClick={onClick} />
+        <ChipButton label='1' onClick={onClick} aria-label='Space 1' />
+        <ChipButton label='2' onClick={onClick} aria-label='Space 2' />
+        <ChipButton label='3' selected onClick={onClick} aria-label='Space 3' />
+        <ChipDropdown
+          items={[
+            { id: 'add', label: 'Add Space', icon: 'Add', onClick },
+            { id: 'duplicate', label: 'Duplicate Space 3', icon: 'Copy', onClick },
+            { id: 'remove', label: 'Remove Space 3', icon: 'Delete', onClick },
+          ]}
+        />
+      </ChipBar>
+
+      <Separator />
+
+      <ChipBar aria-label='Layout controls'>
+        <ChipButton variant='icon' icon='LayoutList' aria-label='Arrangement' onClick={onClick} />
+        <ChipButton variant='icon' icon='Download' aria-label='Save' onClick={onClick} />
+      </ChipBar>
+
+      {trailingBreak ? <Separator /> : null}
+    </TopBar>
+  );
+};
+
+export default ChipZoneBreakStory;

--- a/packages/storybook/src/stories/Chips/molecules/ChipDropdown.stories.tsx
+++ b/packages/storybook/src/stories/Chips/molecules/ChipDropdown.stories.tsx
@@ -1,0 +1,39 @@
+import { boolean } from '@storybook/addon-knobs';
+import { ChipDropdown, type IChipDropdownItem } from 'scorer-ui-kit';
+import { action } from 'storybook/actions';
+
+const ChipDropdownStory = {
+  title: 'Chips/molecules',
+  component: ChipDropdown,
+  decorators: [],
+};
+
+export const _ChipDropdown = () => {
+  const noDivider = boolean('No divider', false);
+  const disabled = boolean('Disabled', false);
+
+  const items: IChipDropdownItem[] = [
+    { id: 'add', label: 'Add Space', icon: 'Add', onClick: action('add-space') },
+    {
+      id: 'duplicate',
+      label: 'Duplicate Space 3',
+      icon: 'Copy',
+      onClick: action('duplicate-space'),
+    },
+    { id: 'remove', label: 'Remove Space 3', icon: 'Delete', onClick: action('remove-space') },
+  ];
+
+  return (
+    // room below the trigger so the open menu is visible in the canvas
+    <div style={{ padding: '20px 20px 220px' }}>
+      <ChipDropdown
+        items={items}
+        noDivider={noDivider}
+        disabled={disabled}
+        onOpenChange={action('open-change')}
+      />
+    </div>
+  );
+};
+
+export default ChipDropdownStory;

--- a/packages/storybook/src/stories/Chips/molecules/ChipDropdownArrangement.stories.tsx
+++ b/packages/storybook/src/stories/Chips/molecules/ChipDropdownArrangement.stories.tsx
@@ -1,0 +1,70 @@
+import { boolean, select } from '@storybook/addon-knobs';
+import { useState } from 'react';
+import { ChipDropdown, type IChipDropdownItem } from 'scorer-ui-kit';
+import { action } from 'storybook/actions';
+import { generateIconList } from '../../helpers';
+
+const ChipDropdownArrangementStory = {
+  title: 'Chips/molecules',
+  component: ChipDropdown,
+  decorators: [],
+};
+
+/* ChipDropdown's labelled mode — Figma "Spaces/Top Bar/Arrangement Cell" (9154:6033). Same
+   component as the ellipsis cell; passing `label` switches the trigger to glyph + text + caret.
+
+   LayoutGrid / LayoutList stand in for the four layout glyphs, which are in no icon package yet. */
+const ARRANGEMENTS = [
+  { id: '6-up', label: '6-up', icon: 'LayoutGrid' },
+  { id: '4-up', label: '4-up', icon: 'LayoutGrid' },
+  { id: '2-up', label: '2-up', icon: 'LayoutList' },
+  { id: '1-big-2', label: '1 big + 2', icon: 'LayoutList' },
+];
+
+export const _ChipDropdownArrangement = () => {
+  const iconList = generateIconList();
+
+  // clearing `label` returns the trigger to the icon-only 56px square. A toggle, not a text knob:
+  // the trigger text tracks the selected row rather than being free-form.
+  const labelled = boolean('Labelled mode (off = icon-only 56px trigger)', true);
+  const checkIcon = select('Check icon', iconList, 'Success');
+  const disabled = boolean('Disabled', false);
+
+  // state, so clicking a row actually moves the check
+  const [selectedId, setSelectedId] = useState('6-up');
+  const onSelect = action('arrangement-select');
+
+  const current = ARRANGEMENTS.find(({ id }) => id === selectedId);
+
+  const items: IChipDropdownItem[] = ARRANGEMENTS.map(({ id, label, icon }) => ({
+    id,
+    label,
+    icon,
+    onClick: () => {
+      onSelect(id);
+      setSelectedId(id);
+    },
+  }));
+
+  return (
+    // room below the trigger so the open menu is visible in the canvas
+    <div style={{ padding: '20px 20px 220px' }}>
+      <ChipDropdown
+        items={items}
+        icon={current?.icon ?? 'LayoutGrid'}
+        label={labelled ? current?.label : undefined}
+        selectedId={selectedId}
+        checkIcon={checkIcon}
+        /* aria-label replaces the content as the accessible name, so it has to lead with the value
+           on screen — otherwise "6-up" is unreachable by voice and fails WCAG 2.5.3 */
+        triggerLabel={current ? `${current.label} arrangement` : undefined}
+        // no left divider: in the top bar a Zone Break owns that hairline
+        noDivider
+        disabled={disabled}
+        onOpenChange={action('open-change')}
+      />
+    </div>
+  );
+};
+
+export default ChipDropdownArrangementStory;

--- a/packages/storybook/src/stories/Chips/molecules/ChipDropdownArrangement.stories.tsx
+++ b/packages/storybook/src/stories/Chips/molecules/ChipDropdownArrangement.stories.tsx
@@ -10,10 +10,10 @@ const ChipDropdownArrangementStory = {
   decorators: [],
 };
 
-/* ChipDropdown's labelled mode — Figma "Spaces/Top Bar/Arrangement Cell" (9154:6033). Same
-   component as the ellipsis cell; passing `label` switches the trigger to glyph + text + caret.
+/* ChipDropdown's labelled mode: the same component as the ellipsis cell, where passing `label`
+   switches the trigger to glyph + text + caret.
 
-   LayoutGrid / LayoutList stand in for the four layout glyphs, which are in no icon package yet. */
+   LayoutGrid / LayoutList stand in for the four layout glyphs, which no icon package provides. */
 const ARRANGEMENTS = [
   { id: '6-up', label: '6-up', icon: 'LayoutGrid' },
   { id: '4-up', label: '4-up', icon: 'LayoutGrid' },
@@ -30,7 +30,6 @@ export const _ChipDropdownArrangement = () => {
   const checkIcon = select('Check icon', iconList, 'Success');
   const disabled = boolean('Disabled', false);
 
-  // state, so clicking a row actually moves the check
   const [selectedId, setSelectedId] = useState('6-up');
   const onSelect = action('arrangement-select');
 

--- a/packages/storybook/src/stories/Chips/organisms/ChipBar.stories.tsx
+++ b/packages/storybook/src/stories/Chips/organisms/ChipBar.stories.tsx
@@ -1,0 +1,150 @@
+import { boolean } from '@storybook/addon-knobs';
+import { useRef, useState } from 'react';
+import { ChipBar, ChipButton, ChipDropdown, type IChipDropdownItem } from 'scorer-ui-kit';
+import { action } from 'storybook/actions';
+
+const ChipBarStory = {
+  title: 'Chips/organisms',
+  component: ChipBar,
+  decorators: [],
+};
+
+// ChipBar has no overflow handling in v1 (it is a plain flex row), so the demo keeps the
+// bar inside a sensible width
+const MAX_SPACES = 6;
+
+interface ISpace {
+  uid: string;
+}
+
+export const _ChipBar = () => {
+  const showWorkspace = boolean('Show workspace chip', true);
+
+  // Spaces carry a stable uid and take their number from their position. That is what makes the
+  // removal legible: the chip you removed is the one that unmounts, and the chips to its right
+  // really do get a new number. Keying by the number instead would silently unmount the
+  // *rightmost* chip and change no label at all.
+  const [spaces, setSpaces] = useState<ISpace[]>([{ uid: 's1' }, { uid: 's2' }, { uid: 's3' }]);
+  const [selectedUid, setSelectedUid] = useState('s1');
+  const [leavingUid, setLeavingUid] = useState<string | null>(null);
+  const [isWorkspaceActive, setIsWorkspaceActive] = useState(false);
+  const nextUid = useRef(spaces.length + 1);
+
+  // a hidden Workspace chip cannot be the active cell
+  const workspaceActive = showWorkspace && isWorkspaceActive;
+  const selectedNumber = String(spaces.findIndex((space) => space.uid === selectedUid) + 1);
+
+  const onWorkspaceClick = action('workspace-click');
+  const onSpaceClick = action('space-click');
+  const onAdd = action('add-space');
+  const onDuplicate = action('duplicate-space');
+  const onRemove = action('remove-space');
+
+  // Add and Duplicate both append: a Space carries no content of its own here, so a copy is just
+  // another Space on the right, taking the next number.
+  const appendSpace = () => {
+    const uid = `s${nextUid.current++}`;
+    setSpaces([...spaces, { uid }]);
+    setSelectedUid(uid); // the new Space becomes the active one
+    setIsWorkspaceActive(false);
+  };
+
+  const dropSpace = (uid: string) => {
+    const index = spaces.findIndex((space) => space.uid === uid);
+    if (index < 0) {
+      return; // already gone
+    }
+    const remaining = spaces.filter((space) => space.uid !== uid);
+    setSpaces(remaining);
+    // the Space that sat to the right takes its number — clamp when the last one went
+    setSelectedUid(remaining[Math.min(index, remaining.length - 1)].uid);
+    setLeavingUid(null);
+    setIsWorkspaceActive(false);
+  };
+
+  // Mark the cell as leaving and let the chip collapse; it calls onLeaveEnd when it is done (or
+  // immediately, if the user prefers reduced motion). The numbers to its right therefore only
+  // shift once the gap has finished closing.
+  const removeSelectedSpace = () => setLeavingUid(selectedUid);
+
+  const menuItems: IChipDropdownItem[] = [
+    {
+      id: 'add',
+      label: 'Add Space',
+      icon: 'Add',
+      disabled: spaces.length >= MAX_SPACES,
+      onClick: () => {
+        onAdd();
+        appendSpace();
+      },
+    },
+    {
+      id: 'duplicate',
+      label: `Duplicate Space ${selectedNumber}`,
+      icon: 'Copy',
+      disabled: spaces.length >= MAX_SPACES,
+      onClick: () => {
+        onDuplicate(selectedNumber);
+        appendSpace();
+      },
+    },
+    {
+      id: 'remove',
+      label: `Remove Space ${selectedNumber}`,
+      icon: 'Delete',
+      disabled: spaces.length <= 1,
+      onClick: () => {
+        onRemove(selectedNumber);
+        removeSelectedSpace();
+      },
+    },
+  ];
+
+  return (
+    // room below the bar so the open dropdown menu is visible in the canvas
+    <div style={{ padding: '0 0 220px' }}>
+      <ChipBar aria-label='Spaces'>
+        {showWorkspace ? (
+          <ChipButton
+            variant='icon'
+            icon='LayoutGrid'
+            aria-label='Workspace'
+            selected={workspaceActive}
+            onClick={() => {
+              onWorkspaceClick();
+              setIsWorkspaceActive(true);
+            }}
+          />
+        ) : null}
+        {spaces.map((space, index) => {
+          const number = String(index + 1);
+          return (
+            <ChipButton
+              key={space.uid}
+              leaving={space.uid === leavingUid}
+              onLeaveEnd={() => dropSpace(space.uid)}
+              variant='text'
+              label={number}
+              selected={!workspaceActive && space.uid === selectedUid}
+              aria-label={`Space ${number}`}
+              onClick={() => {
+                onSpaceClick(number);
+                setSelectedUid(space.uid);
+                setIsWorkspaceActive(false);
+              }}
+            />
+          );
+        })}
+        {/* the Workspace is not a Space, so it cannot be duplicated or removed —
+            the whole menu is disabled while it is the active cell */}
+        <ChipDropdown
+          items={menuItems}
+          disabled={workspaceActive}
+          onOpenChange={action('open-change')}
+        />
+      </ChipBar>
+    </div>
+  );
+};
+
+export default ChipBarStory;

--- a/packages/storybook/src/stories/Chips/organisms/ChipBar.stories.tsx
+++ b/packages/storybook/src/stories/Chips/organisms/ChipBar.stories.tsx
@@ -9,8 +9,8 @@ const ChipBarStory = {
   decorators: [],
 };
 
-// ChipBar has no overflow handling in v1 (it is a plain flex row), so the demo keeps the
-// bar inside a sensible width
+// ChipBar has no overflow handling (it is a plain flex row), so the demo keeps the bar inside a
+// sensible width
 const MAX_SPACES = 6;
 
 interface ISpace {
@@ -45,7 +45,7 @@ export const _ChipBar = () => {
   const appendSpace = () => {
     const uid = `s${nextUid.current++}`;
     setSpaces([...spaces, { uid }]);
-    setSelectedUid(uid); // the new Space becomes the active one
+    setSelectedUid(uid);
     setIsWorkspaceActive(false);
   };
 

--- a/packages/storybook/src/stories/Chips/organisms/SpacesTopBar.stories.tsx
+++ b/packages/storybook/src/stories/Chips/organisms/SpacesTopBar.stories.tsx
@@ -7,31 +7,23 @@ import {
   ChipDropdown,
   ChipZoneBreak,
   type IChipDropdownItem,
+  type INotificationsHistory,
   SplitButton,
+  TopBar,
 } from 'scorer-ui-kit';
 import { action } from 'storybook/actions';
 import styled from 'styled-components';
 
-/* The left half of a 56px top bar, assembled from kit components. A demo, not a pattern to copy:
-   - Top Bar Right (Admin / Notifications / Account) is omitted — the kit's own `TopBar` already
-     provides that chrome, so imitating it here would invite rebuilding it.
-   - LayoutGrid / LayoutList stand in for the four layout glyphs, which no icon package provides.
-   - The container stands in for `TopBar`, so the chips sit flush at x=0 here. Inside the real
-     `TopBar` its own padding will inset them. */
+/* Spaces/Arrangement/Save/Reset content for the kit's real `TopBar`, passed in as
+   `leftAreaElement` below. A demo, not a pattern to copy:
+   - Admin is the `badge` prop (kit's `TopBarBadge`), not a bespoke button — it renders as a plain
+     bordered pill unless given `onClick`/`linkTo`/`linkHref`, which switch it to interactive styling.
+   - LayoutGrid / LayoutList stand in for the four layout glyphs, which no icon package provides. */
 const SpacesTopBarStory = {
   title: 'Chips/organisms',
   component: ChipBar,
   decorators: [],
 };
-
-// no left padding, so the flush-at-x=0 gap against the real TopBar stays visible
-const TopBar = styled.div`
-  display: flex;
-  align-items: center;
-  height: 56px;
-  background: var(--grey-2);
-  border-bottom: 1px solid var(--dividing-line);
-`;
 
 /* Save and Reset hold form controls rather than chips, so they sit outside any ChipBar with their
    own 56px geometry. Do not switch this to styled(SplitButton): it spreads ...rest after its own
@@ -54,6 +46,16 @@ const ResetCell = styled.div`
   padding: 0 16px 0 14px;
 `;
 
+/* TopBar's own drawers are `position: fixed` against the true viewport edges. Without this,
+   Storybook's ambient story padding leaves TopBar itself inset from those edges while an opened
+   drawer still hugs them, so the two drift apart. */
+const FixedTopBar = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+`;
+
 const ARRANGEMENTS = [
   { id: '6-up', label: '6-up', icon: 'LayoutGrid' },
   { id: '4-up', label: '4-up', icon: 'LayoutGrid' },
@@ -63,6 +65,11 @@ const ARRANGEMENTS = [
 
 // ChipBar has no overflow handling, so the demo keeps the row to a sensible width
 const MAX_SPACES = 6;
+
+// an empty history is valid and renders the kit's own "no notifications" placeholder; omitting
+// the prop instead leaves the opened drawer blank, since TopBar checks the prop's presence, not
+// its contents
+const NOTIFICATIONS_HISTORY: INotificationsHistory = { read: [], unread: [] };
 
 interface ISpace {
   uid: string;
@@ -95,6 +102,7 @@ export const _SpacesTopBar = () => {
   const onSave = action('save-space');
   const onSaveAs = action('save-space-as');
   const onReset = action('reset-layout');
+  const onAdminClick = action('admin-click');
 
   const appendSpace = () => {
     const uid = `s${nextUid.current++}`;
@@ -184,74 +192,83 @@ export const _SpacesTopBar = () => {
     },
   ];
 
-  return (
-    // room below the bar so the open menus are visible in the canvas
-    <div style={{ padding: '0 0 260px' }}>
-      <TopBar>
-        <ChipBar aria-label='Spaces'>
-          {showWorkspace ? (
+  const leftAreaElement = (
+    <>
+      <ChipBar aria-label='Spaces'>
+        {showWorkspace ? (
+          <ChipButton
+            variant='icon'
+            icon='LayoutGrid'
+            aria-label='Workspace'
+            selected={workspaceActive}
+            onClick={() => {
+              onWorkspaceClick();
+              setIsWorkspaceActive(true);
+            }}
+          />
+        ) : null}
+        {spaces.map((space, index) => {
+          const number = String(index + 1);
+          return (
             <ChipButton
-              variant='icon'
-              icon='LayoutGrid'
-              aria-label='Workspace'
-              selected={workspaceActive}
+              key={space.uid}
+              leaving={space.uid === leavingUid}
+              onLeaveEnd={() => dropSpace(space.uid)}
+              variant='text'
+              label={number}
+              selected={!workspaceActive && space.uid === selectedUid}
+              aria-label={`Space ${number}`}
               onClick={() => {
-                onWorkspaceClick();
-                setIsWorkspaceActive(true);
+                onSpaceClick(number);
+                setSelectedUid(space.uid);
+                setIsWorkspaceActive(false);
               }}
             />
-          ) : null}
-          {spaces.map((space, index) => {
-            const number = String(index + 1);
-            return (
-              <ChipButton
-                key={space.uid}
-                leaving={space.uid === leavingUid}
-                onLeaveEnd={() => dropSpace(space.uid)}
-                variant='text'
-                label={number}
-                selected={!workspaceActive && space.uid === selectedUid}
-                aria-label={`Space ${number}`}
-                onClick={() => {
-                  onSpaceClick(number);
-                  setSelectedUid(space.uid);
-                  setIsWorkspaceActive(false);
-                }}
-              />
-            );
-          })}
-          {/* the Workspace is not a Space, so it cannot be duplicated or removed */}
-          <ChipDropdown
-            items={spaceMenuItems}
-            disabled={workspaceActive}
-            onOpenChange={action('space-menu-open-change')}
-          />
-        </ChipBar>
+          );
+        })}
+        {/* the Workspace is not a Space, so it cannot be duplicated or removed */}
+        <ChipDropdown
+          items={spaceMenuItems}
+          disabled={workspaceActive}
+          onOpenChange={action('space-menu-open-change')}
+        />
+      </ChipBar>
 
-        {/* both zone breaks present, so the "cells beside a break drop their border" rule reads */}
-        <ChipZoneBreak />
-        <ChipBar aria-label='Layout controls'>
-          <ChipDropdown
-            items={arrangementItems}
-            icon={arrangement?.icon ?? 'LayoutGrid'}
-            label={arrangement?.label}
-            selectedId={arrangementId}
-            // leads with the value on screen: an aria-label that dropped it would fail WCAG 2.5.3
-            triggerLabel={arrangement ? `${arrangement.label} arrangement` : undefined}
-            onOpenChange={action('arrangement-open-change')}
-          />
-        </ChipBar>
-        <SaveCell>
-          <SplitButton mainButtonId={`save-${selectedUid}`} buttonList={saveButtonList} />
-        </SaveCell>
-        <ResetCell>
-          <Button design='text-only' noPadding disabled={!canReset} onClick={onReset}>
-            Reset
-          </Button>
-        </ResetCell>
-        <ChipZoneBreak />
-      </TopBar>
-    </div>
+      {/* both zone breaks present, so the "cells beside a break drop their border" rule reads */}
+      <ChipZoneBreak />
+      <ChipBar aria-label='Layout controls'>
+        <ChipDropdown
+          items={arrangementItems}
+          icon={arrangement?.icon ?? 'LayoutGrid'}
+          label={arrangement?.label}
+          selectedId={arrangementId}
+          // leads with the value on screen: an aria-label that dropped it would fail WCAG 2.5.3
+          triggerLabel={arrangement ? `${arrangement.label} arrangement` : undefined}
+          onOpenChange={action('arrangement-open-change')}
+        />
+      </ChipBar>
+      <SaveCell>
+        <SplitButton mainButtonId={`save-${selectedUid}`} buttonList={saveButtonList} />
+      </SaveCell>
+      <ResetCell>
+        <Button design='text-only' noPadding disabled={!canReset} onClick={onReset}>
+          Reset
+        </Button>
+      </ResetCell>
+      <ChipZoneBreak />
+    </>
+  );
+
+  return (
+    <FixedTopBar>
+      <TopBar
+        loggedInUser='full.name@example.com'
+        hasNotifications
+        notificationsHistory={NOTIFICATIONS_HISTORY}
+        badge={{ text: 'Admin', color: 'grey', onClick: onAdminClick }}
+        leftAreaElement={leftAreaElement}
+      />
+    </FixedTopBar>
   );
 };
 

--- a/packages/storybook/src/stories/Chips/organisms/SpacesTopBar.stories.tsx
+++ b/packages/storybook/src/stories/Chips/organisms/SpacesTopBar.stories.tsx
@@ -12,14 +12,12 @@ import {
 import { action } from 'storybook/actions';
 import styled from 'styled-components';
 
-/* The left half of Figma "Top Bar 56 (componentized)" (9159:6142), assembled from kit components.
-
-   Not finished work, and not to be copied as-is:
-   - Top Bar Right (Admin / Notifications / Account) is omitted on purpose — the kit's own `TopBar`
-     already provides that chrome, so imitating it here would invite rebuilding it.
-   - LayoutGrid / LayoutList stand in for the four layout glyphs, which are in no icon package yet.
-   - The container stands in for `TopBar`, whose `leftAreaElement` (PR #675) is not on this branch.
-     Its `padding: 0 16px 0 24px` will inset the chips, so they will not sit flush at x=0. */
+/* The left half of a 56px top bar, assembled from kit components. A demo, not a pattern to copy:
+   - Top Bar Right (Admin / Notifications / Account) is omitted — the kit's own `TopBar` already
+     provides that chrome, so imitating it here would invite rebuilding it.
+   - LayoutGrid / LayoutList stand in for the four layout glyphs, which no icon package provides.
+   - The container stands in for `TopBar`, so the chips sit flush at x=0 here. Inside the real
+     `TopBar` its own padding will inset them. */
 const SpacesTopBarStory = {
   title: 'Chips/organisms',
   component: ChipBar,
@@ -47,8 +45,7 @@ const SaveCell = styled.div`
   border-left: 1px solid var(--grey-4);
 `;
 
-/* The cell owns the padding and centres the 32px Button in the 56px band. Closest kit variant to
-   Figma's Reset, but --grey-12 text where the design asks --grey-10. */
+/* The cell owns the padding and centres the 32px Button in the 56px band. */
 const ResetCell = styled.div`
   display: flex;
   flex-shrink: 0;
@@ -64,7 +61,7 @@ const ARRANGEMENTS = [
   { id: '1-big-2', label: '1 big + 2', icon: 'LayoutList' },
 ];
 
-// ChipBar has no overflow handling in v1, so the demo keeps the row to a sensible width
+// ChipBar has no overflow handling, so the demo keeps the row to a sensible width
 const MAX_SPACES = 6;
 
 interface ISpace {
@@ -102,7 +99,7 @@ export const _SpacesTopBar = () => {
   const appendSpace = () => {
     const uid = `s${nextUid.current++}`;
     setSpaces([...spaces, { uid }]);
-    setSelectedUid(uid); // the new Space becomes the active one
+    setSelectedUid(uid);
     setIsWorkspaceActive(false);
   };
 
@@ -191,7 +188,6 @@ export const _SpacesTopBar = () => {
     // room below the bar so the open menus are visible in the canvas
     <div style={{ padding: '0 0 260px' }}>
       <TopBar>
-        {/* 280px here against Figma's 268: the shipped ⋯ cell is a 56px square, Figma's is 44px */}
         <ChipBar aria-label='Spaces'>
           {showWorkspace ? (
             <ChipButton
@@ -237,7 +233,6 @@ export const _SpacesTopBar = () => {
         <ChipBar aria-label='Layout controls'>
           <ChipDropdown
             items={arrangementItems}
-            // the trigger glyph tracks the value, as the Figma component description requires
             icon={arrangement?.icon ?? 'LayoutGrid'}
             label={arrangement?.label}
             selectedId={arrangementId}

--- a/packages/storybook/src/stories/Chips/organisms/SpacesTopBar.stories.tsx
+++ b/packages/storybook/src/stories/Chips/organisms/SpacesTopBar.stories.tsx
@@ -1,0 +1,263 @@
+import { boolean } from '@storybook/addon-knobs';
+import { useRef, useState } from 'react';
+import {
+  Button,
+  ChipBar,
+  ChipButton,
+  ChipDropdown,
+  ChipZoneBreak,
+  type IChipDropdownItem,
+  SplitButton,
+} from 'scorer-ui-kit';
+import { action } from 'storybook/actions';
+import styled from 'styled-components';
+
+/* The left half of Figma "Top Bar 56 (componentized)" (9159:6142), assembled from kit components.
+
+   Not finished work, and not to be copied as-is:
+   - Top Bar Right (Admin / Notifications / Account) is omitted on purpose — the kit's own `TopBar`
+     already provides that chrome, so imitating it here would invite rebuilding it.
+   - LayoutGrid / LayoutList stand in for the four layout glyphs, which are in no icon package yet.
+   - The container stands in for `TopBar`, whose `leftAreaElement` (PR #675) is not on this branch.
+     Its `padding: 0 16px 0 24px` will inset the chips, so they will not sit flush at x=0. */
+const SpacesTopBarStory = {
+  title: 'Chips/organisms',
+  component: ChipBar,
+  decorators: [],
+};
+
+// no left padding, so the flush-at-x=0 gap against the real TopBar stays visible
+const TopBar = styled.div`
+  display: flex;
+  align-items: center;
+  height: 56px;
+  background: var(--grey-2);
+  border-bottom: 1px solid var(--dividing-line);
+`;
+
+/* Save and Reset hold form controls rather than chips, so they sit outside any ChipBar with their
+   own 56px geometry. Do not switch this to styled(SplitButton): it spreads ...rest after its own
+   className, which drops the split-button-<design> class and its theming. */
+const SaveCell = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  height: 56px;
+  padding: 0 12px;
+  border-left: 1px solid var(--grey-4);
+`;
+
+/* The cell owns the padding and centres the 32px Button in the 56px band. Closest kit variant to
+   Figma's Reset, but --grey-12 text where the design asks --grey-10. */
+const ResetCell = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  height: 56px;
+  padding: 0 16px 0 14px;
+`;
+
+const ARRANGEMENTS = [
+  { id: '6-up', label: '6-up', icon: 'LayoutGrid' },
+  { id: '4-up', label: '4-up', icon: 'LayoutGrid' },
+  { id: '2-up', label: '2-up', icon: 'LayoutList' },
+  { id: '1-big-2', label: '1 big + 2', icon: 'LayoutList' },
+];
+
+// ChipBar has no overflow handling in v1, so the demo keeps the row to a sensible width
+const MAX_SPACES = 6;
+
+interface ISpace {
+  uid: string;
+}
+
+export const _SpacesTopBar = () => {
+  const showWorkspace = boolean('Show workspace chip', true);
+  const canReset = boolean('Reset enabled (dirty)', true);
+
+  // a stable uid with the number taken from position, so the chip you remove is the one that
+  // unmounts and the chips to its right really do renumber
+  const [spaces, setSpaces] = useState<ISpace[]>([{ uid: 's1' }, { uid: 's2' }, { uid: 's3' }]);
+  const [selectedUid, setSelectedUid] = useState('s3');
+  const [leavingUid, setLeavingUid] = useState<string | null>(null);
+  const [isWorkspaceActive, setIsWorkspaceActive] = useState(false);
+  const [arrangementId, setArrangementId] = useState('4-up');
+  const nextUid = useRef(spaces.length + 1);
+
+  // a hidden Workspace chip cannot be the active cell
+  const workspaceActive = showWorkspace && isWorkspaceActive;
+  const selectedNumber = String(spaces.findIndex((space) => space.uid === selectedUid) + 1);
+  const arrangement = ARRANGEMENTS.find(({ id }) => id === arrangementId);
+
+  const onWorkspaceClick = action('workspace-click');
+  const onSpaceClick = action('space-click');
+  const onAdd = action('add-space');
+  const onDuplicate = action('duplicate-space');
+  const onRemove = action('remove-space');
+  const onArrangement = action('arrangement-select');
+  const onSave = action('save-space');
+  const onSaveAs = action('save-space-as');
+  const onReset = action('reset-layout');
+
+  const appendSpace = () => {
+    const uid = `s${nextUid.current++}`;
+    setSpaces([...spaces, { uid }]);
+    setSelectedUid(uid); // the new Space becomes the active one
+    setIsWorkspaceActive(false);
+  };
+
+  const dropSpace = (uid: string) => {
+    const index = spaces.findIndex((space) => space.uid === uid);
+    if (index < 0) {
+      return; // already gone
+    }
+    const remaining = spaces.filter((space) => space.uid !== uid);
+    setSpaces(remaining);
+    // the Space that sat to the right takes its number — clamp when the last one went
+    setSelectedUid(remaining[Math.min(index, remaining.length - 1)].uid);
+    setLeavingUid(null);
+    setIsWorkspaceActive(false);
+  };
+
+  // ChipButton collapses the cell and calls onLeaveEnd when done, so the renumbering waits for the
+  // gap to close
+  const removeSelectedSpace = () => setLeavingUid(selectedUid);
+
+  // interpolating the active Space into these labels is the consumer's job, not ChipDropdown's
+  const spaceMenuItems: IChipDropdownItem[] = [
+    {
+      id: 'add',
+      label: 'Add Space',
+      icon: 'Add',
+      disabled: spaces.length >= MAX_SPACES,
+      onClick: () => {
+        onAdd();
+        appendSpace();
+      },
+    },
+    {
+      id: 'duplicate',
+      label: `Duplicate Space ${selectedNumber}`,
+      icon: 'Copy',
+      disabled: spaces.length >= MAX_SPACES,
+      onClick: () => {
+        onDuplicate(selectedNumber);
+        appendSpace();
+      },
+    },
+    {
+      id: 'remove',
+      label: `Remove Space ${selectedNumber}`,
+      icon: 'Delete',
+      disabled: spaces.length <= 1,
+      onClick: () => {
+        onRemove(selectedNumber);
+        removeSelectedSpace();
+      },
+    },
+  ];
+
+  const arrangementItems: IChipDropdownItem[] = ARRANGEMENTS.map(({ id, label, icon }) => ({
+    id,
+    label,
+    icon,
+    onClick: () => {
+      onArrangement(id);
+      setArrangementId(id);
+    },
+  }));
+
+  // one row per Space with the active one as mainButtonId, which SplitButton excludes from the
+  // dropdown. Derived from `spaces`, so it tracks additions and removals on its own.
+  const saveButtonList = [
+    ...spaces.map((space, index) => ({
+      id: `save-${space.uid}`,
+      text: `Save Space ${index + 1}`,
+      onClickCallback: () => onSave(String(index + 1)),
+    })),
+    {
+      id: 'add-new',
+      text: 'Add new space',
+      icon: 'Add',
+      disabled: spaces.length >= MAX_SPACES,
+      onClickCallback: () => {
+        onSaveAs();
+        appendSpace();
+      },
+    },
+  ];
+
+  return (
+    // room below the bar so the open menus are visible in the canvas
+    <div style={{ padding: '0 0 260px' }}>
+      <TopBar>
+        {/* 280px here against Figma's 268: the shipped ⋯ cell is a 56px square, Figma's is 44px */}
+        <ChipBar aria-label='Spaces'>
+          {showWorkspace ? (
+            <ChipButton
+              variant='icon'
+              icon='LayoutGrid'
+              aria-label='Workspace'
+              selected={workspaceActive}
+              onClick={() => {
+                onWorkspaceClick();
+                setIsWorkspaceActive(true);
+              }}
+            />
+          ) : null}
+          {spaces.map((space, index) => {
+            const number = String(index + 1);
+            return (
+              <ChipButton
+                key={space.uid}
+                leaving={space.uid === leavingUid}
+                onLeaveEnd={() => dropSpace(space.uid)}
+                variant='text'
+                label={number}
+                selected={!workspaceActive && space.uid === selectedUid}
+                aria-label={`Space ${number}`}
+                onClick={() => {
+                  onSpaceClick(number);
+                  setSelectedUid(space.uid);
+                  setIsWorkspaceActive(false);
+                }}
+              />
+            );
+          })}
+          {/* the Workspace is not a Space, so it cannot be duplicated or removed */}
+          <ChipDropdown
+            items={spaceMenuItems}
+            disabled={workspaceActive}
+            onOpenChange={action('space-menu-open-change')}
+          />
+        </ChipBar>
+
+        {/* both zone breaks present, so the "cells beside a break drop their border" rule reads */}
+        <ChipZoneBreak />
+        <ChipBar aria-label='Layout controls'>
+          <ChipDropdown
+            items={arrangementItems}
+            // the trigger glyph tracks the value, as the Figma component description requires
+            icon={arrangement?.icon ?? 'LayoutGrid'}
+            label={arrangement?.label}
+            selectedId={arrangementId}
+            // leads with the value on screen: an aria-label that dropped it would fail WCAG 2.5.3
+            triggerLabel={arrangement ? `${arrangement.label} arrangement` : undefined}
+            onOpenChange={action('arrangement-open-change')}
+          />
+        </ChipBar>
+        <SaveCell>
+          <SplitButton mainButtonId={`save-${selectedUid}`} buttonList={saveButtonList} />
+        </SaveCell>
+        <ResetCell>
+          <Button design='text-only' noPadding disabled={!canReset} onClick={onReset}>
+            Reset
+          </Button>
+        </ResetCell>
+        <ChipZoneBreak />
+      </TopBar>
+    </div>
+  );
+};
+
+export default SpacesTopBarStory;

--- a/packages/ui-lib/src/Chips/Chips.test.tsx
+++ b/packages/ui-lib/src/Chips/Chips.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Regression tests for two defects that the Storybook sweep cannot see: it watches for console
+ * errors, page errors and render loops, so a second tab stop or a missed completion callback both
+ * pass it silently. Behavioural verification for the Chips family otherwise lives in the sweep.
+ */
+import { act, type ReactElement, useEffect, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import ChipButton from './atoms/ChipButton';
+import ChipBar from './organisms/ChipBar';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const roots: Root[] = [];
+
+const render = async (element: ReactElement) => {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => root.render(element));
+  return container;
+};
+
+// counts what a keyboard user would actually land on: enabled buttons that are tabbable
+const tabStops = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLButtonElement>('button:not(:disabled)')).filter(
+    (button) => button.tabIndex === 0
+  ).length;
+
+const setReducedMotion = (reduced: boolean) => {
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: (query: string) =>
+      ({
+        matches: reduced && query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  });
+  return () => Object.defineProperty(window, 'matchMedia', { configurable: true, value: original });
+};
+
+let enableStatefulChip: (() => void) | undefined;
+
+// a cell that enables itself from its own state, without ChipBar re-rendering
+const StatefulChip = () => {
+  const [disabled, setDisabled] = useState(true);
+  useEffect(() => {
+    enableStatefulChip = () => setDisabled(false);
+  }, []);
+  return <ChipButton label='Stateful' disabled={disabled} />;
+};
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) {
+      root.unmount();
+    }
+  });
+  document.body.replaceChildren();
+  enableStatefulChip = undefined;
+  vi.restoreAllMocks();
+});
+
+describe('ChipBar', () => {
+  it('keeps exactly one tab stop when a descendant enables its own button', async () => {
+    const container = await render(
+      <ChipBar>
+        <StatefulChip />
+        <ChipButton label='Second' />
+      </ChipBar>
+    );
+    expect(tabStops(container)).toBe(1);
+
+    await act(async () => {
+      enableStatefulChip?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // without the MutationObserver the newly enabled button keeps its native tabIndex of 0
+    // alongside the existing one, giving the bar two tab stops
+    expect(tabStops(container)).toBe(1);
+    const buttons = container.querySelectorAll('button');
+    expect(buttons[0].tabIndex).toBe(0);
+    expect(buttons[1].tabIndex).toBe(-1);
+  });
+});
+
+describe('ChipButton', () => {
+  it('fires onLeaveEnd immediately when the user prefers reduced motion', async () => {
+    const restore = setReducedMotion(true);
+    const onLeaveEnd = vi.fn();
+    try {
+      // no animation runs, so animationend never arrives; without the immediate call the caller
+      // would hold a zero-width cell open forever
+      await render(<ChipButton label='Leaving' leaving onLeaveEnd={onLeaveEnd} />);
+      expect(onLeaveEnd).toHaveBeenCalledOnce();
+    } finally {
+      restore();
+    }
+  });
+
+  it('fires onLeaveEnd once per collapse, however many animationend events arrive', async () => {
+    const restore = setReducedMotion(false);
+    const onLeaveEnd = vi.fn();
+    try {
+      const container = await render(
+        <ChipButton label='Leaving' leaving onLeaveEnd={onLeaveEnd} />
+      );
+      expect(onLeaveEnd).not.toHaveBeenCalled();
+
+      await act(async () => {
+        const button = container.querySelector('button');
+        // React picks `animationend` or the prefixed `webkitAnimationEnd` by feature detection,
+        // and in jsdom that resolves to the prefixed name — fire both, twice each, so whichever
+        // one React is listening to arrives more than once and the once-only guard is exercised
+        for (const type of ['animationend', 'webkitAnimationEnd']) {
+          button?.dispatchEvent(new Event(type, { bubbles: true }));
+          button?.dispatchEvent(new Event(type, { bubbles: true }));
+        }
+      });
+      expect(onLeaveEnd).toHaveBeenCalledOnce();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/ui-lib/src/Chips/Chips.test.tsx
+++ b/packages/ui-lib/src/Chips/Chips.test.tsx
@@ -6,6 +6,7 @@
 import { act, type ReactElement, useEffect, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import ChipButton from './atoms/ChipButton';
+import ChipZoneBreak from './atoms/ChipZoneBreak';
 import ChipBar from './organisms/ChipBar';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -130,5 +131,60 @@ describe('ChipButton', () => {
     } finally {
       restore();
     }
+  });
+});
+
+describe('ChipZoneBreak', () => {
+  it('keeps both hairlines inside the 12px band', async () => {
+    // Figma's node is 12px *including* both 1px borders. Under the CSS default of content-box
+    // the band renders 14px and the top bar drifts 2px per zone break — silent, cumulative, and
+    // invisible to the sweep, which only watches for console errors and render loops.
+    // offsetWidth is not asserted: jsdom does no layout and always returns 0.
+    const container = await render(<ChipZoneBreak />);
+    const band = container.firstElementChild as HTMLElement;
+
+    expect(getComputedStyle(band).boxSizing).toBe('border-box');
+  });
+
+  it('adds no cell of its own to the bars it separates', async () => {
+    // the band goes *between* bars, so it must not be focusable: each ChipBar keeps its own
+    // single tab stop and the break contributes none
+    const container = await render(
+      <>
+        <ChipBar aria-label='Spaces'>
+          <ChipButton label='1' />
+          <ChipButton label='2' />
+        </ChipBar>
+        <ChipZoneBreak />
+        <ChipBar aria-label='Layout controls'>
+          <ChipButton label='3' />
+          <ChipButton label='4' />
+        </ChipBar>
+      </>
+    );
+
+    expect(container.querySelectorAll('button')).toHaveLength(4);
+    expect(tabStops(container)).toBe(2);
+  });
+
+  it('is hidden from assistive technology unless the consumer opts in', async () => {
+    const decorative = await render(<ChipZoneBreak />);
+    expect(decorative.firstElementChild?.getAttribute('aria-hidden')).toBe('true');
+
+    // the default is written before the prop spread, so a consumer can override it — but both
+    // attributes are needed, so pin that too (below)
+    const announced = await render(<ChipZoneBreak role='separator' aria-hidden={false} />);
+    expect(announced.firstElementChild?.getAttribute('aria-hidden')).toBe('false');
+    expect(announced.firstElementChild?.getAttribute('role')).toBe('separator');
+  });
+
+  it('stays hidden when given role="separator" alone', async () => {
+    // the trap this component's docs have to warn about: the spread carries no aria-hidden, so
+    // the default survives and the role is inert. Asserted so the docs cannot drift back to
+    // claiming role='separator' is enough on its own.
+    const container = await render(<ChipZoneBreak role='separator' />);
+
+    expect(container.firstElementChild?.getAttribute('role')).toBe('separator');
+    expect(container.firstElementChild?.getAttribute('aria-hidden')).toBe('true');
   });
 });

--- a/packages/ui-lib/src/Chips/Chips.test.tsx
+++ b/packages/ui-lib/src/Chips/Chips.test.tsx
@@ -7,6 +7,7 @@ import { act, type ReactElement, useEffect, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import ChipButton from './atoms/ChipButton';
 import ChipZoneBreak from './atoms/ChipZoneBreak';
+import ChipDropdown, { type IChipDropdownItem } from './molecules/ChipDropdown';
 import ChipBar from './organisms/ChipBar';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -186,5 +187,91 @@ describe('ChipZoneBreak', () => {
 
     expect(container.firstElementChild?.getAttribute('role')).toBe('separator');
     expect(container.firstElementChild?.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+/**
+ * The Arrangement cell (Figma "Spaces/Top Bar/Arrangement Cell") is ChipDropdown's labelled mode
+ * rather than a component of its own. What the sweep cannot see is the accessibility contract: the
+ * accessible name in labelled mode, and "which row is current" reaching a screen reader rather than
+ * only reaching an eye. Geometry is deliberately not asserted here — jsdom does no layout, so
+ * offsetWidth is always 0; the widths are checked in a real browser instead.
+ */
+describe('ChipDropdown labelled', () => {
+  const ARRANGEMENTS: IChipDropdownItem[] = [
+    { id: '6-up', label: '6-up', icon: 'LayoutGrid' },
+    { id: '4-up', label: '4-up', icon: 'LayoutGrid' },
+    { id: '2-up', label: '2-up', icon: 'LayoutList' },
+  ];
+
+  const openMenu = async (container: HTMLElement) => {
+    await act(async () => container.querySelector('button')?.click());
+    const menu = container.querySelector('[role="menu"]');
+    if (!menu) {
+      throw new Error('the menu did not open');
+    }
+    return menu as HTMLElement;
+  };
+
+  // the check is the only aria-hidden node inside the menu: the per-row item icons are not hidden
+  const checks = (menu: HTMLElement) => menu.querySelectorAll('[aria-hidden="true"]');
+
+  it('uses the visible label as the accessible name instead of an aria-label', async () => {
+    // aria-label='Space actions' on a button that visibly reads "6-up" is a WCAG 2.5.3 (Label in
+    // Name) failure, so icon-only mode's default must not follow the label into labelled mode
+    const container = await render(<ChipDropdown items={ARRANGEMENTS} label='6-up' />);
+    const trigger = container.querySelector('button');
+
+    expect(trigger?.textContent).toContain('6-up');
+    expect(trigger?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  it('still honours a triggerLabel the consumer passes alongside a label', async () => {
+    // not defaulting it must not mean ignoring it
+    const container = await render(
+      <ChipDropdown items={ARRANGEMENTS} label='6-up' triggerLabel='Arrangement' />
+    );
+
+    expect(container.querySelector('button')?.getAttribute('aria-label')).toBe('Arrangement');
+  });
+
+  it('leaves the menu exactly as it shipped when no selectedId is given', async () => {
+    const container = await render(<ChipDropdown items={ARRANGEMENTS} label='6-up' />);
+    const menu = await openMenu(container);
+
+    expect(menu.querySelectorAll('[role="menuitem"]')).toHaveLength(ARRANGEMENTS.length);
+    expect(menu.querySelectorAll('[role="menuitemradio"]')).toHaveLength(0);
+    expect(checks(menu)).toHaveLength(0);
+  });
+
+  it('marks the current row for a screen reader, not just with a glyph', async () => {
+    const container = await render(
+      <ChipDropdown items={ARRANGEMENTS} label='4-up' selectedId='4-up' />
+    );
+    const menu = await openMenu(container);
+
+    const rows = menu.querySelectorAll('[role="menuitemradio"]');
+    expect(rows).toHaveLength(ARRANGEMENTS.length);
+    expect(menu.querySelectorAll('[role="menuitem"]')).toHaveLength(0);
+
+    const checked = Array.from(rows).filter((row) => row.getAttribute('aria-checked') === 'true');
+    expect(checked).toHaveLength(1);
+    expect(checked[0].textContent).toContain('4-up');
+
+    // aria-checked carries "current", so the glyph is decorative and sits only on that row
+    expect(checks(menu)).toHaveLength(1);
+    expect(checked[0].querySelector('[aria-hidden="true"] svg')).not.toBeNull();
+  });
+
+  it('checks no row when selectedId matches no item, and throws nothing', async () => {
+    const container = await render(
+      <ChipDropdown items={ARRANGEMENTS} label='6-up' selectedId='8-up' />
+    );
+    const menu = await openMenu(container);
+
+    // a radio group with nothing chosen yet is a real state, so the rows keep the radio semantics
+    expect(menu.querySelectorAll('[role="menuitemradio"]')).toHaveLength(ARRANGEMENTS.length);
+    expect(menu.querySelectorAll('[aria-checked="true"]')).toHaveLength(0);
+    expect(checks(menu)).toHaveLength(0);
   });
 });

--- a/packages/ui-lib/src/Chips/Chips.test.tsx
+++ b/packages/ui-lib/src/Chips/Chips.test.tsx
@@ -1,7 +1,7 @@
 /**
- * Regression tests for two defects that the Storybook sweep cannot see: it watches for console
- * errors, page errors and render loops, so a second tab stop or a missed completion callback both
- * pass it silently. Behavioural verification for the Chips family otherwise lives in the sweep.
+ * Regression tests for defects the Storybook sweep cannot see: it watches for console errors, page
+ * errors and render loops, so a second tab stop or a missed completion callback both pass it
+ * silently. Behavioural verification for the Chips family otherwise lives in the sweep.
  */
 import { act, type ReactElement, useEffect, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -147,7 +147,7 @@ describe('ChipButton', () => {
 
 describe('ChipZoneBreak', () => {
   it('keeps both hairlines inside the 12px band', async () => {
-    // Figma's node is 12px *including* both 1px borders. Under the CSS default of content-box
+    // the band is 12px *including* both 1px borders. Under the CSS default of content-box
     // the band renders 14px and the top bar drifts 2px per zone break — silent, cumulative, and
     // invisible to the sweep, which only watches for console errors and render loops.
     // offsetWidth is not asserted: jsdom does no layout and always returns 0.
@@ -201,11 +201,11 @@ describe('ChipZoneBreak', () => {
 });
 
 /**
- * The Arrangement cell (Figma "Spaces/Top Bar/Arrangement Cell") is ChipDropdown's labelled mode
- * rather than a component of its own. What the sweep cannot see is the accessibility contract: the
- * accessible name in labelled mode, and "which row is current" reaching a screen reader rather than
- * only reaching an eye. Geometry is deliberately not asserted here — jsdom does no layout, so
- * offsetWidth is always 0; the widths are checked in a real browser instead.
+ * The Arrangement cell is ChipDropdown's labelled mode rather than a component of its own. What the
+ * sweep cannot see is the accessibility contract: the accessible name in labelled mode, and "which
+ * row is current" reaching a screen reader rather than only reaching an eye. Geometry is
+ * deliberately not asserted here — jsdom does no layout, so offsetWidth is always 0; the widths are
+ * checked in a real browser instead.
  */
 describe('ChipDropdown labelled', () => {
   const ARRANGEMENTS: IChipDropdownItem[] = [
@@ -252,7 +252,6 @@ describe('ChipDropdown labelled', () => {
   });
 
   it('still honours a triggerLabel the consumer passes alongside a label', async () => {
-    // not defaulting it must not mean ignoring it
     const container = await render(
       <ChipDropdown items={ARRANGEMENTS} label='6-up' triggerLabel='Arrangement' />
     );

--- a/packages/ui-lib/src/Chips/Chips.test.tsx
+++ b/packages/ui-lib/src/Chips/Chips.test.tsx
@@ -96,6 +96,16 @@ describe('ChipBar', () => {
 });
 
 describe('ChipButton', () => {
+  it('keeps toggle semantics on a plain chip', async () => {
+    // the other half of the rule asserted on ChipDropdown's trigger: a chip that owns no popup is a
+    // toggle button, so `selected` must still surface as aria-pressed
+    const off = await render(<ChipButton label='1' />);
+    expect(off.querySelector('button')?.getAttribute('aria-pressed')).toBe('false');
+
+    const on = await render(<ChipButton label='2' selected />);
+    expect(on.querySelector('button')?.getAttribute('aria-pressed')).toBe('true');
+  });
+
   it('fires onLeaveEnd immediately when the user prefers reduced motion', async () => {
     const restore = setReducedMotion(true);
     const onLeaveEnd = vi.fn();
@@ -224,6 +234,21 @@ describe('ChipDropdown labelled', () => {
 
     expect(trigger?.textContent).toContain('6-up');
     expect(trigger?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  it('is a menu button, not a toggle button: aria-expanded without aria-pressed', async () => {
+    // the trigger borrows ChipButton's `selected` purely for the bar, and on the atom that also
+    // means aria-pressed — carrying both states would announce the cell twice and contradictorily
+    const container = await render(<ChipDropdown items={ARRANGEMENTS} label='6-up' />);
+    const trigger = container.querySelector('button');
+
+    expect(trigger?.hasAttribute('aria-pressed')).toBe(false);
+    expect(trigger?.getAttribute('aria-haspopup')).toBe('menu');
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+
+    await act(async () => trigger?.click());
+    expect(trigger?.getAttribute('aria-expanded')).toBe('true');
+    expect(trigger?.hasAttribute('aria-pressed')).toBe(false);
   });
 
   it('still honours a triggerLabel the consumer passes alongside a label', async () => {

--- a/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
+++ b/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
@@ -34,6 +34,14 @@ const collapse = keyframes`
   }
 `;
 
+/* `& svg [stroke]`: icon colour follows state — mirrors IconButton.tsx targeting [stroke].
+
+   `&:focus-visible`: the keyboard focus ring. Mouse and selected states keep the `outline: none`
+   set above.
+
+   `$leaving`: `overflow: hidden` and `min-width: 0` are scoped to the leaving state on purpose —
+   permanent overflow would clip the 4px bar's 1px overhang, and a flex item will not shrink past
+   its content without `min-width: 0`. */
 const StyledChip = styled.button<IStyledChip>`
   position: relative;
   display: flex;
@@ -58,7 +66,6 @@ const StyledChip = styled.button<IStyledChip>`
 
   ${({ $showDivider }) => $showDivider && css`border-left: 1px solid var(--grey-4);`}
 
-  /* icon colour follows state — mirrors IconButton.tsx targeting [stroke] */
   & svg [stroke] { stroke: var(--grey-12); }
 
   &::after {
@@ -73,7 +80,6 @@ const StyledChip = styled.button<IStyledChip>`
   }
   &:hover:enabled::after { background-color: var(--primary-6); }
 
-  /* keyboard focus ring (mouse/selected states keep outline: none above) */
   &:focus-visible {
     outline: 2px solid var(--primary-9);
     outline-offset: -2px;
@@ -94,8 +100,6 @@ const StyledChip = styled.button<IStyledChip>`
   ${({ $leaving }) =>
     $leaving &&
     css`
-    /* both scoped to the leaving state on purpose: permanent overflow would clip the 4px bar's
-       1px overhang, and a flex item will not shrink past its content without min-width: 0 */
     overflow: hidden;
     min-width: 0;
     pointer-events: none;
@@ -125,7 +129,6 @@ const ChipButton: React.FC<IChipButton> = ({
      state without the toggle semantics. */
   const isMenuButton = props['aria-haspopup'] !== undefined;
 
-  // fire onLeaveEnd exactly once per collapse
   const hasFired = useRef(false);
   const fireLeaveEnd = useCallback(() => {
     if (hasFired.current) {
@@ -147,7 +150,6 @@ const ChipButton: React.FC<IChipButton> = ({
     }
   }, [leaving, fireLeaveEnd]);
 
-  // compose with a consumer handler rather than replacing it
   const handleAnimationEnd = useCallback(
     (e: React.AnimationEvent<HTMLButtonElement>) => {
       onAnimationEnd?.(e);

--- a/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
+++ b/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
@@ -1,0 +1,104 @@
+import type React from 'react';
+import type { ButtonHTMLAttributes } from 'react';
+import styled, { css } from 'styled-components';
+import Icon from '../../Icons/Icon';
+
+export type IChipVariant = 'icon' | 'text';
+
+interface OwnProps {
+  variant?: IChipVariant; // default 'text'
+  icon?: string; // icon name (@future-standard/icons) when variant='icon'
+  label?: string; // numeral/text when variant='text' (falls back to children)
+  selected?: boolean; // persistent selected state (Figma "Active"): wash + bar
+  noDivider?: boolean; // force-hide the 1px left divider
+}
+
+export type IChipButton = OwnProps & ButtonHTMLAttributes<HTMLButtonElement>;
+
+interface IStyledChip {
+  $selected: boolean;
+  $showDivider: boolean;
+}
+
+const StyledChip = styled.button<IStyledChip>`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  outline: none;
+  box-sizing: border-box;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: var(--grey-12);
+  transition:
+    color var(--speed-normal) var(--easing-primary-in-out),
+    background-color var(--speed-normal) var(--easing-primary-in-out);
+
+  ${({ $showDivider }) => $showDivider && css`border-left: 1px solid var(--grey-4);`}
+
+  /* icon colour follows state — mirrors IconButton.tsx targeting [stroke] */
+  & svg [stroke] { stroke: var(--grey-12); }
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: -1px;
+    right: -1px;
+    height: 4px;
+    background-color: transparent;
+    transition: background-color var(--speed-normal) var(--easing-primary-in-out);
+  }
+  &:hover:enabled::after { background-color: var(--primary-6); }
+
+  /* keyboard focus ring (mouse/selected states keep outline: none above) */
+  &:focus-visible {
+    outline: 2px solid var(--primary-9);
+    outline-offset: -2px;
+  }
+
+  ${({ $selected }) =>
+    $selected &&
+    css`
+    background-color: var(--primary-a3);
+    color: var(--primary-11);
+    & svg [stroke] { stroke: var(--primary-11); }
+    &::after { background-color: var(--primary-9); }
+    &:hover:enabled::after { background-color: var(--primary-9); }
+  `}
+
+  &:disabled { cursor: not-allowed; opacity: 0.5; }
+`;
+
+const ChipButton: React.FC<IChipButton> = ({
+  variant = 'text',
+  icon,
+  label,
+  selected = false,
+  noDivider = false,
+  children,
+  ...props
+}) => {
+  const showDivider = variant === 'text' && !noDivider;
+  return (
+    <StyledChip
+      type='button'
+      aria-pressed={selected}
+      $selected={selected}
+      $showDivider={showDivider}
+      {...props}
+    >
+      {variant === 'icon' && icon ? <Icon icon={icon} size={16} /> : (label ?? children)}
+    </StyledChip>
+  );
+};
+
+export default ChipButton;

--- a/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
+++ b/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
@@ -87,7 +87,7 @@ const ChipButton: React.FC<IChipButton> = ({
   children,
   ...props
 }) => {
-  const showDivider = variant === 'text' && !noDivider;
+  const showDivider = !noDivider;
   return (
     <StyledChip
       type='button'

--- a/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
+++ b/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
-import type { ButtonHTMLAttributes } from 'react';
-import styled, { css } from 'styled-components';
+import { type ButtonHTMLAttributes, useCallback, useEffect, useRef } from 'react';
+import styled, { css, keyframes } from 'styled-components';
 import Icon from '../../Icons/Icon';
 
 export type IChipVariant = 'icon' | 'text';
@@ -11,6 +11,8 @@ interface OwnProps {
   label?: string; // numeral/text when variant='text' (falls back to children)
   selected?: boolean; // persistent selected state (Figma "Active"): wash + bar
   noDivider?: boolean; // force-hide the 1px left divider
+  leaving?: boolean; // collapse the cell to zero width — the removal animation
+  onLeaveEnd?: () => void; // collapse finished (or was skipped): safe to unmount the cell now
 }
 
 export type IChipButton = OwnProps & ButtonHTMLAttributes<HTMLButtonElement>;
@@ -18,7 +20,19 @@ export type IChipButton = OwnProps & ButtonHTMLAttributes<HTMLButtonElement>;
 interface IStyledChip {
   $selected: boolean;
   $showDivider: boolean;
+  $leaving: boolean;
 }
+
+/* Removal. No `from` block, so the collapse starts from whatever the chip currently computes and
+   the 56px width lives in exactly one place. In a flex row this also slides every later cell left
+   on its own — no measuring, no FLIP. */
+const collapse = keyframes`
+  to {
+    width: 0;
+    opacity: 0;
+    border-left-width: 0;
+  }
+`;
 
 const StyledChip = styled.button<IStyledChip>`
   position: relative;
@@ -76,6 +90,19 @@ const StyledChip = styled.button<IStyledChip>`
   `}
 
   &:disabled { cursor: not-allowed; opacity: 0.5; }
+
+  ${({ $leaving }) =>
+    $leaving &&
+    css`
+    /* both scoped to the leaving state on purpose: permanent overflow would clip the 4px bar's
+       1px overhang, and a flex item will not shrink past its content without min-width: 0 */
+    overflow: hidden;
+    min-width: 0;
+    pointer-events: none;
+    animation: ${collapse} var(--speed-fast) var(--easing-primary-in-out) forwards;
+
+    @media (prefers-reduced-motion: reduce) { animation: none; }
+  `}
 `;
 
 const ChipButton: React.FC<IChipButton> = ({
@@ -84,17 +111,56 @@ const ChipButton: React.FC<IChipButton> = ({
   label,
   selected = false,
   noDivider = false,
+  leaving = false,
+  onLeaveEnd,
+  onAnimationEnd,
   children,
   ...props
 }) => {
   const showDivider = !noDivider;
+
+  // fire onLeaveEnd exactly once per collapse
+  const hasFired = useRef(false);
+  const fireLeaveEnd = useCallback(() => {
+    if (hasFired.current) {
+      return;
+    }
+    hasFired.current = true;
+    onLeaveEnd?.();
+  }, [onLeaveEnd]);
+
+  useEffect(() => {
+    if (!leaving) {
+      hasFired.current = false;
+      return;
+    }
+    // with reduced motion there is no animation, so animationend never arrives — tell the caller
+    // straight away, or the cell it is holding open would never be dropped
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      fireLeaveEnd();
+    }
+  }, [leaving, fireLeaveEnd]);
+
+  // compose with a consumer handler rather than replacing it
+  const handleAnimationEnd = useCallback(
+    (e: React.AnimationEvent<HTMLButtonElement>) => {
+      onAnimationEnd?.(e);
+      if (leaving && e.target === e.currentTarget) {
+        fireLeaveEnd();
+      }
+    },
+    [leaving, fireLeaveEnd, onAnimationEnd]
+  );
+
   return (
     <StyledChip
       type='button'
       aria-pressed={selected}
       $selected={selected}
       $showDivider={showDivider}
+      $leaving={leaving}
       {...props}
+      onAnimationEnd={handleAnimationEnd}
     >
       {variant === 'icon' && icon ? <Icon icon={icon} size={16} /> : (label ?? children)}
     </StyledChip>

--- a/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
+++ b/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
@@ -119,6 +119,12 @@ const ChipButton: React.FC<IChipButton> = ({
 }) => {
   const showDivider = !noDivider;
 
+  /* `selected` means "wears the wash and the bar", which for a chip is also "pressed". But a button
+     that owns a popup is a menu button, whose state is aria-expanded — carrying aria-pressed too
+     would announce it as a toggle button as well. So the cell that opens a menu keeps the visual
+     state without the toggle semantics. */
+  const isMenuButton = props['aria-haspopup'] !== undefined;
+
   // fire onLeaveEnd exactly once per collapse
   const hasFired = useRef(false);
   const fireLeaveEnd = useCallback(() => {
@@ -155,7 +161,7 @@ const ChipButton: React.FC<IChipButton> = ({
   return (
     <StyledChip
       type='button'
-      aria-pressed={selected}
+      aria-pressed={isMenuButton ? undefined : selected}
       $selected={selected}
       $showDivider={showDivider}
       $leaving={leaving}

--- a/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
+++ b/packages/ui-lib/src/Chips/atoms/ChipButton.tsx
@@ -6,13 +6,20 @@ import Icon from '../../Icons/Icon';
 export type IChipVariant = 'icon' | 'text';
 
 interface OwnProps {
-  variant?: IChipVariant; // default 'text'
-  icon?: string; // icon name (@future-standard/icons) when variant='icon'
-  label?: string; // numeral/text when variant='text' (falls back to children)
-  selected?: boolean; // persistent selected state (Figma "Active"): wash + bar
-  noDivider?: boolean; // force-hide the 1px left divider
-  leaving?: boolean; // collapse the cell to zero width — the removal animation
-  onLeaveEnd?: () => void; // collapse finished (or was skipped): safe to unmount the cell now
+  /** content mode (default 'text') */
+  variant?: IChipVariant;
+  /** icon name (@future-standard/icons) when variant='icon' */
+  icon?: string;
+  /** numeral/text when variant='text' (falls back to children) */
+  label?: string;
+  /** persistent selected state (Figma "Active"): wash + bar */
+  selected?: boolean;
+  /** force-hide the 1px left divider */
+  noDivider?: boolean;
+  /** collapse the cell to zero width — the removal animation */
+  leaving?: boolean;
+  /** collapse finished (or was skipped): safe to unmount the cell now */
+  onLeaveEnd?: () => void;
 }
 
 export type IChipButton = OwnProps & ButtonHTMLAttributes<HTMLButtonElement>;

--- a/packages/ui-lib/src/Chips/atoms/ChipZoneBreak.tsx
+++ b/packages/ui-lib/src/Chips/atoms/ChipZoneBreak.tsx
@@ -1,0 +1,34 @@
+import type React from 'react';
+import type { HTMLAttributes } from 'react';
+import styled from 'styled-components';
+
+export type IChipZoneBreak = HTMLAttributes<HTMLDivElement>;
+
+/* Figma "Spaces/Top Bar/Zone Break": the 12px band that separates two zones of the top bar. It
+   owns both edge hairlines, which is why ChipBar suppresses its first cell's left divider
+   unconditionally — that half of the rule already shipped, this is the other half.
+
+   Sits BETWEEN bars, never inside one: a zone break is not a cell of either zone. */
+const Break = styled.div`
+  /* border-box keeps both 1px hairlines inside the 12px, matching Figma's 12px node. With the
+     CSS default the band renders 14px and the top bar drifts 2px per zone break. */
+  box-sizing: border-box;
+  /* ChipBar protects its own children, but a zone break sits outside any bar, so it has to
+     protect itself or a narrow top bar squashes the band. */
+  flex-shrink: 0;
+  width: 12px;
+  height: 56px;
+  background-color: var(--grey-3);
+  border-left: 1px solid var(--grey-4);
+  border-right: 1px solid var(--grey-4);
+`;
+
+/* aria-hidden before the spread, so a consumer can override it — the ordering ChipBar uses for
+   role / aria-label. Decorative by default.
+
+   To have it announced, both attributes are required: `role='separator'` on its own is inert,
+   because the default aria-hidden='true' survives the spread and keeps the element out of the
+   accessibility tree. Pass `role='separator' aria-hidden={false}`. */
+const ChipZoneBreak: React.FC<IChipZoneBreak> = (props) => <Break aria-hidden='true' {...props} />;
+
+export default ChipZoneBreak;

--- a/packages/ui-lib/src/Chips/atoms/ChipZoneBreak.tsx
+++ b/packages/ui-lib/src/Chips/atoms/ChipZoneBreak.tsx
@@ -4,17 +4,17 @@ import styled from 'styled-components';
 
 export type IChipZoneBreak = HTMLAttributes<HTMLDivElement>;
 
-/* Figma "Spaces/Top Bar/Zone Break": the 12px band that separates two zones of the top bar. It
-   owns both edge hairlines, which is why ChipBar suppresses its first cell's left divider
-   unconditionally — that half of the rule already shipped, this is the other half.
+/* The 12px band that separates two zones of the top bar, owning both edge hairlines.
 
-   Sits BETWEEN bars, never inside one: a zone break is not a cell of either zone. */
+   Sits BETWEEN bars, never inside one: a zone break is not a cell of either zone.
+
+   `box-sizing: border-box` keeps both 1px hairlines inside the 12px. With the CSS default the band
+   renders 14px and the top bar drifts 2px per zone break.
+
+   `flex-shrink: 0`: a zone break sits outside any bar, so it has to protect itself or a narrow top
+   bar squashes the band. */
 const Break = styled.div`
-  /* border-box keeps both 1px hairlines inside the 12px, matching Figma's 12px node. With the
-     CSS default the band renders 14px and the top bar drifts 2px per zone break. */
   box-sizing: border-box;
-  /* ChipBar protects its own children, but a zone break sits outside any bar, so it has to
-     protect itself or a narrow top bar squashes the band. */
   flex-shrink: 0;
   width: 12px;
   height: 56px;
@@ -23,8 +23,7 @@ const Break = styled.div`
   border-right: 1px solid var(--grey-4);
 `;
 
-/* aria-hidden before the spread, so a consumer can override it — the ordering ChipBar uses for
-   role / aria-label. Decorative by default.
+/* aria-hidden before the spread, so a consumer can override it. Decorative by default.
 
    To have it announced, both attributes are required: `role='separator'` on its own is inert,
    because the default aria-hidden='true' survives the spread and keeps the element out of the

--- a/packages/ui-lib/src/Chips/index.ts
+++ b/packages/ui-lib/src/Chips/index.ts
@@ -1,5 +1,6 @@
 import ChipButton, { type IChipButton, type IChipVariant } from './atoms/ChipButton';
 import ChipDropdown, { type IChipDropdown, type IChipDropdownItem } from './molecules/ChipDropdown';
+import ChipBar, { type IChipBar } from './organisms/ChipBar';
 
-export type { IChipButton, IChipDropdown, IChipDropdownItem, IChipVariant };
-export { ChipButton, ChipDropdown };
+export type { IChipBar, IChipButton, IChipDropdown, IChipDropdownItem, IChipVariant };
+export { ChipBar, ChipButton, ChipDropdown };

--- a/packages/ui-lib/src/Chips/index.ts
+++ b/packages/ui-lib/src/Chips/index.ts
@@ -1,4 +1,5 @@
 import ChipButton, { type IChipButton, type IChipVariant } from './atoms/ChipButton';
+import ChipDropdown, { type IChipDropdown, type IChipDropdownItem } from './molecules/ChipDropdown';
 
-export type { IChipButton, IChipVariant };
-export { ChipButton };
+export type { IChipButton, IChipDropdown, IChipDropdownItem, IChipVariant };
+export { ChipButton, ChipDropdown };

--- a/packages/ui-lib/src/Chips/index.ts
+++ b/packages/ui-lib/src/Chips/index.ts
@@ -1,6 +1,14 @@
 import ChipButton, { type IChipButton, type IChipVariant } from './atoms/ChipButton';
+import ChipZoneBreak, { type IChipZoneBreak } from './atoms/ChipZoneBreak';
 import ChipDropdown, { type IChipDropdown, type IChipDropdownItem } from './molecules/ChipDropdown';
 import ChipBar, { type IChipBar } from './organisms/ChipBar';
 
-export type { IChipBar, IChipButton, IChipDropdown, IChipDropdownItem, IChipVariant };
-export { ChipBar, ChipButton, ChipDropdown };
+export type {
+  IChipBar,
+  IChipButton,
+  IChipDropdown,
+  IChipDropdownItem,
+  IChipVariant,
+  IChipZoneBreak,
+};
+export { ChipBar, ChipButton, ChipDropdown, ChipZoneBreak };

--- a/packages/ui-lib/src/Chips/index.ts
+++ b/packages/ui-lib/src/Chips/index.ts
@@ -1,0 +1,4 @@
+import ChipButton, { type IChipButton, type IChipVariant } from './atoms/ChipButton';
+
+export type { IChipButton, IChipVariant };
+export { ChipButton };

--- a/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
+++ b/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
@@ -8,20 +8,28 @@ import ChipButton from '../atoms/ChipButton';
 export interface IChipDropdownItem {
   id: string;
   label: string;
-  icon?: string; // icon name (@future-standard/icons)
+  /** icon name (@future-standard/icons) */
+  icon?: string;
   disabled?: boolean;
   onClick?: () => void;
 }
 
 interface OwnProps {
   items: IChipDropdownItem[];
-  icon?: string; // icon-only mode: the trigger icon, 16px. Labelled mode: the leading glyph, 18px
-  label?: string; // visible trigger text, e.g. '6-up'; switches the trigger to labelled mode
-  selectedId?: string; // items[].id of the current row: --grey-4 background, check, radio semantics
-  checkIcon?: string; // icon name for the current-row indicator (default 'Success')
-  triggerLabel?: string; // trigger aria-label; defaulted to 'Space actions' in icon-only mode only
-  noDivider?: boolean; // pass-through: hide the chip's 1px left divider
-  disabled?: boolean; // disable the trigger
+  /** icon-only mode: the trigger icon, 16px. Labelled mode: the leading glyph, 18px */
+  icon?: string;
+  /** visible trigger text, e.g. '6-up'; switches the trigger to labelled mode */
+  label?: string;
+  /** items[].id of the current row: --grey-4 background, check, radio semantics */
+  selectedId?: string;
+  /** icon name for the current-row indicator (default 'Success') */
+  checkIcon?: string;
+  /** trigger aria-label; defaulted to 'Space actions' in icon-only mode only */
+  triggerLabel?: string;
+  /** pass-through: hide the chip's 1px left divider */
+  noDivider?: boolean;
+  /** disable the trigger */
+  disabled?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
 

--- a/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
+++ b/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { type HTMLAttributes, useCallback, useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useClickOutside } from '../../hooks';
 import Icon from '../../Icons/Icon';
 import ChipButton from '../atoms/ChipButton';
@@ -15,8 +15,11 @@ export interface IChipDropdownItem {
 
 interface OwnProps {
   items: IChipDropdownItem[];
-  icon?: string; // trigger icon name, default the 3-dot kebab 'FilterEllipsis'
-  triggerLabel?: string; // trigger aria-label (default 'Space actions')
+  icon?: string; // icon-only mode: the trigger icon, 16px. Labelled mode: the leading glyph, 18px
+  label?: string; // visible trigger text, e.g. '6-up'; switches the trigger to labelled mode
+  selectedId?: string; // items[].id of the current row: --grey-4 background, check, radio semantics
+  checkIcon?: string; // icon name for the current-row indicator (default 'Success')
+  triggerLabel?: string; // trigger aria-label; defaulted to 'Space actions' in icon-only mode only
   noDivider?: boolean; // pass-through: hide the chip's 1px left divider
   disabled?: boolean; // disable the trigger
   onOpenChange?: (open: boolean) => void;
@@ -33,9 +36,29 @@ const Wrapper = styled.div`
    Primary/9 4px bar only, with no Primary/a3 wash. We still map Open to ChipButton's `selected`
    so the bar (and the hover bar) come from the atom, and drop just the wash here — otherwise an
    open menu sitting next to an active chip reads as one merged block. `&&` doubles the class so
-   this beats the atom's own rule without depending on stylesheet order. */
-const Trigger = styled(ChipButton)`
-  && { background-color: transparent; }
+   this beats the atom's own rule without depending on stylesheet order.
+
+   $labelled holds the Arrangement cell's geometry, scoped to the transient prop so the icon-only
+   trigger keeps the atom's 56 x 56 square untouched. */
+const Trigger = styled(ChipButton)<{ $labelled: boolean }>`
+  && {
+    background-color: transparent;
+
+    ${({ $labelled }) =>
+      $labelled &&
+      css`
+      width: auto;
+      padding: 0 16px 0 14px;
+      gap: 8px;
+      justify-content: flex-start;
+      white-space: nowrap; /* wrapping would break the 56px height, not widen the cell */
+
+      /* Figma's Open state keeps the label on --grey-12 and turns only the bar primary; the atom
+         ties its selected state to --primary-11 text, far louder on a word than on a glyph */
+      color: var(--grey-12);
+      & svg [stroke] { stroke: var(--grey-12); }
+    `}
+  }
 `;
 
 /* Deviation from Figma "Spaces/Card Shadow": that shadow has no theme token, and its
@@ -60,7 +83,7 @@ const Menu = styled.div`
   box-shadow: 0px 5px 25px 0px var(--filter-button-shadow-color);
 `;
 
-const MenuItem = styled.button`
+const MenuItem = styled.button<{ $current: boolean }>`
   display: flex;
   align-items: center;
   gap: 4px;
@@ -85,12 +108,30 @@ const MenuItem = styled.button`
   &:last-child { border-bottom: none; }
   &:hover:enabled { background-color: var(--grey-3); }
   &:disabled { cursor: not-allowed; opacity: 0.5; }
+
+  /* After the hover rule so it wins: --grey-4 is a step darker than the --grey-3 hover in both
+     themes, so letting hover win would make the current row look less selected when pointed at. */
+  ${({ $current }) =>
+    $current &&
+    css`
+    background-color: var(--grey-4);
+    &:hover:enabled { background-color: var(--grey-5); }
+  `}
+`;
+
+/* auto margin rather than absolute, so it reuses MenuItem's padding-right */
+const CheckSlot = styled.span`
+  display: flex;
+  margin-left: auto;
 `;
 
 const ChipDropdown: React.FC<IChipDropdown> = ({
   items,
   icon = 'FilterEllipsis',
-  triggerLabel = 'Space actions',
+  label,
+  selectedId,
+  checkIcon = 'Success',
+  triggerLabel,
   noDivider = false,
   disabled = false,
   onOpenChange,
@@ -99,6 +140,17 @@ const ChipDropdown: React.FC<IChipDropdown> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // empty counts as absent: a consumer binding label={state} gets the square back
+  const isLabelled = Boolean(label);
+
+  // an undefined check, not a truthiness one: absent must leave the menu as it shipped, but a
+  // selectedId matching nothing is a real state — a radio group with nothing chosen yet
+  const marksCurrent = selectedId !== undefined;
+
+  // 'Space actions' on a button that visibly reads "6-up" is a WCAG 2.5.3 (Label in Name) failure,
+  // so labelled mode takes the visible text as its name and only an explicit triggerLabel overrides
+  const ariaLabel = triggerLabel ?? (isLabelled ? undefined : 'Space actions');
 
   const setOpen = useCallback(
     (next: boolean) => {
@@ -141,34 +193,59 @@ const ChipDropdown: React.FC<IChipDropdown> = ({
 
   return (
     <Wrapper ref={wrapperRef} {...props} onKeyDown={handleKeyDown}>
+      {/* labelled mode passes no `variant` and no ChipButton `label`: either would win over the
+          children in the atom and drop the glyph and caret */}
       <Trigger
-        variant='icon'
-        icon={icon}
+        $labelled={isLabelled}
+        variant={isLabelled ? undefined : 'icon'}
+        icon={isLabelled ? undefined : icon}
         selected={isOpen}
         noDivider={noDivider}
         disabled={disabled}
-        aria-label={triggerLabel}
+        aria-label={ariaLabel}
         aria-haspopup='menu'
         aria-expanded={isOpen}
         onClick={toggle}
-      />
+      >
+        {isLabelled ? (
+          <>
+            {icon ? <Icon icon={icon} size={18} /> : null}
+            {label}
+            {/* does not flip when open — Figma uses one caret asset in all three states */}
+            <Icon icon='Down' size={12} />
+          </>
+        ) : null}
+      </Trigger>
       {isOpen && !disabled ? (
         <Menu role='menu'>
-          {items.map((item) => (
-            <MenuItem
-              key={item.id}
-              type='button'
-              role='menuitem'
-              disabled={item.disabled}
-              onClick={() => {
-                item.onClick?.();
-                close();
-              }}
-            >
-              {item.icon ? <Icon icon={item.icon} size={14} /> : null}
-              {item.label}
-            </MenuItem>
-          ))}
+          {items.map((item) => {
+            const isCurrent = marksCurrent && item.id === selectedId;
+            return (
+              <MenuItem
+                key={item.id}
+                type='button'
+                // so a screen reader gets "current" too, not just the glyph
+                role={marksCurrent ? 'menuitemradio' : 'menuitem'}
+                aria-checked={marksCurrent ? isCurrent : undefined}
+                $current={isCurrent}
+                disabled={item.disabled}
+                onClick={() => {
+                  item.onClick?.();
+                  close();
+                }}
+              >
+                {item.icon ? <Icon icon={item.icon} size={14} /> : null}
+                {item.label}
+                {isCurrent ? (
+                  // decorative: aria-checked carries it. `light` because non-scaling-stroke keeps
+                  // `regular` at 1.5px, muddy on a 14px tick.
+                  <CheckSlot aria-hidden='true'>
+                    <Icon icon={checkIcon} size={14} weight='light' />
+                  </CheckSlot>
+                ) : null}
+              </MenuItem>
+            );
+          })}
         </Menu>
       ) : null}
     </Wrapper>

--- a/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
+++ b/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
@@ -29,6 +29,15 @@ const Wrapper = styled.div`
   display: inline-flex;
 `;
 
+/* Figma calls this cell "a different kind of button from the chips": its Open state is the
+   Primary/9 4px bar only, with no Primary/a3 wash. We still map Open to ChipButton's `selected`
+   so the bar (and the hover bar) come from the atom, and drop just the wash here — otherwise an
+   open menu sitting next to an active chip reads as one merged block. `&&` doubles the class so
+   this beats the atom's own rule without depending on stylesheet order. */
+const Trigger = styled(ChipButton)`
+  && { background-color: transparent; }
+`;
+
 /* Deviation from Figma "Spaces/Card Shadow": that shadow has no theme token, and its
    literal rgba pair (a blue drop + a white outer glow) read badly — the glow is invisible
    on light and a halo on dark. We reuse FilterDropdownContainer's dropdown shadow instead,
@@ -132,7 +141,7 @@ const ChipDropdown: React.FC<IChipDropdown> = ({
 
   return (
     <Wrapper ref={wrapperRef} {...props} onKeyDown={handleKeyDown}>
-      <ChipButton
+      <Trigger
         variant='icon'
         icon={icon}
         selected={isOpen}

--- a/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
+++ b/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
@@ -1,0 +1,169 @@
+import type React from 'react';
+import { type HTMLAttributes, useCallback, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { useClickOutside } from '../../hooks';
+import Icon from '../../Icons/Icon';
+import ChipButton from '../atoms/ChipButton';
+
+export interface IChipDropdownItem {
+  id: string;
+  label: string;
+  icon?: string; // icon name (@future-standard/icons)
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+interface OwnProps {
+  items: IChipDropdownItem[];
+  icon?: string; // trigger icon name, default the 3-dot kebab 'FilterEllipsis'
+  triggerLabel?: string; // trigger aria-label (default 'Space actions')
+  noDivider?: boolean; // pass-through: hide the chip's 1px left divider
+  disabled?: boolean; // disable the trigger
+  onOpenChange?: (open: boolean) => void;
+}
+
+export type IChipDropdown = OwnProps & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>;
+
+const Wrapper = styled.div`
+  position: relative;
+  display: inline-flex;
+`;
+
+/* Deviation from Figma "Spaces/Card Shadow": that shadow has no theme token, and its
+   literal rgba pair (a blue drop + a white outer glow) read badly — the glow is invisible
+   on light and a halo on dark. We reuse FilterDropdownContainer's dropdown shadow instead,
+   which is theme-aware via --filter-button-shadow-color (primary-a3 light / black-a8 dark)
+   and keeps every colour on a token. */
+const Menu = styled.div`
+  position: absolute;
+  /* 8px below the cell — Figma has the 56px cell's menu instance starting at y=64 */
+  top: calc(100% + 8px);
+  left: -1px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-width: 216px;
+  padding: 4px 0;
+  background: var(--grey-1);
+  border: 1px solid var(--grey-4);
+  border-radius: 4px;
+  box-shadow: 0px 5px 25px 0px var(--filter-button-shadow-color);
+`;
+
+const MenuItem = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  height: var(--button-height, 32px);
+  padding: 3px 8px;
+  border: none;
+  border-bottom: 1px solid var(--grey-7);
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: var(--grey-12);
+  text-align: left;
+  transition: background-color var(--speed-fast) var(--easing-primary-in-out);
+
+  /* icon colour follows the row text — mirrors ChipButton/IconButton targeting [stroke] */
+  & svg [stroke] { stroke: var(--grey-12); }
+
+  &:last-child { border-bottom: none; }
+  &:hover:enabled { background-color: var(--grey-3); }
+  &:disabled { cursor: not-allowed; opacity: 0.5; }
+`;
+
+const ChipDropdown: React.FC<IChipDropdown> = ({
+  items,
+  icon = 'FilterEllipsis',
+  triggerLabel = 'Space actions',
+  noDivider = false,
+  disabled = false,
+  onOpenChange,
+  onKeyDown,
+  ...props
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      setIsOpen(next);
+      onOpenChange?.(next);
+    },
+    [onOpenChange]
+  );
+
+  const close = useCallback(() => setOpen(false), [setOpen]);
+  const toggle = useCallback(() => setOpen(!isOpen), [isOpen, setOpen]);
+
+  // only notify on a real close — the document listener also fires while closed
+  const onClickOutside = useCallback(() => {
+    if (isOpen) {
+      close();
+    }
+  }, [isOpen, close]);
+
+  useClickOutside(wrapperRef, onClickOutside);
+
+  // becoming disabled while open must also reset the state the trigger reads
+  // (selected / aria-expanded), not just unmount the panel
+  useEffect(() => {
+    if (disabled && isOpen) {
+      close();
+    }
+  }, [disabled, isOpen, close]);
+
+  // compose with any consumer onKeyDown — it would otherwise replace this one
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(e);
+      if (e.key === 'Escape' && isOpen) {
+        close();
+      }
+    },
+    [isOpen, close, onKeyDown]
+  );
+
+  return (
+    <Wrapper ref={wrapperRef} {...props} onKeyDown={handleKeyDown}>
+      <ChipButton
+        variant='icon'
+        icon={icon}
+        selected={isOpen}
+        noDivider={noDivider}
+        disabled={disabled}
+        aria-label={triggerLabel}
+        aria-haspopup='menu'
+        aria-expanded={isOpen}
+        onClick={toggle}
+      />
+      {isOpen && !disabled ? (
+        <Menu role='menu'>
+          {items.map((item) => (
+            <MenuItem
+              key={item.id}
+              type='button'
+              role='menuitem'
+              disabled={item.disabled}
+              onClick={() => {
+                item.onClick?.();
+                close();
+              }}
+            >
+              {item.icon ? <Icon icon={item.icon} size={14} /> : null}
+              {item.label}
+            </MenuItem>
+          ))}
+        </Menu>
+      ) : null}
+    </Wrapper>
+  );
+};
+
+export default ChipDropdown;

--- a/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
+++ b/packages/ui-lib/src/Chips/molecules/ChipDropdown.tsx
@@ -32,14 +32,18 @@ const Wrapper = styled.div`
   display: inline-flex;
 `;
 
-/* Figma calls this cell "a different kind of button from the chips": its Open state is the
-   Primary/9 4px bar only, with no Primary/a3 wash. We still map Open to ChipButton's `selected`
-   so the bar (and the hover bar) come from the atom, and drop just the wash here — otherwise an
-   open menu sitting next to an active chip reads as one merged block. `&&` doubles the class so
-   this beats the atom's own rule without depending on stylesheet order.
+/* The open state is the 4px Primary/9 bar only, with no Primary/a3 wash. Open still maps to
+   ChipButton's `selected` so the bar (and the hover bar) come from the atom, and only the wash is
+   dropped here — otherwise an open menu sitting next to an active chip reads as one merged block.
+   `&&` doubles the class so this beats the atom's own rule without depending on stylesheet order.
 
    $labelled holds the Arrangement cell's geometry, scoped to the transient prop so the icon-only
-   trigger keeps the atom's 56 x 56 square untouched. */
+   trigger keeps the atom's 56 x 56 square untouched.
+
+   `white-space: nowrap`: wrapping would break the 56px height, not widen the cell.
+
+   `color` and the `[stroke]` override: the label stays on --grey-12 and only the bar turns primary;
+   the atom ties its selected state to --primary-11 text, far louder on a word than on a glyph. */
 const Trigger = styled(ChipButton)<{ $labelled: boolean }>`
   && {
     background-color: transparent;
@@ -51,24 +55,18 @@ const Trigger = styled(ChipButton)<{ $labelled: boolean }>`
       padding: 0 16px 0 14px;
       gap: 8px;
       justify-content: flex-start;
-      white-space: nowrap; /* wrapping would break the 56px height, not widen the cell */
-
-      /* Figma's Open state keeps the label on --grey-12 and turns only the bar primary; the atom
-         ties its selected state to --primary-11 text, far louder on a word than on a glyph */
+      white-space: nowrap;
       color: var(--grey-12);
       & svg [stroke] { stroke: var(--grey-12); }
     `}
   }
 `;
 
-/* Deviation from Figma "Spaces/Card Shadow": that shadow has no theme token, and its
-   literal rgba pair (a blue drop + a white outer glow) read badly — the glow is invisible
-   on light and a halo on dark. We reuse FilterDropdownContainer's dropdown shadow instead,
-   which is theme-aware via --filter-button-shadow-color (primary-a3 light / black-a8 dark)
-   and keeps every colour on a token. */
+/* Uses FilterDropdownContainer's dropdown shadow, not Figma's "Spaces/Card Shadow" — do not switch
+   back: that shadow has no theme token, and its literal rgba pair is invisible on light and a halo
+   on dark. */
 const Menu = styled.div`
   position: absolute;
-  /* 8px below the cell — Figma has the 56px cell's menu instance starting at y=64 */
   top: calc(100% + 8px);
   left: -1px;
   z-index: 100;
@@ -83,6 +81,12 @@ const Menu = styled.div`
   box-shadow: 0px 5px 25px 0px var(--filter-button-shadow-color);
 `;
 
+/* `& svg [stroke]`: icon colour follows the row text — mirrors ChipButton/IconButton targeting
+   [stroke].
+
+   `$current` comes after the hover rule so it wins: --grey-4 is a step darker than the --grey-3
+   hover in both themes, so letting hover win would make the current row look less selected when
+   pointed at. */
 const MenuItem = styled.button<{ $current: boolean }>`
   display: flex;
   align-items: center;
@@ -102,15 +106,12 @@ const MenuItem = styled.button<{ $current: boolean }>`
   text-align: left;
   transition: background-color var(--speed-fast) var(--easing-primary-in-out);
 
-  /* icon colour follows the row text — mirrors ChipButton/IconButton targeting [stroke] */
   & svg [stroke] { stroke: var(--grey-12); }
 
   &:last-child { border-bottom: none; }
   &:hover:enabled { background-color: var(--grey-3); }
   &:disabled { cursor: not-allowed; opacity: 0.5; }
 
-  /* After the hover rule so it wins: --grey-4 is a step darker than the --grey-3 hover in both
-     themes, so letting hover win would make the current row look less selected when pointed at. */
   ${({ $current }) =>
     $current &&
     css`
@@ -180,7 +181,6 @@ const ChipDropdown: React.FC<IChipDropdown> = ({
     }
   }, [disabled, isOpen, close]);
 
-  // compose with any consumer onKeyDown — it would otherwise replace this one
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       onKeyDown?.(e);
@@ -211,7 +211,7 @@ const ChipDropdown: React.FC<IChipDropdown> = ({
           <>
             {icon ? <Icon icon={icon} size={18} /> : null}
             {label}
-            {/* does not flip when open — Figma uses one caret asset in all three states */}
+            {/* deliberately does not flip when open */}
             <Icon icon='Down' size={12} />
           </>
         ) : null}

--- a/packages/ui-lib/src/Chips/organisms/ChipBar.tsx
+++ b/packages/ui-lib/src/Chips/organisms/ChipBar.tsx
@@ -14,7 +14,8 @@ import {
 import styled from 'styled-components';
 
 interface OwnProps {
-  children: ReactNode; // the cells: any mix of ChipButton / ChipDropdown, in any order
+  /** the cells: any mix of ChipButton / ChipDropdown, in any order */
+  children: ReactNode;
 }
 
 export type IChipBar = OwnProps & HTMLAttributes<HTMLDivElement>;

--- a/packages/ui-lib/src/Chips/organisms/ChipBar.tsx
+++ b/packages/ui-lib/src/Chips/organisms/ChipBar.tsx
@@ -19,15 +19,15 @@ interface OwnProps {
 
 export type IChipBar = OwnProps & HTMLAttributes<HTMLDivElement>;
 
+/* The `& > *` rule below pins every cell's width, so the row overflows instead of squashing — a
+   consumer that needs scrolling wraps ChipBar itself. Without it, flex items default to
+   flex-shrink: 1 and a narrow container silently shrinks the 56px cells — measured at 36px in a
+   200px container — which is not a designed state. */
 const Bar = styled.div`
   display: flex;
   align-items: center;
   height: 56px;
 
-  /* Cells keep their fixed width and the row overflows instead (SPEC decision 7: overflow is
-     undefined in v1 and the consumer wraps ChipBar if it needs scrolling). Without this, flex
-     items default to flex-shrink: 1 and a narrow container silently squashes the 56px cells —
-     measured at 36px in a 200px container — which is not a designed state. */
   & > * {
     flex-shrink: 0;
   }
@@ -39,7 +39,6 @@ const ChipBar: React.FC<IChipBar> = ({ children, onKeyDown, onFocus, ...props })
   const barRef = useRef<HTMLDivElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
 
-  // focusable cells, excluding the rows of an open ChipDropdown menu
   const getCells = useCallback(() => {
     const root = barRef.current;
     if (!root) {
@@ -81,8 +80,8 @@ const ChipBar: React.FC<IChipBar> = ({ children, onKeyDown, onFocus, ...props })
     return () => observer.disconnect();
   }, [activeIndex, getCells]);
 
-  // the cells: ChipButton / ChipDropdown elements, in any order. A Fragment wrapper is not a
-  // supported child — see SPEC §4 subtlety A.
+  // A Fragment wrapper is not a supported child: it arrives as one element, so the cells inside it
+  // are never seen.
   const cells = Children.toArray(children).filter(isValidElement);
 
   const handleFocus = useCallback(

--- a/packages/ui-lib/src/Chips/organisms/ChipBar.tsx
+++ b/packages/ui-lib/src/Chips/organisms/ChipBar.tsx
@@ -80,8 +80,9 @@ const ChipBar: React.FC<IChipBar> = ({ children, onKeyDown, onFocus, ...props })
     return () => observer.disconnect();
   }, [activeIndex, getCells]);
 
-  // A Fragment wrapper is not a supported child: it arrives as one element, so the cells inside it
-  // are never seen.
+  // A Fragment wrapper is not a supported child: toArray flattens arrays but not fragments, so the
+  // wrapper itself arrives as the first element and noDivider lands on it — the leading chip keeps
+  // its hairline, and React logs the invalid-prop warning only on re-render, never on mount.
   const cells = Children.toArray(children).filter(isValidElement);
 
   const handleFocus = useCallback(

--- a/packages/ui-lib/src/Chips/organisms/ChipBar.tsx
+++ b/packages/ui-lib/src/Chips/organisms/ChipBar.tsx
@@ -1,0 +1,154 @@
+import type React from 'react';
+import {
+  Children,
+  cloneElement,
+  type HTMLAttributes,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import styled from 'styled-components';
+
+interface OwnProps {
+  children: ReactNode; // the cells: any mix of ChipButton / ChipDropdown, in any order
+}
+
+export type IChipBar = OwnProps & HTMLAttributes<HTMLDivElement>;
+
+const Bar = styled.div`
+  display: flex;
+  align-items: center;
+  height: 56px;
+
+  /* Cells keep their fixed width and the row overflows instead (SPEC decision 7: overflow is
+     undefined in v1 and the consumer wraps ChipBar if it needs scrolling). Without this, flex
+     items default to flex-shrink: 1 and a narrow container silently squashes the 56px cells —
+     measured at 36px in a 200px container — which is not a designed state. */
+  & > * {
+    flex-shrink: 0;
+  }
+`;
+
+const NAV_KEYS = ['ArrowLeft', 'ArrowRight', 'Home', 'End'];
+
+const ChipBar: React.FC<IChipBar> = ({ children, onKeyDown, onFocus, ...props }) => {
+  const barRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // focusable cells, excluding the rows of an open ChipDropdown menu
+  const getCells = useCallback(() => {
+    const root = barRef.current;
+    if (!root) {
+      return [] as HTMLElement[];
+    }
+    return Array.from(root.querySelectorAll<HTMLElement>('button:not(:disabled)')).filter(
+      (el) => !el.closest('[role="menu"]')
+    );
+  }, []);
+
+  // roving tabindex — exactly one cell is tabbable, so the bar is a single tab stop
+  useEffect(() => {
+    const root = barRef.current;
+    if (!root) {
+      return;
+    }
+
+    const sync = () => {
+      const focusables = getCells();
+      const index = Math.min(activeIndex, focusables.length - 1);
+      focusables.forEach((cell, i) => {
+        cell.tabIndex = i === index ? 0 : -1;
+      });
+    };
+    sync();
+
+    /* A child can add a button or drop its `disabled` from its own state, without ChipBar
+       re-rendering — an effect alone would miss that and leave a second native tab stop. Watching
+       the subtree is the only way to stay authoritative over cells ChipBar does not own.
+       `attributeFilter` must never include `tabindex`: sync() writes it, so observing it would
+       re-enter this callback forever. */
+    const observer = new MutationObserver(sync);
+    observer.observe(root, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['disabled'],
+    });
+    return () => observer.disconnect();
+  }, [activeIndex, getCells]);
+
+  // the cells: ChipButton / ChipDropdown elements, in any order. A Fragment wrapper is not a
+  // supported child — see SPEC §4 subtlety A.
+  const cells = Children.toArray(children).filter(isValidElement);
+
+  const handleFocus = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      onFocus?.(e);
+      const index = getCells().indexOf(e.target as HTMLElement);
+      if (index >= 0) {
+        setActiveIndex(index);
+      }
+    },
+    [getCells, onFocus]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(e);
+      if (!NAV_KEYS.includes(e.key)) {
+        return;
+      }
+      // an open ChipDropdown menu owns the keyboard
+      if (barRef.current?.querySelector('[role="menu"]')) {
+        return;
+      }
+
+      const focusables = getCells();
+      const current = focusables.indexOf(document.activeElement as HTMLElement);
+      if (focusables.length === 0 || current < 0) {
+        return;
+      }
+
+      e.preventDefault();
+      let next = current;
+      if (e.key === 'ArrowLeft') {
+        next = (current - 1 + focusables.length) % focusables.length;
+      }
+      if (e.key === 'ArrowRight') {
+        next = (current + 1) % focusables.length;
+      }
+      if (e.key === 'Home') {
+        next = 0;
+      }
+      if (e.key === 'End') {
+        next = focusables.length - 1;
+      }
+      focusables[next]?.focus();
+    },
+    [getCells, onKeyDown]
+  );
+
+  return (
+    <Bar
+      ref={barRef}
+      role='toolbar'
+      aria-label='Chip bar'
+      {...props}
+      onFocus={handleFocus}
+      onKeyDown={handleKeyDown}
+    >
+      {cells.map((child, i) =>
+        // guard on child.type so a plain DOM child never gets an unknown noDivider attribute
+        i === 0 && typeof child.type !== 'string'
+          ? cloneElement(child as ReactElement<{ noDivider?: boolean }>, { noDivider: true })
+          : child
+      )}
+    </Bar>
+  );
+};
+
+export default ChipBar;

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -158,8 +158,8 @@ import {
 } from './Misc';
 
 // Components - Chips
-import { ChipButton } from './Chips';
-import type { IChipButton, IChipVariant } from './Chips';
+import { ChipButton, ChipDropdown } from './Chips';
+import type { IChipButton, IChipDropdown, IChipDropdownItem, IChipVariant } from './Chips';
 
 import { ConfirmationModal } from './Modals';
 
@@ -366,6 +366,7 @@ export {
   Pagination,
   // Chips
   ChipButton,
+  ChipDropdown,
   //Context
   NotificationProvider,
   useNotification,
@@ -465,4 +466,6 @@ export type {
   // Chips types
   IChipButton,
   IChipVariant,
+  IChipDropdown,
+  IChipDropdownItem,
 };

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -158,8 +158,14 @@ import {
 } from './Misc';
 
 // Components - Chips
-import { ChipButton, ChipDropdown } from './Chips';
-import type { IChipButton, IChipDropdown, IChipDropdownItem, IChipVariant } from './Chips';
+import { ChipBar, ChipButton, ChipDropdown } from './Chips';
+import type {
+  IChipBar,
+  IChipButton,
+  IChipDropdown,
+  IChipDropdownItem,
+  IChipVariant,
+} from './Chips';
 
 import { ConfirmationModal } from './Modals';
 
@@ -367,6 +373,7 @@ export {
   // Chips
   ChipButton,
   ChipDropdown,
+  ChipBar,
   //Context
   NotificationProvider,
   useNotification,
@@ -468,4 +475,5 @@ export type {
   IChipVariant,
   IChipDropdown,
   IChipDropdownItem,
+  IChipBar,
 };

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -157,6 +157,10 @@ import {
   type IPagination,
 } from './Misc';
 
+// Components - Chips
+import { ChipButton } from './Chips';
+import type { IChipButton, IChipVariant } from './Chips';
+
 import { ConfirmationModal } from './Modals';
 
 // Other
@@ -360,6 +364,8 @@ export {
   DebouncedSearcher,
   ActionsBar,
   Pagination,
+  // Chips
+  ChipButton,
   //Context
   NotificationProvider,
   useNotification,
@@ -456,4 +462,7 @@ export type {
   IInputOptionsType,
   TypeLabelDirection,
   IButtonProps,
+  // Chips types
+  IChipButton,
+  IChipVariant,
 };

--- a/packages/ui-lib/src/index.tsx
+++ b/packages/ui-lib/src/index.tsx
@@ -158,13 +158,14 @@ import {
 } from './Misc';
 
 // Components - Chips
-import { ChipBar, ChipButton, ChipDropdown } from './Chips';
+import { ChipBar, ChipButton, ChipDropdown, ChipZoneBreak } from './Chips';
 import type {
   IChipBar,
   IChipButton,
   IChipDropdown,
   IChipDropdownItem,
   IChipVariant,
+  IChipZoneBreak,
 } from './Chips';
 
 import { ConfirmationModal } from './Modals';
@@ -374,6 +375,7 @@ export {
   ChipButton,
   ChipDropdown,
   ChipBar,
+  ChipZoneBreak,
   //Context
   NotificationProvider,
   useNotification,
@@ -476,4 +478,5 @@ export type {
   IChipDropdown,
   IChipDropdownItem,
   IChipBar,
+  IChipZoneBreak,
 };


### PR DESCRIPTION
## Description

This PR adds a new **Chips** component family to the kit: the "Spaces / Top Bar" chip
controls from Figma. It is a feature addition, not a bug fix, and ships four new
public components plus their stories, docs, and tests.

[Design Link](https://www.figma.com/design/gy3dEIgHhqW30HiKINb2Rb/1.-Hattabara-Dam---CCTV---Design-Base?node-id=9159-6167&m=dev)


- [**ChipButton** ](https://future-standard.github.io/scorer-ui-kit/pr/682/storybook/?path=/story/chips-atoms--chip-button)(atom) — the 56×56 top-bar "Space" chip. Icon and text variants,
  a CSS-driven hover bar, a prop-driven persistent `selected` state (bar + wash), and
  a built-in removal animation (`leaving` + `onLeaveEnd`) that collapses the cell to
  zero width and honours `prefers-reduced-motion`.
  
- [**ChipDropdown**](https://future-standard.github.io/scorer-ui-kit/pr/682/storybook/?path=/story/chips-molecules--chip-dropdown) (molecule) — the ellipsis "Space actions" menu cell. Composes
  `ChipButton` as its trigger and adds a fully data-driven action menu
  (`items[]`: icon/label/disabled/onClick). Also ships a **labelled mode**
  (`label` prop) that turns the same component into the Arrangement cell — the
  active-layout picker with a `selectedId`/`checkIcon` current-row indicator — so a
  fifth, near-duplicate component wasn't needed.
-[**ChipDropdown Demo 2**](https://future-standard.github.io/scorer-ui-kit/pr/682/storybook/?path=/story/chips-molecules--chip-dropdown-arrangement)

- [**ChipBar** ](https://future-standard.github.io/scorer-ui-kit/pr/682/storybook/?path=/story/chips-organisms--chip-bar)(organism) — the 56px flex row that glues chips together. Pure layout
  glue: no selection state of its own. Owns `role='toolbar'` with arrow-key roving
  focus (Left/Right/Home/End) and one tab stop, kept in sync by a `MutationObserver`
  so a child enabling its own button can't quietly add a second tab stop.
  
- [**ChipZoneBreak**](https://future-standard.github.io/scorer-ui-kit/pr/682/storybook/?path=/story/chips-atoms--chip-zone-break) (atom) — the 12px band that separates two zones of the top bar
  (fill + hairline on each edge). Stateless, but `box-sizing: border-box` is
  load-bearing: without it the band renders 14px and the bar drifts 2px per break.
 
 - [**SpacesTopBar Demo** ](https://future-standard.github.io/scorer-ui-kit/pr/682/storybook/?path=/story/chips-organisms--spaces-top-bar)


This PR also adds `COMMENT_STYLE_GUIDE.md` focused in making AI comments less verbose and more useful, and wires `npm run test:unit` into
`lint.yml` so the Vitest suite (previously unexecuted in CI) now runs on every push.

## Considerations on Implementation

- **Deliberate deviations from Figma**, called out so reviewers don't flag them as
  bugs:
  - `ChipDropdown`'s trigger is 56px wide (reuses `ChipButton`), not Figma's 44px
    ellipsis cell — keeps a consistent top-bar cell width and avoids a
    trigger-specific atom. Total `ChipBar` width is therefore 280px vs Figma's
    268px.
  - The Arrangement menu's `min-width` stays 216px (shared with the ellipsis menu)
    against Figma's 192px.
  - `checkIcon` defaults to `Success` (tick-in-circle) because `@future-standard/icons`
    has no bare check mark. The four layout glyphs used in the Arrangement story
    (6-up / 4-up / 2-up / 1-big+2) aren't in the icon package either — the kit
    renders icons by name, so no code change is needed once they exist upstream.
  - The menu shadow reuses `FilterDropdownContainer`'s themed
    `--filter-button-shadow-color` instead of Figma's untokenised "Card Shadow",
    which read badly in both themes as a literal rgba pair.
- **Accessibility trap left in place on purpose, not designed away:** in
  `ChipDropdown` labelled mode, `triggerLabel` becomes an `aria-label` and
  *replaces* the visible text as the accessible name rather than adding to it. A
  flat `triggerLabel='Arrangement'` on a trigger reading "6-up" would hide "6-up"
  from assistive tech (WCAG 2.5.3). Both stories lead with the visible value
  instead; the component still honours an explicit `triggerLabel` verbatim if a
  consumer passes one anyway. Worth a second pair of eyes on the docs wording in
  `COMPONENT_INVENTORY.md` to confirm the trap is clear enough to a consumer who
  hasn't read the commit history.

- **Fragment children are explicitly unsupported** in `ChipBar` — divider
  suppression targets `Children.toArray()[0]` directly, and a `Fragment` wrapper
  around a leading child is not unwrapped. This is intentional (documented in code
  and in the Zone Break constraint), but worth confirming reviewers are fine with a
  hard "not supported" rather than a runtime warning.
- **Test coverage is intentionally narrow (16 tests across 2 files), not a full
  suite.** It targets exactly two regressions the Storybook sweep structurally
  can't see (a second native tab stop from `ChipBar`'s roving-tabindex resync, and
  a missed `onLeaveEnd` callback) plus the Arrangement cell's accessible-name /
  role changes. 

## Reviewing/Testing steps

### Pre-merge verification

| Check                                                  |  Result   |
|---------------------------------------------------------|:---------:|
| Lint (`npx @biomejs/biome@2.5.0 check`)                  | ✅ PASS  |
| Type-check (`npm run test:types -w packages/ui-lib`)     | ✅ PASS  |
| Build (`npm run build -w packages/ui-lib`)               | ✅ PASS  |
| Unit tests (`npm run test:unit -w packages/ui-lib`)      | ✅ PASS (16/16) |
| Story sweep (`npm run sweep`)                            | ✅ PASS (92/92, 0 errors, 0 timeouts, 0 render-loop suspects) |
| Manual smoke test in browser                             | ✅ PASS — all 6 Chips stories driven live via Chrome DevTools (see below) |
| Console / log clean of new warnings                      | ✅ PASS — only the standard React DevTools info line on every page checked |
| Docker / deploy artifact builds                          | ⏭️ N/A — no deploy artifact changes in this PR |

All rows above were executed in this session, not carried over from development-time
notes: `npm run start:example` + `npm run start:storybook` (started directly, not via
`start:all`, to avoid the watch-build race that can poison the example dev server's
`dist` cache mid-sweep), then `npm run sweep`, then a manual pass over each of the 6
Chips stories with Chrome DevTools attached, inspecting the accessibility tree and
console after every interaction:
- **ChipButton** — `Space 3` correctly reports `pressed`.
- **ChipZoneBreak** (composed bar) — `Space actions` trigger reports
  `expandable haspopup="menu"` with no `pressed`, confirming the aria-pressed/
  aria-haspopup fix (ce963dc7).
- **ChipDropdown** — opened via click → `expanded` + `haspopup="menu"` + 3
  `menuitem` rows; **Escape** closed it and returned focus correctly.
- **ChipDropdown (Arrangement/labelled mode)** — accessible name reads "6-up
  arrangement" (the documented WCAG 2.5.3 mitigation); opened menu shows
  `menuitemradio` rows with `checked` on the current row only.
- **ChipBar** — arrow-key roving focus moved the tab stop correctly
  (Workspace → Space 1); removing the selected Space via the dropdown's
  "Remove" action animated it out and the remaining chips renumbered (Space 2 →
  Space 1) with no console errors during the collapse/unmount.
- **SpacesTopBar** (composed organism) — renders as expected, screenshot
  confirms layout matches Figma zones (Workspace grid / numbered Spaces /
  ellipsis / Arrangement "4-up" / Save split button / Reset).

### Detailed steps to reproduce

**Setup**
\`\`\`bash
nvm use
npm install
\`\`\`

**Automated checks** (what's already been run and reported PASS above)
\`\`\`bash
npx @biomejs/biome@2.5.0 check
npm run test:types -w packages/ui-lib
npm run test:unit -w packages/ui-lib
npm run build -w packages/ui-lib
\`\`\`

**Story sweep and manual smoke test** (already run for this description; repeat to
reproduce)
\`\`\`bash
# start example + storybook only — do NOT use start:all, its watch build
# has been observed to poison the example dev server cache mid-sweep
npm run start:example
npm run start:storybook
npm run sweep
\`\`\`
Expected outcome: sweep reports 0 console errors, 0 page errors, 0 render loops
across all 92 Storybook stories and example routes. Reproduced in this session:
`{"total":92,"withErrors":0,"timedOut":[],"loopSuspect":[],"bad":[]}`.

To manually exercise the components: open Storybook navigate to:
- `Chips/atoms/ChipButton` — toggle `selected`, `variant`, `leaving` via knobs;
  confirm the hover bar, wash, and collapse animation.
- `Chips/atoms/ChipZoneBreak` — confirm 12×56 band, and the knob comparing it to a
  plain 1px divider.
- `Chips/molecules/ChipDropdown` and `ChipDropdownArrangement` — open the trigger,
  confirm `aria-expanded`/`aria-haspopup='menu'` and no `aria-pressed` in the
  accessibility tree (Chrome DevTools → Accessibility pane); confirm Escape and
  click-outside close the menu.
- `Chips/organisms/ChipBar` and `SpacesTopBar` — use arrow keys to move focus
  across cells (single tab stop into the bar, then Left/Right/Home/End roams);
  use the story's add/duplicate/remove controls and confirm removed chips animate
  out and remaining chips renumber without remounting the wrong chip.

#### Screenshoot

[SpacesTopBar Demo](https://future-standard.github.io/scorer-ui-kit/pr/682/storybook/?path=/story/chips-organisms--spaces-top-bar)
<img width="700" height="160" alt="Screenshot 2026-07-29 at 17 43 49" src="https://github.com/user-attachments/assets/f949e7c7-7a1e-4615-8969-be3579296695" />
